### PR TITLE
Report information about active jobs

### DIFF
--- a/lib/current.mli
+++ b/lib/current.mli
@@ -287,6 +287,10 @@ module Job : sig
   val lookup_running : job_id -> t option
   (** If [lookup_running job_id] is the job [j] with id [job_id], if [is_running j]. *)
 
+  val jobs : unit -> t Job_map.t
+  (** [jobs ()] is the set of active jobs, whether they are currently used in a pipeline or not.
+      This is any job which is running or ready to run (i.e. every job which hasn't closed its log file). *)
+
   val approve_early_start : t -> unit
   (** [approve_early_start t] marks the job as approved to start even if the
       global confirmation threshold would otherwise prevent it. Calling this

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -230,3 +230,5 @@ let cancelled_state t =
   match t.cancel_hooks with
   | `Cancelled reason -> Error (`Msg reason)
   | `Hooks _ -> Ok ()
+
+let jobs () = !jobs

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -1,5 +1,16 @@
 open Lwt.Infix
 
+module Metrics = struct
+  open Prometheus
+
+  let namespace = "ocurrent"
+  let subsystem = "core"
+
+  let active_jobs =
+    let help = "Number of ready or running job" in
+    Gauge.v ~help ~namespace ~subsystem "active_jobs"
+end
+
 module Map = Map.Make(String)
 
 (* For unit-tests: *)
@@ -109,6 +120,7 @@ let create ~switch ~label ~config () =
     let t = { switch; id; ch = Some ch; start_time; set_start_time; config; log_cond; cancel_hooks;
               explicit_confirm; set_explicit_confirm; waiting_for_confirmation = false } in
     jobs := Map.add id t !jobs;
+    Prometheus.Gauge.inc_one Metrics.active_jobs;
     Switch.add_hook_or_fail switch (fun () ->
         begin match t.cancel_hooks with
           | `Hooks hooks ->
@@ -120,6 +132,7 @@ let create ~switch ~label ~config () =
         close_out ch;
         t.ch <- None;
         jobs := Map.remove id !jobs;
+        Prometheus.Gauge.dec_one Metrics.active_jobs;
         Lwt_condition.broadcast t.log_cond ();
         Lwt.return_unit
       );

--- a/lib_cache/dune
+++ b/lib_cache/dune
@@ -9,6 +9,7 @@
    logs
    lwt
    lwt.unix
+   prometheus
    re
    result
    sqlite3))

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -166,6 +166,9 @@ let handle_request ~engine ~webhooks _conn request body =
       Server.respond_string ~status:`OK ~body ()
     | `GET, ["log-rules"] ->
       Log_rules.render ()
+    | `GET, ["jobs"] ->
+      let body = Jobs.render () in
+      Server.respond_string ~status:`OK ~body ()
     | `GET, ["metrics"] ->
       Current.Engine.(update_metrics (state engine));
       let data = Prometheus.CollectorRegistry.(collect default) in

--- a/lib_web/jobs.ml
+++ b/lib_web/jobs.ml
@@ -1,0 +1,33 @@
+open Tyxml.Html
+
+module Job = Current.Job
+
+let render_row (id, job) =
+  let url = Fmt.strf "/job/%s" id in
+  let start_time =
+    match Lwt.state (Job.start_time job) with
+    | Lwt.Sleep -> "(ready to start)"
+    | Lwt.Return t -> Query.string_of_timestamp (Unix.gmtime t)
+    | Lwt.Fail f -> Printexc.to_string f
+  in
+  tr [
+    td [ a ~a:[a_href url] [txt id] ];
+    td [ txt start_time ];
+  ]
+
+let render () =
+  let jobs = Current.Job.jobs () in
+  Main.template (
+    if Current.Job_map.is_empty jobs then [
+      txt "There are no active jobs."
+    ] else [
+      table ~a:[a_class ["table"]]
+        ~thead:(thead [
+            tr [
+              th [txt "Job"];
+              th [txt "Start time"];
+            ]
+          ])
+        (Current.Job_map.bindings jobs |> List.map render_row)
+    ]
+  )

--- a/lib_web/jobs.mli
+++ b/lib_web/jobs.mli
@@ -1,0 +1,3 @@
+(** The /jobs page *)
+
+val render : unit -> string

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -24,6 +24,7 @@ let template contents =
             ul [
               li [a ~a:[a_href "/"] [txt "OCurrent"]];
               li [a ~a:[a_href "/"] [txt "Home"]];
+              li [a ~a:[a_href "/jobs"] [txt "Jobs"]];
               li [a ~a:[a_href "/query"] [txt "Query"]];
               li [a ~a:[a_href "/log-rules"] [txt "Log analysis"]];
             ]


### PR DESCRIPTION
- Add a simple /jobs page to the admin web UI
- Report a Prometheus metric for number of active jobs