### PR TITLE
Require Alcotest < 1.0.0

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -34,5 +34,5 @@ depends: [
   "dune" {>= "1.9"}
   "re"
   "lwt-dllist"
-  "alcotest-lwt" {with-test}
+  "alcotest-lwt" {< "1.0.0" & with-test}
 ]


### PR DESCRIPTION
The new version doesn't work (will be fixed in 1.0.1).