### PR TITLE
Fix the ocaml-ci status badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCurrent
 
-[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focurrent%2Focurrent&logo=ocaml)](https://ci.ocamllabs.io/github/ocurrent/ocurrent)
+[![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focurrent%2Focurrent%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/ocurrent/ocurrent)
 
 OCurrent allows you to specify a workflow / pipeline for keeping things up-to-date.
 


### PR DESCRIPTION
These URLs require the branch to be stated explicitly.