### PR TITLE
Minor code cleanups and fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test build
 
-DOTS=$(sort $(wildcard _build/default/test/v*.dot))
+DOTS=$(sort $(wildcard _build/default/test/*.dot))
 
 test:
 	dune build @check

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -9,16 +9,11 @@ module Make (Job : sig type id end) : sig
     | Pass
     | Fail of string
 
-  type env
-
-  val make_env : unit -> env
-  (** All linked static values must be created within the same environment (this is
-      used to number them). *)
-
-  val with_bind : t -> env -> env
-  (* [with_bind b ctx] is the environment to use when evaluating the function
-     passed to a [bind]. All static values created within this environment get an
-     implicit dependency on [b]. *)
+  type env = t option
+  (** When evaluating a bind function we need to record that everything also
+      depends on the bind itself, so all the constructors take this in an
+      [~env] argument. This will be [None] if the node wasn't created by
+      a bind. *)
 
   val return       : env:env -> string option -> t
   val fail         : env:env -> string -> t

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -31,14 +31,12 @@ module Make (Job : sig type id end) : sig
   val of_output    : env:env -> _ Output.t -> t
   val pair         : env:env -> t -> t -> t
   val bind         : env:env -> ?info:string -> t -> state -> t
-  val bind_input   : env:env -> info:string -> t -> state -> t
+  val bind_input   : env:env -> info:string -> ?id:Job.id -> t -> state -> t
   val list_map     : env:env -> f:t -> t -> t
   val option_map   : env:env -> f:t -> t -> t
   val gate         : env:env -> on:t -> t -> t
 
   val booting : t
-
-  val set_state : t -> ?id:Job.id -> state -> unit
 
   val job_id : t -> Job.id option
 

--- a/test/expected/v4.2.dot
+++ b/test/expected/v4.2.dot
@@ -3,7 +3,7 @@ digraph pipeline {
   rankdir=LR
   n3 [label="head",fillcolor="#90ee90",style="filled"]
   n2 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="custom-build",fillcolor="#ffa500",style="filled"]
+  n1 [label="custom-build",fillcolor="#90ee90",style="filled"]
   n4 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#ffa500",style="filled"]
   n4 -> n0

--- a/test/expected/v4.3.dot
+++ b/test/expected/v4.3.dot
@@ -3,7 +3,7 @@ digraph pipeline {
   rankdir=LR
   n3 [label="head",fillcolor="#90ee90",style="filled"]
   n2 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="custom-build",fillcolor="#ff4500",style="filled",tooltip="Failed"]
+  n1 [label="custom-build",fillcolor="#90ee90",style="filled"]
   n4 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Failed"]
   n4 -> n0


### PR DESCRIPTION
A bunch of simple code cleanups and fixes extracted from my experimental incremental branch:

- Colour binds based on input state, not output state. The bind box represents choosing the next stage of the pipeline, not its result. This means that analysis nodes are now fully immutable.
- Simplify the analysis `env`, since we no longer use the counter.
- In `lib_term`, handle the bind context explicitly instead of via the `cache` function, which is going away.
- Generate all SVG test outputs, not just the `v*` ones.
