### PR TITLE
Github plugin: Expose the origin (branch or PR) of a commit

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -512,6 +512,8 @@ module Commit = struct
 
   let hash (_, id) = id.Commit_id.hash
 
+  let kind (_, id) = id.Commit_id.id
+
   let pp = Fmt.using snd Commit_id.pp
 
   let set_status commit context status =

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -13,6 +13,7 @@ module Commit : sig
   val repo_id : t -> Repo_id.t
   val owner_name : t -> string
   val hash : t -> string
+  val kind : t -> [ `Ref of string | `PR of int ]
   val pp : t Fmt.t
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
 end

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -49,6 +49,10 @@ module Api : sig
     val hash : t -> string
     (** [hash t] is the Git commit hash of [t]. *)
 
+    val kind : t -> [ `Ref of string | `PR of int ]
+    (** [kind t] tells you whether this commit is from a branch [`Ref branch_name]
+        or a PR [`PR pr_number]. *)
+
     val pp : t Fmt.t
   end
 


### PR DESCRIPTION
Using the github plugin, it is currently rather hard to know whether a commit is from a PRs or a Branch as both are merged together and their kind are not exposed to the user level.

Comparing their `Repo_id.t` with the main repository might have been a solution, however this still does not differentiate between a branch and a PR where the branch used to open it, is from the repository itself.

This PR adds the `kind` function which exposes the internal `id` field and allows users to have some more informations about the origin of a commit