### PR TITLE
Add support for run-arguments in docker plugin

### DIFF
--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -38,10 +38,10 @@ module Make (Host : S.HOST) = struct
 
   module RC = Current_cache.Make(Run)
 
-  let run ?label ?pool image ~args =
+  let run ?label ?pool ?(run_args=[]) image ~args  =
     Current.component "run%a" pp_sp_label label |>
     let> image = image in
-    RC.get { Run.pool } { Run.Key.image; args; docker_context }
+    RC.get { Run.pool } { Run.Key.image; args; docker_context; run_args }
 
   module TC = Current_cache.Output(Tag)
 

--- a/plugins/docker/run.ml
+++ b/plugins/docker/run.ml
@@ -11,20 +11,22 @@ module Key = struct
     image : Image.t;
     args : string list;
     docker_context : string option;
+    run_args : string list;
   }
 
   let pp_args = Fmt.(list ~sep:sp (quote string))
 
-  let cmd { image; args; docker_context } =
-    Cmd.docker ~docker_context @@ ["run"; "--rm"; "-i"; Image.hash image] @ args
+  let cmd { image; args; docker_context; run_args } =
+    Cmd.docker ~docker_context @@ ["run"] @ run_args @ ["--rm"; "-i"; Image.hash image] @ args
 
   let pp f t = Cmd.pp f (cmd t)
 
-  let digest { image; args; docker_context } =
+  let digest { image; args; docker_context; run_args } =
     Yojson.Safe.to_string @@ `Assoc [
       "image", `String (Image.hash image);
       "args", [%derive.to_yojson:string list] args;
       "docker_context", [%derive.to_yojson:string option] docker_context;
+      "run_args", [%derive.to_yojson:string list] run_args;
     ]
 end
 

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -39,9 +39,12 @@ module type DOCKER = sig
   val run :
     ?label:string ->
     ?pool:Current.Pool.t ->
+    ?run_args:string list ->
     Image.t Current.t -> args:string list ->
     unit Current.t
-  (** [run image ~args] runs [image args] with Docker. *)
+  (** [run image ~args] runs [image args] with Docker.
+      @param run_args List of additional arguments to pass to the "docker
+                      run" subcommand. *)
 
   val tag : tag:string -> Image.t Current.t -> unit Current.t
   (** [tag image ~tag] does "docker tag image tag" *)


### PR DESCRIPTION
This allows optional additional arguments to be passed to `docker run`. This is useful to e.g. pass parameters for `--cpuset-*` when running benchmarks.