### PR TITLE
Remove per_module pps rules

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -16,5 +16,4 @@
    re
    result
    sqlite3)
- (preprocess (per_module
-              ((pps ppx_deriving.std) level))))
+ (preprocess (pps ppx_deriving.std)))

--- a/lib_term/dune
+++ b/lib_term/dune
@@ -4,6 +4,4 @@
  (libraries
    bos
    fmt)
- (preprocess (per_module
-              ((pps ppx_deriving.std) output)
-)))
+ (preprocess (pps ppx_deriving.std)))

--- a/plugins/docker/dune
+++ b/plugins/docker/dune
@@ -15,6 +15,4 @@
    lwt.unix
    ppx_deriving_yojson.runtime
    result)
- (preprocess (per_module
-              ((pps ppx_deriving.std ppx_deriving_yojson) pull build run pread tag push service)
-)))
+ (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/plugins/git/dune
+++ b/plugins/git/dune
@@ -13,6 +13,4 @@
    lwt.unix
    ppx_deriving_yojson
    result)
- (preprocess (per_module
-              ((pps ppx_deriving_yojson) commit_id commit clone)
-)))
+ (preprocess (pps ppx_deriving_yojson)))


### PR DESCRIPTION
These were needed for OCaml < 4.08 because some files used `let*` and others used ppx and they weren't compatible.