### PR TITLE
Git.fetch: don't take repository lock until the job starts

### DIFF
--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -21,12 +21,12 @@ module Fetch = struct
 
   let build No_context job key =
     let { Commit_id.repo = remote_repo; gref; hash = _ } = key in
-    Lwt_mutex.with_lock (Clone.repo_lock remote_repo) @@ fun () ->
     let level =
       if Commit_id.is_local key then Current.Level.Harmless
       else Current.Level.Mostly_harmless
     in
     Current.Job.start job ~level >>= fun () ->
+    Lwt_mutex.with_lock (Clone.repo_lock remote_repo) @@ fun () ->
     let local_repo = Cmd.local_copy remote_repo in
     (* Ensure we have a local clone of the repository. *)
     begin


### PR DESCRIPTION
Otherwise, we can only manually start whichever job happened to take the lock first.