### PR TITLE
Preparations for incremental support

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -32,6 +32,8 @@ let v ?auto_release ?confirm () =
 
 let default = v ()
 
+let now : t option ref = ref None
+
 let rec confirmed l t =
   match t.confirm with
   | Some threshold when Level.compare l threshold >= 0 ->

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -42,8 +42,6 @@ module Input = struct
 
   type 'a t = unit -> 'a Current_term.Output.t * job_id option
 
-  type env = unit
-
   let register_actions ?job_id actions =
     watches := actions :: !watches;
     begin match job_id with
@@ -58,10 +56,10 @@ module Input = struct
       Error (`Msg (Printexc.to_string ex)), None
 
   let const x =
-    of_fn @@ fun _env ->
+    of_fn @@ fun () ->
     Ok x, None
 
-  let get () (t : 'a t) = t ()
+  let get (t : 'a t) = t ()
 
   let map_result fn t step =
     let x, md = t step in
@@ -119,7 +117,7 @@ module Engine = struct
       let next = Lwt_condition.wait propagate in
       Log.debug (fun f -> f "Evaluating...");
       let t0 = Unix.gettimeofday () in
-      let r, an = Executor.run ~env:() f in
+      let r, an = Executor.run f in
       let t1 = Unix.gettimeofday () in
       Prometheus.Summary.observe Metrics.evaluation_time_seconds (t1 -. t0);
       let new_jobs = !active_jobs in

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -17,6 +17,9 @@ module Config : sig
   val get_confirm : t -> Level.t option
 
   val cmdliner : t Cmdliner.Term.t
+
+  val now : t option ref
+  (** [None] initially, then set to the configuration and never changes. *)
 end
 
 type job_id = string
@@ -42,8 +45,6 @@ module Step : sig
   val id : t -> id
   (** [id t] is a unique value for this evaluation step.
       This can be useful to detect if e.g. the same output has been set to two different values in one step. *)
-
-  val config : t -> Config.t
 end
 
 module Input : sig

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -115,7 +115,6 @@ module Engine : sig
   type results = {
     value : unit Current_term.Output.t;
     analysis : Analysis.t;
-    watches : metadata list;
     jobs : actions Job_map.t;        (** The jobs currently being used (whether running or finished). *)
   }
 

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -63,6 +63,11 @@ module Input : sig
       @param job_id An ID that can be used to refer to this job later (to request a rebuild, etc).
       @param actions Ways to interact with this input. *)
 
+  val register : ?job_id:job_id -> actions -> unit
+  (** [register ~job_id actions] is used to register handlers for cancelling and rebuilding jobs.
+      @param job_id An ID that can be used to refer to this job later (to request a rebuild, etc).
+      @param actions Ways to interact with this input. *)
+
   val of_fn : (Step.t -> 'a Current_term.Output.t * metadata) -> 'a t
   (** [of_fn f] is an input that calls [f config] when it is evaluated.
       When [f] is called, the caller gets a ref-count on the watches and will

--- a/lib_term/current_term.mli
+++ b/lib_term/current_term.mli
@@ -7,15 +7,11 @@ module Output = Output
 module Make (Input : S.INPUT) : sig
   include S.TERM with type 'a input := 'a Input.t
 
-  val env : Input.env t
-  (** [env] evaluates to the user-provided environment. *)
-
   module Analysis : S.ANALYSIS with
     type 'a term := 'a t and
     type job_id := Input.job_id
 
   module Executor : S.EXECUTOR with
     type 'a term := 'a t and
-    type env := Input.env and
     type analysis := Analysis.t
 end

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -22,10 +22,7 @@ module type INPUT = sig
 
   type job_id
 
-  type env
-  (** A context which the caller can associate with an execution. *)
-
-  val get : env -> 'a t -> 'a Output.t * job_id option
+  val get : 'a t -> 'a Output.t * job_id option
 end
 
 module type ANALYSIS = sig
@@ -208,12 +205,9 @@ module type EXECUTOR = sig
   type 'a term
   (** See [TERM]. *)
 
-  type env
-  (** See [INPUT]. *)
-
   type analysis
   (** See [ANALYSIS]. *)
 
-  val run : env:env -> (unit -> 'a term) -> 'a Output.t * analysis
-  (** [run ~env f] evaluates term [f ()], returning the current output and its analysis. *)
+  val run : (unit -> 'a term) -> 'a Output.t * analysis
+  (** [run f] evaluates term [f ()], returning the current output and its analysis. *)
 end

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -56,7 +56,7 @@ let settings config =
 
 let dashboard engine =
   let config = Current.Engine.config engine in
-  let { Current.Engine.value; analysis = _; watches = _; jobs = _ } = Current.Engine.state engine in
+  let { Current.Engine.value; analysis = _; jobs = _ } = Current.Engine.state engine in
   template [
     div [
       object_ ~a:[a_data "/pipeline.svg"] [txt "Pipeline diagram"];

--- a/plugins/fs/current_fs.ml
+++ b/plugins/fs/current_fs.ml
@@ -8,22 +8,17 @@ let save path value =
   let> path = path
   and> value = value in
   Current.Input.of_fn @@ fun _env ->
-  let actions = object
-    method pp f = Fmt.pf f "Save %a" Fpath.pp path
-    method rebuild = None
-    method release = ()
-  end in
   match Bos.OS.File.read path with
   | Ok old when old = value ->
     Log.info (fun f -> f "No change for %a" Fpath.pp path);
-    Ok (), Current.Input.metadata actions
+    Ok (), None
   | Error _ as e when Bos.OS.File.exists path = Ok true ->
-    e, Current.Input.metadata actions
+    e, None
   | _ ->
     (* Old contents differ, or file doesn't exist. *)
     match Bos.OS.File.write path value with
     | Ok () ->
       Log.info (fun f -> f "Updated %a" Fpath.pp path);
-      Ok (), Current.Input.metadata actions
+      Ok (), None
     | Error _ as e ->
-      e, Current.Input.metadata actions
+      e, None

--- a/test/test.ml
+++ b/test/test.ml
@@ -168,15 +168,14 @@ let test_state _switch () =
 module Test_input = struct
   type 'a t = unit
   type job_id = unit
-  type env = unit
 
-  let get () () = Error (`Msg "Can't happen"), None
+  let get () = Error (`Msg "Can't happen"), None
 end
 
 module Term = Current_term.Make(Test_input)
 
 let test_all_labelled () =
-  let test x = fst (Term.Executor.run ~env:() (fun () -> Term.all_labelled x)) in
+  let test x = fst (Term.Executor.run (fun () -> Term.all_labelled x)) in
   Alcotest.check engine_result "all_ok" (Ok ()) @@ test [
     "Alpine", Term.return ();
     "Debian", Term.return ();

--- a/test/test_monitor.ml
+++ b/test/test_monitor.ml
@@ -70,17 +70,15 @@ let result =
   let error = Alcotest.testable pp (=) in
   Alcotest.(result unit) error
 
-let trace step ~next:_ { Current.Engine.value = out; watches = inputs; _ } =
+let trace step ~next:_ { Current.Engine.value = out; _ } =
   incr step;
   let step = !step in
-  Logs.info (fun f -> f "Step %d (inputs = %a)" step Fmt.(Dump.list Current.Engine.pp_metadata) inputs);
   match step with
   | 1 ->
     (* Although there is data ready, we shouldn't have started the read yet
        because we're still enabling the watch. *)
     Alcotest.check result "Initially pending" (Error (`Active `Running)) out;
     assert (!w <> None);
-    assert (List.length inputs = 2);
     let w = get_watch () in
     Lwt.wakeup w.set_ready ();
     Lwt.return_unit
@@ -107,7 +105,6 @@ let trace step ~next:_ { Current.Engine.value = out; watches = inputs; _ } =
     Lwt.return_unit
   | 5 ->
     Alcotest.check result "Not wanted" (Ok ()) out;
-    assert (List.length inputs = 1);
     assert (!w <> None);
     Lwt.pause () >>= fun () ->
     (* Wanted again, before we've finished shutting down. *)
@@ -132,7 +129,6 @@ let trace step ~next:_ { Current.Engine.value = out; watches = inputs; _ } =
     Lwt.return_unit
   | 8 ->
     Alcotest.check result "Not wanted" (Ok ()) out;
-    assert (List.length inputs = 1);
     Lwt.pause () >>= fun () ->
     assert (!w <> None);
     Lwt_condition.broadcast unwatch ();   (* Allow shutdown to finish *)


### PR DESCRIPTION
The old code created a fresh `Step.t` at each iteration and passed that through to every user function. That doesn't work well with incremental evaluation, since updating it causes everything to be reevaluated each time. This PR gets rid of the step object, moving or removing everything that was inside it:

- The configuration is now available as `Config.now`.
- The step ID is available from `Engine` (it's just used to help detect bugs).
- `watches` and `active_jobs` are now globals, not part of the step.
- `watches` is no longer in the public API (it will be replaced in incremental). Only the unit-tests used this.
- `user_env` is no longer needed and has been removed from `lib_term`.
- Input functions no longer return the actions. Instead, they can call `register_actions` to do this. This simplifies ref-counting with incremental evaluation, since you can just bump the count immediately before calling `register_actions`. It also avoids the need to provide a dummy set of actions if you don't need any.