### PR TITLE
Allow alternative Dockerfile filenames in `Docker.build`

### DIFF
--- a/examples/build_matrix.ml
+++ b/examples/build_matrix.ml
@@ -25,7 +25,7 @@ let pipeline ~repo () =
   let build ocaml_version =
     let dockerfile =
       let+ base = base in
-      dockerfile ~base ~ocaml_version
+      `Contents (dockerfile ~base ~ocaml_version)
     in
     Docker.build ~label:ocaml_version ~pull:false ~dockerfile (`Git src) |>
     Docker.tag ~tag:(Fmt.strf "example-%s" ocaml_version)

--- a/examples/github.ml
+++ b/examples/github.ml
@@ -34,7 +34,7 @@ let pipeline ~github ~repo () =
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   let dockerfile =
     let+ base = Docker.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08" in
-    dockerfile ~base
+    `Contents (dockerfile ~base)
   in
   Docker.build ~pull:false ~dockerfile (`Git src)
   |> Current.state

--- a/examples/github_app.ml
+++ b/examples/github_app.ml
@@ -36,7 +36,7 @@ let github_status_of_state = function
 let pipeline ~app () =
   let dockerfile =
     let+ base = Docker.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08" in
-    dockerfile ~base
+    `Contents (dockerfile ~base)
   in
   Github.App.installations app |> Current.list_iter ~pp:Github.Installation.pp @@ fun installation ->
   let repos = Github.Installation.repositories installation in

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -33,7 +33,12 @@ module Make (Host : S.HOST) = struct
     Current.component "build%a" pp_sp_label label |>
     let> commit = get_build_context src
     and> dockerfile = Current.option_seq dockerfile in
-    let dockerfile = option_map Dockerfile.string_of_t dockerfile in
+    let dockerfile =
+      match dockerfile with
+      | None -> `File (Fpath.v "Dockerfile")
+      | Some (`File _ as f) -> f
+      | Some (`Contents c) -> `Contents (Dockerfile.string_of_t c)
+    in
     BC.get ?schedule { Build.pull; pool; timeout }
       { Build.Key.commit; dockerfile; docker_context; squash; build_args }
 

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -24,7 +24,7 @@ module type DOCKER = sig
     ?timeout:Duration.t ->
     ?squash:bool ->
     ?label:string ->
-    ?dockerfile:Dockerfile.t Current.t ->
+    ?dockerfile:[`File of Fpath.t | `Contents of Dockerfile.t] Current.t ->
     ?pool:Current.Pool.t ->
     ?build_args:string list ->
     pull:bool ->


### PR DESCRIPTION
Previously, you could only build `Dockerfile`, or specify the contents manually.