### PR TITLE
Github API: Split ci_refs into Branches and PRs

### DIFF
--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -21,14 +21,16 @@ type t
 val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
-val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
+val branches : t -> Repo_id.t -> Commit.t list Current.t
+val prs : t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t
 
 module Repo : sig
   type nonrec t = t * Repo_id.t
 
   val id : t -> Repo_id.t
-  val ci_refs : t Current.t -> Commit.t list Current.t
+  val branches : t Current.t -> Commit.t list Current.t
+  val prs : t Current.t -> Commit.t list Current.t
   val head_commit : t Current.t -> Commit.t Current.t
   val pp : t Fmt.t
 end

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -58,8 +58,11 @@ module Api : sig
     val id : t -> Repo_id.t
     val pp : t Fmt.t
 
-    val ci_refs : t Current.t -> Commit.t list Current.t
-    (** [ci_refs t] evaluates to the list of branches and open PRs in [t]. *)
+    val branches : t Current.t -> Commit.t list Current.t
+    (** [branches t] evaluates to the list of branches in [t]. *)
+
+    val prs : t Current.t -> Commit.t list Current.t
+    (** [prs t] evaluates to the list of open PRs in [t]. *)
 
     val head_commit : t Current.t -> Commit.t Current.t
     (** [head_commit t] evaluates to the commit at the head of the default branch in [t]. *)
@@ -74,8 +77,11 @@ module Api : sig
   val head_commit : t -> Repo_id.t -> Commit.t Current.t
   (** [head_commit t repo] evaluates to the commit at the head of the default branch in [repo]. *)
 
-  val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
-  (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo]. *)
+  val branches : t -> Repo_id.t -> Commit.t list Current.t
+  (** [branches t repo] evaluates to the list of branches in [repo]. *)
+
+  val prs : t -> Repo_id.t -> Commit.t list Current.t
+  (** [prs t repo] evaluates to the list of open PRs in [repo]. *)
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub configuration. *)


### PR DESCRIPTION
This is a draft PR that stores branches and prs independently. Currently both are stored together and delivered via the the `ci_refs` function. However, if feel like this function tries to do to many things and its name does not clearly reflect what it does.

My proposition is to split this function into two functions exposed to the user `branches` and `prs` which returns every branches from a given repo or every PR from a given repo.

However one annoying side effect of this split is code duplication and query duplication in case both branches and PRs are required. However this reduces the size of the request in case only one is required.

This is only a draft as an invitation to discuss what can be done to improve the github API. The main feature I personally would like to have is in a separate PR (https://github.com/ocurrent/ocurrent/pull/104) so this is not urgent.