### PR TITLE
Replace changed promises with Engine.update

### DIFF
--- a/test/test_monitor.ml
+++ b/test/test_monitor.ml
@@ -70,7 +70,7 @@ let result =
   let error = Alcotest.testable pp (=) in
   Alcotest.(result unit) error
 
-let trace step { Current.Engine.value = out; watches = inputs; _ } =
+let trace step ~next:_ { Current.Engine.value = out; watches = inputs; _ } =
   incr step;
   let step = !step in
   Logs.info (fun f -> f "Step %d (inputs = %a)" step Fmt.(Dump.list Current.Engine.pp_metadata) inputs);


### PR DESCRIPTION
Previously, inputs returned a Lwt promise that resolved when the input needed to be recalculated. The idea was that this would allow the system to recalculate only the input that had changed. However:

1. This wasn't implemented, so it just recalcuated everything when anything changed.

2. It turns out that incremental systems work by marking things as dirty and then triggering a global propagate operation.

This commit replaces the promises with a single `Engine.update` call which all inputs should use when something changes. This is simpler, and will make adding incremental support easier too.