### PR TITLE
Add Prometheus metric for in-memory cache sizes

### DIFF
--- a/lib_cache/dune
+++ b/lib_cache/dune
@@ -9,6 +9,7 @@
    logs
    lwt
    lwt.unix
+   prometheus
    re
    result
    sqlite3))


### PR DESCRIPTION
The fact that we only ever add things to the cache is likely to be a problem, but let's add monitoring first before trying to fix it...