### PR TITLE
Add OCaml-CI status badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# OCurrent
+
+[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focurrent%2Focurrent&logo=ocaml)](https://ci.ocamllabs.io/github/ocurrent/ocurrent)
+
 OCurrent allows you to specify a workflow / pipeline for keeping things up-to-date.
 
 <p align='center'>


### PR DESCRIPTION
Now that https://github.com/ocurrent/ocaml-ci/pull/100 has been merged, we have access to new badges for OCaml-CI.