### PR TITLE
GitHub: add Commit.uri

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -117,6 +117,9 @@ module Commit_id = struct
     let gref = Ref.to_git id in
     Current_git.Commit_id.v ~repo ~gref ~hash
 
+  let uri t =
+    Uri.make ~scheme:"https" ~host:"github.com" ~path:(Printf.sprintf "/%s/commit/%s" t.owner_name t.hash) ()
+
   let pp_id = Ref.pp
 
   let pp f { owner_name; id; hash } =
@@ -499,6 +502,8 @@ module Commit = struct
   module Set_status_cache = Current_cache.Output(Set_status)
 
   type t = commit
+
+  let uri (_, commit) = Commit_id.uri commit
 
   let id (_, commit_id) = Commit_id.to_git commit_id
 

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -15,6 +15,7 @@ module Commit : sig
   val hash : t -> string
   val pp : t Fmt.t
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
+  val uri : t -> Uri.t
 end
 
 module Ref : sig

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -50,6 +50,9 @@ module Api : sig
     (** [hash t] is the Git commit hash of [t]. *)
 
     val pp : t Fmt.t
+
+    val uri : t -> Uri.t
+    (** [uri t] is a URI for the GitHub web page showing [t]. *)
   end
 
   module Repo : sig


### PR DESCRIPTION
Returns a suitable URI for linking to a commit's page on GitHub.