### PR TITLE
Don't use fpath to generate dune test files

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -10,7 +10,7 @@
 (executable
  (name gen_dune_rules)
  (modules gen_dune_rules)
- (libraries fmt fpath))
+ (libraries fmt))
 
 (include dune.inc)
 

--- a/test/gen_dune_rules.ml
+++ b/test/gen_dune_rules.ml
@@ -1,5 +1,5 @@
 let is_testcase name =
-  Fpath.(has_ext "dot" (v name))
+  Filename.extension name = ".dot"
 
 let pp_targets ppf filenames =
   Fmt.pf ppf


### PR DESCRIPTION
This forced every package to have a test dependency on fpath, even if it doesn't have any tests.

/cc @CraigFe 