### PR TITLE
Add Input.map_result

### DIFF
--- a/lib/current.ml
+++ b/lib/current.ml
@@ -95,6 +95,11 @@ module Input = struct
       | Some job_id -> Step.register_job step job_id actions
     end;
     (value, job_id)
+
+  let map_result fn t step =
+    let x, md = t step in
+    let y = try fn x with ex -> Error (`Msg (Printexc.to_string ex)) in
+    y, md
 end
 
 include Current_term.Make(Input)

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -78,6 +78,10 @@ module Input : sig
       Note: the engine calls [f] in an evaluation before calling [release]
       on the previous watches, so if the ref-count drops to zero then you can
       cancel the job. *)
+
+  val map_result : ('a Current_term.Output.t -> 'b Current_term.Output.t) -> 'a t -> 'b t
+  (** [map_result fn t] transforms the result of [t] with [fn]. The metadata remains the same.
+      If [fn] raises an exception, this is converted to [Error]. *)
 end
 
 module Job_map : Map.S with type key = job_id


### PR DESCRIPTION
Allows reporting errors in the right diagram box if you need to post-process something. In a regular map we have to use a separate box because the input box might also be used for something else.
But an Input hasn't been put into a box yet, so it must get its own.