### PR TITLE
Docker: make it easier to add custom Docker commands

### DIFF
--- a/examples/docker_custom.ml
+++ b/examples/docker_custom.ml
@@ -1,0 +1,101 @@
+(* Usage: docker_custom.exe
+
+   This fetches the latest nginx image (once a week) and tests it. The test
+   starts the container running and then tries running curl inside it.
+   This demonstrates how to write custom pipeline stages to cover cases that
+   the built-in Docker plugin doesn't.
+*)
+
+open Current.Syntax
+
+module Docker = Current_docker.Default
+
+let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
+
+let () = Logging.init ()
+
+module Test = struct
+  open Lwt.Infix
+
+  let id = "docker-custom-test"         (* A unique ID for the results database *)
+
+  type t = No_context
+
+  module Key = Docker.Image
+  module Value = Current.Unit
+
+  let ( >>!= ) x f =
+    x >>= function
+    | Ok x -> f x
+    | Error (`Msg m) -> failwith m
+
+  let run image = Docker.Cmd.docker ["container"; "run"; "-d"; Docker.Image.hash image]
+  let stop id = Docker.Cmd.docker ["container"; "stop"; id]
+  let rm id = Docker.Cmd.docker ["container"; "rm"; id]
+  let exec id args = Docker.Cmd.docker ("container" :: "exec" :: "-i" :: id :: args)
+
+  (* The test command to run. You might want to make this part of the key if it
+     should be configurable. *)
+  let test_command = ["curl"; "-Ss"; "--fail"; "http://localhost/"]
+
+  let build No_context job image =
+    Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
+    (* Start the container running: *)
+    Current.Process.check_output ~cancellable:false ~job (run image) >>!= fun id ->
+    let id = String.trim id in
+    (* Stop and remove the container when the job finishes: *)
+    Current.Job.on_cancel job (fun _ ->
+        Current.Process.exec ~cancellable:false ~job (stop id) >>!= fun () ->
+        Current.Process.exec ~cancellable:false ~job (rm id) >>!= fun () ->
+        Current.Job.log job "Test cleanup complete";
+        Lwt.return_unit
+      ) >>= fun () ->
+    Current.Job.log job "Waiting 1 second to let HTTP server start...";
+    Lwt_unix.sleep 1.0 >>= fun () ->
+    (* Test the container's service: *)
+    Current.Process.exec ~cancellable:true ~job (exec id test_command)
+
+  let auto_cancel = true
+
+  let pp f image =
+    Fmt.pf f "Test %a" Docker.Image.pp image
+end
+
+module Test_cache = Current_cache.Make(Test)
+
+(* Test a Docker image by running it and then execing curl inside it. *)
+let test image =
+  Current.component "test with@,@[<h>%a@]" Fmt.(list ~sep:sp string) Test.test_command |>
+  let> image = image in
+  Test_cache.get Test.No_context image
+
+(* Build a docker image with nginx and curl and then test it. *)
+let pipeline () =
+  let dockerfile =
+    let+ base = Docker.pull ~schedule:weekly "nginx" in
+    `Contents Dockerfile.(
+        from (Docker.Image.hash base) @@
+        run "apt-get update && apt-get install -y curl --no-install-recommends"
+      )
+  in
+  test (Docker.build ~pull:false ~dockerfile `No_context)
+
+let main config mode =
+  let engine = Current.Engine.create ~config pipeline in
+  Logging.run begin
+    Lwt.choose [
+      Current.Engine.thread engine;
+      Current_web.run ~mode engine;
+    ]
+  end
+
+(* Command-line parsing *)
+
+open Cmdliner
+
+let cmd =
+  let doc = "Check that the nginx container can serve a web page" in
+  Term.(const main $ Current.Config.cmdliner $ Current_web.cmdliner),
+  Term.info "docker_build_local" ~doc
+
+let () = Term.(exit @@ eval cmd)

--- a/examples/dune
+++ b/examples/dune
@@ -1,6 +1,7 @@
 (executables
  (public_names docker_build_local
                docker_service
+               docker_custom
                build_matrix
                github
                github_app

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -76,6 +76,15 @@ module Make (Host : S.HOST) = struct
     Current.component "docker-service@,%s" name |>
     let> image = image in
     SC.set Service.No_context { Service.Key.name; docker_context } { Service.Value.image }
+
+  module Cmd = struct
+    type t = Lwt_process.command
+
+    let docker args =
+      Cmd.docker ~docker_context args
+
+    let pp = Cmd.pp
+  end
 end
 
 module Default = Make(struct

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -78,10 +78,54 @@ module Make (Host : S.HOST) = struct
     SC.set Service.No_context { Service.Key.name; docker_context } { Service.Value.image }
 
   module Cmd = struct
+    open Lwt.Infix
+
+    let ( >>!= ) = Lwt_result.bind
+
     type t = Lwt_process.command
 
     let docker args =
       Cmd.docker ~docker_context args
+
+    let rm_f id = docker ["container"; "rm"; "-f"; id]
+    let kill id = docker ["container"; "kill"; id]
+
+    (* Try to "docker kill $id". If it fails, just log a warning and continue. *)
+    let try_kill_container ~job id =
+      Current.Process.exec ~cancellable:false ~job (kill id) >|= function
+      | Ok () -> ()
+      | Error (`Msg m) -> Current.Job.log job "Warning: Failed to kill container %S: %s" id m
+
+    let with_container ~kill_on_cancel ~job t fn =
+      Current.Process.check_output ~cancellable:false ~job t >>!= fun id ->
+      let id = String.trim id in
+      let did_rm = ref false in
+      Lwt.catch
+        (fun () ->
+           begin
+             if kill_on_cancel then (
+               Current.Job.on_cancel job (fun _ ->
+                   if !did_rm = false then try_kill_container ~job id
+                   else Lwt.return_unit
+                 )
+             ) else (
+               Lwt.return_unit
+             )
+           end >>= fun () ->
+           fn id)
+        (fun ex -> Lwt.return (Fmt.error_msg "with_container: uncaught exception: %a" Fmt.exn ex))
+      >>= fun result ->
+      did_rm := true;
+      Current.Process.exec ~cancellable:false ~job (rm_f id) >|= function
+      | Ok () -> result         (* (the common case, where removing the container succeeds) *)
+      | Error (`Msg rm_error) as rm_e ->
+        match result with
+        | Ok _ -> rm_e
+        | Error _ as e ->
+          (* The job failed, and removing the container failed too.
+             Log the second error and return the first. *)
+          Current.Job.log job "Failed to remove container %S when job failed: %s" id rm_error;
+          e
 
     let pp = Cmd.pp
   end

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -65,6 +65,18 @@ module type DOCKER = sig
 
   val service : name:string -> image:Image.t Current.t -> unit -> unit Current.t
   (** [service ~name ~image ()] keeps a Docker SwarmKit service up-to-date. *)
+
+  module Cmd : sig
+    (** Building Docker commands. This is useful for creating custom pipeline stages. *)
+
+    type t = Lwt_process.command
+
+    val docker : string list -> t
+    (** [docker args] is a command to run docker, with the "--context" argument added (if necessary).
+        e.g. [docker ["run"; image]] *)
+
+    val pp : t Fmt.t
+  end
 end
 
 module type HOST = sig

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -75,6 +75,17 @@ module type DOCKER = sig
     (** [docker args] is a command to run docker, with the "--context" argument added (if necessary).
         e.g. [docker ["run"; image]] *)
 
+    val with_container :
+      kill_on_cancel:bool ->
+      job:Current.Job.t -> t ->
+      (string -> 'a Current.or_error Lwt.t) ->
+      'a Current.or_error Lwt.t
+    (** [with_container ~kill_on_cancel ~job t fn] runs [t] to create a new container
+        (the output is the container ID), then calls [fn id].
+        When [fn] returns, it removes the container (killing it first if necessary).
+        If [fn] raises an exception, it catches it and turns it into an error return.
+        @param kill_on_cancel "docker kill" the container if the the job is cancelled. *)
+
     val pp : t Fmt.t
   end
 end


### PR DESCRIPTION
This adds a `Cmd` submodule to the `DOCKER` type, which creates Docker commands with the right context.

It also adds `examples/docker_custom.ml` which uses this to test an HTTP service container by execing curl in a running container.

This is a more flexible alternative to #99.