### PR TITLE
Mark HTML pages as UTF-8

### DIFF
--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -17,6 +17,7 @@ let template contents =
     html
       (head (title (txt "OCurrent")) [
           link ~rel:[ `Stylesheet ] ~href:"/css/style.css" ();
+          meta ~a:[a_charset "UTF-8"] ();
         ]
       )
       (body [


### PR DESCRIPTION
Otherwise, Firefox uses some strange Windows encoding by default.