### PR TITLE
Fix analysis with hidden catch/state nodes

### DIFF
--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -20,8 +20,8 @@ module Make (Job : sig type id end) : sig
   val map_input    : env:env -> t -> (string, [`Blocked | `Empty_list]) result -> t
   val map_failed   : env:env -> t -> string -> t
   val option_input : env:env -> t -> [`Blocked | `Selected | `Not_selected] -> t
-  val state        : env:env -> t -> t
-  val catch        : env:env -> t -> t
+  val state        : env:env -> hidden:bool -> t -> t
+  val catch        : env:env -> hidden:bool -> t -> t
   val active       : env:env -> Output.active -> t
   val of_output    : env:env -> _ Output.t -> t
   val pair         : env:env -> t -> t -> t

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -68,14 +68,14 @@ module Make (Input : S.INPUT) = struct
     let env = !bind_context in
     cache @@ fun ctx ->
     let t = t ctx in
-    let an = if hidden then t.md else An.state ~env t.md in
+    let an = An.state ~env ~hidden t.md in
     make an (Dyn.state t.fn)
 
   let catch ?(hidden=false) t =
     let env = !bind_context in
     cache @@ fun ctx ->
     let t = t ctx in
-    let an = if hidden then t.md else An.catch ~env t.md in
+    let an = An.catch ~env ~hidden t.md in
     make an (Dyn.catch t.fn)
 
   let of_output x =

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -3,6 +3,7 @@
           option-none.2.dot
           option-some.1.dot
           option-some.2.dot
+          state.1.dot
           v1.1.dot
           v1.2.dot
           v1.3.dot
@@ -46,6 +47,11 @@
  (name runtest)
  (package current)
  (action (diff expected/option-some.2.dot option-some.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/state.1.dot state.1.dot)))
 
 (alias
  (name runtest)

--- a/test/expected/state.1.dot
+++ b/test/expected/state.1.dot
@@ -1,0 +1,7 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n3 [label="(const)",fillcolor="#ffff00",style="filled"]
+  n1 [label="set-status",fillcolor="#90ee90",style="filled"]
+  n3 -> n1
+  }


### PR DESCRIPTION
If a state node was hidden then we previously used the input's analysis directly. However, this is not correct because the input may be pending while the state itself is ready. Instead, create a node for the state but don't render it in the diagram.