### PR TITLE
Improve cancellation

### DIFF
--- a/lib/current.ml
+++ b/lib/current.ml
@@ -25,7 +25,6 @@ type job_id = string
 
 class type actions = object
   method pp : Format.formatter -> unit
-  method cancel : (unit -> unit) option
   method rebuild : (unit -> job_id) option
   method release : unit
 end
@@ -75,7 +74,6 @@ module Input = struct
       Log.warn (fun f -> f "Uncaught exception from input: %a" Fmt.exn ex);
       Error (`Msg (Printexc.to_string ex)), metadata @@ object
         method pp f = Fmt.exn f ex
-        method cancel = None
         method rebuild = None
         method release = ()
       end
@@ -84,7 +82,6 @@ module Input = struct
     of_fn @@ fun _env ->
     Ok x, metadata @@ object
       method pp f = Fmt.string f "Input.const"
-      method cancel = None
       method rebuild = None
       method release = ()
     end
@@ -212,7 +209,6 @@ module Var (T : Current_term.S.T) = struct
     t.current, Input.metadata @@
     object
       method pp f = Fmt.string f t.name
-      method cancel = None
       method rebuild = None
       method release = ()
     end
@@ -283,7 +279,6 @@ end = struct
     );  (* (else the previous thread will check [ref_count] before exiting) *)
     t.value, Input.metadata @@
     object
-      method cancel = None
       method rebuild = None   (* Might be useful to implement this *)
       method pp f = t.pp f
       method release =

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -25,10 +25,6 @@ class type actions = object
   method pp : Format.formatter -> unit
   (** Format a message for the user explaining what is being waited on. *)
 
-  method cancel : (unit -> unit) option
-  (** A function to call if the user explicitly requests the operation be cancelled,
-      or [None] if it is not something that can be cancelled. *)
-
   method rebuild : (unit -> job_id) option
   (** A function to call if the user explicitly requests the operation be done again,
       or [None] if it is not something that can be repeated. Returns the new job ID. *)

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -160,7 +160,7 @@ let with_handler t ~on_cancel fn =
 let confirm t ?pool level =
   let confirmed =
     let confirmed = Config.confirmed level t.config in
-    Switch.add_hook_or_fail t.switch (fun _ -> Lwt.cancel confirmed; Lwt.return_unit);
+    on_cancel t (fun _ -> Lwt.cancel confirmed; Lwt.return_unit) >>= fun () ->
     match Lwt.state confirmed with
     | Lwt.Return () -> Lwt.return_unit
     | _ ->

--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -297,7 +297,6 @@ module Output(Op : S.PUBLISHER) = struct
         Current.Input.metadata ~job_id @@
         object
           method pp f = pp_output f o
-          method cancel = None
           method rebuild = Some rebuild
           method release = ()
         end
@@ -321,7 +320,6 @@ module Output(Op : S.PUBLISHER) = struct
               Fmt.pf f "%a will be invalid after %a"
                 pp_op (key, value)
                 pp_duration_rough (Duration.of_f remaining_time)
-          method cancel = None
           method rebuild = Some rebuild
           method release = ()
         end
@@ -377,7 +375,6 @@ module Output(Op : S.PUBLISHER) = struct
       Error (`Active a), Current.Input.metadata ?job_id:o.job_id @@
       object
         method pp f = pp_output f o
-        method cancel = Some (fun () -> Job.cancel op.job "Cancelled by user")
         method rebuild = None
         method release =
           o.ref_count <- o.ref_count - 1;

--- a/lib_rpc/s.ml
+++ b/lib_rpc/s.ml
@@ -7,7 +7,6 @@ module type CURRENT = sig
 
   class type actions = object
     method pp : Format.formatter -> unit
-    method cancel : (unit -> unit) option
     method rebuild : (unit -> string) option
     method release : unit
   end
@@ -18,6 +17,8 @@ module type CURRENT = sig
     val lookup_running : string -> t option
     val wait_for_log_data : t -> unit Lwt.t
     val approve_early_start : t -> unit
+    val cancel : t -> string -> unit
+    val cancelled_state : t -> (unit, [`Msg of string]) result
   end
 
   module Engine : sig

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -19,7 +19,6 @@ let respond_error status body =
 
 type actions = <
   rebuild : (unit -> string) option;
-  cancel : (unit -> unit) option;
 >
 
 let lookup_actions ~engine job_id =
@@ -30,7 +29,6 @@ let lookup_actions ~engine job_id =
   | None ->
     object
       method rebuild = None
-      method cancel = None
     end
 
 let get_job ~actions job_id =
@@ -47,11 +45,11 @@ let get_job ~actions job_id =
       in
       Server.respond ~status:`OK ~headers ~body ()
 
-let cancel_job ~actions _job_id =
-  match actions#cancel with
+let cancel_job job_id =
+  match Current.Job.lookup_running job_id with
   | None -> respond_error `Bad_request "Job does not support cancel (already finished?)"
-  | Some cancel ->
-    cancel ();
+  | Some job ->
+    Current.Job.cancel job "Cancelled by user";
     Server.respond_redirect ~uri:(Uri.of_string "/") ()
 
 let rebuild_job ~actions _job_id =
@@ -124,8 +122,7 @@ let handle_request ~engine ~webhooks _conn request body =
               rebuild_job ~actions job_id
             | ["job"; date; log; "cancel"] ->
               let job_id = Fmt.strf "%s/%s" date log in
-              let actions = lookup_actions ~engine job_id in
-              cancel_job ~actions job_id
+              cancel_job job_id
             | ["job"; date; log; "start"] ->
               let job_id = Fmt.strf "%s/%s" date log in
               begin match Current.Job.lookup_running job_id with

--- a/lib_web/job.ml
+++ b/lib_web/job.ml
@@ -15,12 +15,13 @@ let render ~actions ~job_id ~log =
       ]
   in
   let cancel_button =
-    if actions#cancel = None then []
-    else
+    match Current.Job.lookup_running job_id with
+    | Some job when Current.Job.cancelled_state job = Ok () ->
       [form ~a:[action "cancel"; a_method `Post]
          [ input ~a:[a_input_type `Submit; a_value "Cancel"] ();
            input ~a:[a_name "csrf"; a_input_type `Hidden; a_value Main.csrf_token] () ]
       ]
+    | _ -> []
   in
   let start_button =
     match Current.Job.lookup_running job_id with

--- a/plugins/fs/current_fs.ml
+++ b/plugins/fs/current_fs.ml
@@ -10,7 +10,6 @@ let save path value =
   Current.Input.of_fn @@ fun _env ->
   let actions = object
     method pp f = Fmt.pf f "Save %a" Fpath.pp path
-    method cancel = None
     method rebuild = None
     method release = ()
   end in


### PR DESCRIPTION
- Fix cancelling a job while waiting for confirmation.
- Use `Job.cancel` directly to allow cancelling jobs that are no longer needed but not auto-cancelled.