### PR TITLE
Github: expose the low-level refs function

### DIFF
--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -17,10 +17,19 @@ module Commit : sig
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
 end
 
+module Ref : sig
+  type t = [ `Ref of string | `PR of int ]
+  val pp : t Fmt.t
+  val to_git : t -> string
+end
+
+module Ref_map : Map.S with type key = Ref.t
+
 type t
 val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
+val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Input.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
 val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -65,6 +65,17 @@ module Api : sig
     (** [head_commit t] evaluates to the commit at the head of the default branch in [t]. *)
   end
 
+  module Ref : sig
+    type t = [ `Ref of string | `PR of int ]
+
+    val pp : t Fmt.t
+
+    val to_git : t -> string
+    (** [to_git t] is the Git-format string of the ref, e.g."refs/pull/%d/head" *)
+  end
+
+  module Ref_map : Map.S with type key = Ref.t
+
   val of_oauth : string -> t
   (** [of_oauth token] is a configuration that authenticates to GitHub using [token]. *)
 
@@ -80,6 +91,12 @@ module Api : sig
 
   val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
   (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo], excluding gh-pages. *)
+
+  val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Input.t
+  (** [refs t repo] is the input for all the references in [repo].
+      This is the low-level API for getting the refs.
+      It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly.
+      The result is cached (so calling it twice will return the same input). *)
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub configuration. *)


### PR DESCRIPTION
This allows users to make custom pipeline stages similar to `ci_refs` and `head_of`.

@kit-ty-kate : would this solve your problem in #104?