### PR TITLE
Make Docker.run return its stdout as a string

### DIFF
--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -49,6 +49,13 @@ module Make (Host : S.HOST) = struct
     let> image = image in
     RC.get { Run.pool } { Run.Key.image; args; docker_context; run_args }
 
+  module PrC = Current_cache.Make(Pread)
+
+  let pread ?label ?pool ?(run_args=[]) image ~args  =
+    Current.component "pread%a" pp_sp_label label |>
+    let> image = image in
+    PrC.get { Pread.pool } { Pread.Key.image; args; docker_context; run_args }
+
   module TC = Current_cache.Output(Tag)
 
   let tag ~tag image =

--- a/plugins/docker/dune
+++ b/plugins/docker/dune
@@ -16,5 +16,5 @@
    ppx_deriving_yojson.runtime
    result)
  (preprocess (per_module
-              ((pps ppx_deriving.std ppx_deriving_yojson) pull build run tag push service)
+              ((pps ppx_deriving.std ppx_deriving_yojson) pull build run pread tag push service)
 )))

--- a/plugins/docker/pread.ml
+++ b/plugins/docker/pread.ml
@@ -1,0 +1,41 @@
+open Lwt.Infix
+
+type t = {
+  pool : Current.Pool.t option;
+}
+
+let id = "docker-pread"
+
+module Key = struct
+  type t = {
+    image : Image.t;
+    args : string list;
+    docker_context : string option;
+    run_args : string list;
+  }
+
+  let pp_args = Fmt.(list ~sep:sp (quote string))
+
+  let cmd { image; args; docker_context; run_args } =
+    Cmd.docker ~docker_context @@ ["run"] @ run_args @ ["--rm"; "-i"; Image.hash image] @ args
+
+  let pp f t = Cmd.pp f (cmd t)
+
+  let digest { image; args; docker_context; run_args } =
+    Yojson.Safe.to_string @@ `Assoc [
+      "image", `String (Image.hash image);
+      "args", [%derive.to_yojson:string list] args;
+      "docker_context", [%derive.to_yojson:string option] docker_context;
+      "run_args", [%derive.to_yojson:string list] run_args;
+    ]
+end
+
+module Value = Current.String
+
+let build { pool } job key =
+  Current.Job.start job ?pool ~level:Current.Level.Average >>= fun () ->
+  Current.Process.check_output ~cancellable:true ~job (Key.cmd key)
+
+let pp = Key.pp
+
+let auto_cancel = true

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -47,6 +47,15 @@ module type DOCKER = sig
       @param run_args List of additional arguments to pass to the "docker
                       run" subcommand. *)
 
+  val pread :
+    ?label:string ->
+    ?pool:Current.Pool.t ->
+    ?run_args:string list ->
+    Image.t Current.t -> args:string list ->
+    string Current.t
+  (** [pread image ~args] runs [image args] with Docker the same way than [run]
+      does but returns its stdout as a string. *)
+
   val tag : tag:string -> Image.t Current.t -> unit Current.t
   (** [tag image ~tag] does "docker tag image tag" *)
 


### PR DESCRIPTION
After commenting on https://github.com/ocurrent/ocurrent/pull/99#issuecomment-593637717 I realized it was relatively easy to change `Current_docker.run` to do what i want and return its result as a string.

This is the current design I'm using in opam-ci where it successfully gets the list of reverse dependencies for each packages:
![screenshot](https://user-images.githubusercontent.com/2611789/75733990-a6e1a900-5cee-11ea-8a71-643d0149dd8e.png)