### PR TITLE
Improve Monitor and Input APIs

### DIFF
--- a/lib/current.ml
+++ b/lib/current.ml
@@ -4,8 +4,6 @@ type 'a or_error = ('a, [`Msg of string]) result
 
 module Config = Config
 
-module Job_map = Job.Map
-
 module Metrics = struct
   open Prometheus
 
@@ -26,28 +24,12 @@ type job_id = string
 class type actions = object
   method pp : Format.formatter -> unit
   method rebuild : (unit -> job_id) option
-  method release : unit
 end
-
-type job_metadata = {
-  job_id : job_id option;
-  actions : actions;
-}
-
-let watches : actions list ref = ref []         (* Will call #release at end-of-step *)
-let active_jobs : actions Job_map.t ref = ref Job_map.empty
 
 module Input = struct
   type nonrec job_id = job_id
 
   type 'a t = 'a Current_term.Output.t * job_id option
-
-  let register_actions ?job_id actions =
-    watches := actions :: !watches;
-    begin match job_id with
-      | None -> ()
-      | Some job_id -> active_jobs := Job_map.add job_id actions !active_jobs
-    end
 
   let const x = Ok x, None
 
@@ -63,6 +45,8 @@ include Current_term.Make(Input)
 type 'a term = 'a t
 
 module Engine = struct
+  let active_jobs : actions Job.Map.t ref = ref Job.Map.empty
+
   module Step = struct
     type t = < >
     let create () = object end
@@ -73,12 +57,10 @@ module Engine = struct
       current_step := create ()
   end
 
-  type metadata = job_metadata
-
   type results = {
     value : unit Current_term.Output.t;
     analysis : Analysis.t;
-    jobs : actions Job_map.t;
+    jobs : actions Job.Map.t;
   }
 
   type t = {
@@ -86,6 +68,8 @@ module Engine = struct
     last_result : results ref;
     config : Config.t;
   }
+
+  let watches : (unit -> unit) list ref = ref []         (* Functions to call at end-of-step *)
 
   let propagate = Lwt_condition.create ()
 
@@ -95,7 +79,7 @@ module Engine = struct
   let booting = {
     value = Error (`Active `Running);
     analysis = Analysis.booting;
-    jobs = Job_map.empty;
+    jobs = Job.Map.empty;
   }
 
   let default_trace ~next:_ r =
@@ -106,16 +90,17 @@ module Engine = struct
     let last_result = ref booting in
     let rec aux old_watches =
       let next = Lwt_condition.wait propagate in
+      active_jobs := Job.Map.empty;
       Log.debug (fun f -> f "Evaluating...");
       let t0 = Unix.gettimeofday () in
       let r, an = Executor.run f in
       let t1 = Unix.gettimeofday () in
       Prometheus.Summary.observe Metrics.evaluation_time_seconds (t1 -. t0);
       let new_jobs = !active_jobs in
-      active_jobs := Job_map.empty;
+      active_jobs := Job.Map.empty;
       let new_watches = !watches in
       watches := [];
-      List.iter (fun w -> w#release) old_watches;
+      List.iter (fun w -> w ()) old_watches;
       last_result := {
         value = r;
         analysis = an;
@@ -140,6 +125,9 @@ module Engine = struct
     in
     { thread; last_result; config }
 
+  let on_disable fn =
+    watches := fn :: !watches
+
   let state t = !(t.last_result)
 
   let jobs s = s.jobs
@@ -147,12 +135,6 @@ module Engine = struct
   let config t = t.config
 
   let thread t = t.thread
-
-  let actions m = m.actions
-
-  let job_id m = m.job_id
-
-  let pp_metadata f m = m.actions#pp f
 
   let update_metrics results =
     let { Current_term.S.ok; ready; running; failed; blocked } = Analysis.stats results.analysis in
@@ -231,14 +213,11 @@ module Monitor = struct
 
   let input t =
     t.ref_count <- t.ref_count + 1;
-    Input.register_actions @@ object
-      method rebuild = None   (* Might be useful to implement this *)
-      method pp f = t.pp f
-      method release =
+    Engine.on_disable (fun () ->
         assert (t.ref_count > 0);
         t.ref_count <- t.ref_count - 1;
         if t.ref_count = 0 then Lwt_condition.broadcast t.cond ()
-    end;
+      );
     if not t.active then (
       t.active <- true;
       Lwt.async (fun () -> enable t >|= fun `Finished -> ())
@@ -284,8 +263,14 @@ end
 let state_dir = Disk_store.state_dir
 
 module Db = Db
-module Job = Job
 module Process = Process
 module Switch = Switch
 module Pool = Pool
 module Log_matcher = Log_matcher
+
+module Job = struct
+  include Job
+
+  let register_actions job_id actions =
+    Engine.active_jobs := Job.Map.add job_id actions !Engine.active_jobs
+end

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -39,7 +39,7 @@ class type actions = object
 end
 
 module Input : sig
-  type 'a t
+  type 'a t = 'a Current_term.Output.t * job_id option
   (** An input that produces an ['a term]. *)
 
   val const : 'a -> 'a t
@@ -52,10 +52,6 @@ module Input : sig
       If the ref-count drops to zero then you can then cancel the job.
       @param job_id An ID that can be used to refer to this job later (to request a rebuild, etc).
       @param actions Ways to interact with this input. *)
-
-  val of_fn : (unit -> 'a Current_term.Output.t * job_id option) -> 'a t
-  (** [of_fn f] is an input that calls [f ()] when it is evaluated.
-      [f] can call [register] to attach actions to a job. *)
 
   val map_result : ('a Current_term.Output.t -> 'b Current_term.Output.t) -> 'a t -> 'b t
   (** [map_result fn t] transforms the result of [t] with [fn]. The metadata remains the same.

--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -343,7 +343,6 @@ module Output(Op : S.PUBLISHER) = struct
       end
 
   let set ?(schedule=Schedule.default) ctx key value =
-    Current.Input.of_fn @@ fun () ->
     match !Current.Config.now with
     | None -> Error (`Active `Ready), None
     | Some config ->

--- a/lib_rpc/impl.ml
+++ b/lib_rpc/impl.ml
@@ -18,7 +18,7 @@ module Make (Current : S.CURRENT) = struct
   open Capnp_rpc_lwt
 
   module Job = struct
-    let job_cache = ref Current.Job_map.empty
+    let job_cache = ref Current.Job.Map.empty
 
     let stream_log_data ~job_id ~start =
       match Current.Job.log_path job_id with
@@ -38,7 +38,7 @@ module Make (Current : S.CURRENT) = struct
 
     let rec local engine job_id =
       let module Job = Api.Service.Job in
-      match Current.Job_map.find_opt job_id !job_cache with
+      match Current.Job.Map.find_opt job_id !job_cache with
       | Some job ->
         Capability.inc_ref job;
         job
@@ -46,7 +46,7 @@ module Make (Current : S.CURRENT) = struct
         let cap =
           let lookup () =
             let state = Current.Engine.state engine in
-            Current.Job_map.find_opt job_id (Current.Engine.jobs state)
+            Current.Job.Map.find_opt job_id (Current.Engine.jobs state)
           in
           Job.local @@ object
             inherit Job.service
@@ -125,10 +125,10 @@ module Make (Current : S.CURRENT) = struct
                 Service.return response
 
             method! release =
-              job_cache := Current.Job_map.remove job_id !job_cache
+              job_cache := Current.Job.Map.remove job_id !job_cache
           end
         in
-        job_cache := Current.Job_map.add job_id cap !job_cache;
+        job_cache := Current.Job.Map.add job_id cap !job_cache;
         cap
 
     let local_opt engine job_id =
@@ -150,7 +150,7 @@ module Make (Current : S.CURRENT) = struct
         Log.info (fun f -> f "activeJobs");
         let response, results = Service.Response.create Results.init_pointer in
         let state = Current.Engine.state engine in
-        Current.Job_map.bindings (Current.Engine.jobs state)
+        Current.Job.Map.bindings (Current.Engine.jobs state)
         |> List.map fst |> Results.ids_set_list results |> ignore;
         Service.return response
 

--- a/lib_rpc/s.ml
+++ b/lib_rpc/s.ml
@@ -3,16 +3,14 @@
     the "current" service implementation package. *)
 
 module type CURRENT = sig
-  module Job_map : Map.S with type key = string
-
   class type actions = object
     method pp : Format.formatter -> unit
     method rebuild : (unit -> string) option
-    method release : unit
   end
 
   module Job : sig
     type t
+    module Map : Map.S with type key = string
     val log_path : string -> (Fpath.t, [`Msg of string]) result
     val lookup_running : string -> t option
     val wait_for_log_data : t -> unit Lwt.t
@@ -26,6 +24,6 @@ module type CURRENT = sig
     type results
 
     val state : t -> results
-    val jobs : results -> actions Job_map.t
+    val jobs : results -> actions Job.Map.t
   end
 end

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -24,7 +24,7 @@ type actions = <
 let lookup_actions ~engine job_id =
   let state = Current.Engine.state engine in
   let jobs = state.Current.Engine.jobs in
-  match Current.Job_map.find_opt job_id jobs with
+  match Current.Job.Map.find_opt job_id jobs with
   | Some a -> (a :> actions)
   | None ->
     object

--- a/lib_web/jobs.ml
+++ b/lib_web/jobs.ml
@@ -18,7 +18,7 @@ let render_row (id, job) =
 let render () =
   let jobs = Current.Job.jobs () in
   Main.template (
-    if Current.Job_map.is_empty jobs then [
+    if Current.Job.Map.is_empty jobs then [
       txt "There are no active jobs."
     ] else [
       table ~a:[a_class ["table"]]
@@ -28,6 +28,6 @@ let render () =
               th [txt "Start time"];
             ]
           ])
-        (Current.Job_map.bindings jobs |> List.map render_row)
+        (Current.Job.Map.bindings jobs |> List.map render_row)
     ]
   )

--- a/plugins/fs/current_fs.ml
+++ b/plugins/fs/current_fs.ml
@@ -7,7 +7,6 @@ let save path value =
   Current.component "save" |>
   let> path = path
   and> value = value in
-  Current.Input.of_fn @@ fun _env ->
   match Bos.OS.File.read path with
   | Ok old when old = value ->
     Log.info (fun f -> f "No change for %a" Fpath.pp path);

--- a/plugins/github/installation.ml
+++ b/plugins/github/installation.ml
@@ -16,7 +16,7 @@ type t = {
   iid : int;
   account : string;
   api : Api.t;
-  repos : Api.Repo.t list Current.Input.t;
+  repos : Api.Repo.t list Current.Monitor.t;
 }
 
 let installation_repositories_cond = Lwt_condition.create ()
@@ -66,7 +66,7 @@ let v ~iid ~account ~api =
     let thread = aux (Lwt_condition.wait installation_repositories_cond) in
     Lwt.return (fun () -> Lwt.cancel thread; Lwt.return_unit) in
   let pp f = Fmt.string f account in
-  let repos = Current.monitor ~read ~watch ~pp in
+  let repos = Current.Monitor.create ~read ~watch ~pp in
   { iid; account; api; repos }
 
 let api t = t.api
@@ -74,4 +74,4 @@ let api t = t.api
 let repositories t =
   Current.component "list repos" |>
   let> t = t in
-  t.repos
+  Current.Monitor.input t.repos

--- a/test/driver.ml
+++ b/test/driver.ml
@@ -50,12 +50,12 @@ let test_pipeline =
 let current_watches = ref { Current.Engine.
                             value = Error (`Active `Ready);
                             analysis = Current.Analysis.booting;
-                            jobs = Current.Job_map.empty }
+                            jobs = Current.Job.Map.empty }
 
 let pp_job f j = j#pp f
 
 let find_by_descr msg =
-  let jobs = (!current_watches).Current.Engine.jobs |> Current.Job_map.bindings in
+  let jobs = (!current_watches).Current.Engine.jobs |> Current.Job.Map.bindings in
   match List.find_opt (fun (_, job) -> Fmt.strf "%t" job#pp = msg) jobs with
   | None ->
     Fmt.failwith "@[<v2>No job with description %S. We have:@,%a@]" msg

--- a/test/test_monitor.ml
+++ b/test/test_monitor.ml
@@ -40,12 +40,12 @@ let watch update =
 
 let pp f = Fmt.string f "watch"
 
-let monitor = Current.monitor ~read ~watch ~pp
+let monitor = Current.Monitor.create ~read ~watch ~pp
 
 let input () =
   Current.component "input" |>
   let> () = Current.return () in
-  monitor
+  Current.Monitor.input monitor
 
 module Bool_var = Current.Var(struct type t = bool let pp = Fmt.bool let equal = (=) end)
 


### PR DESCRIPTION
More changes to help with incremental evaluation:

- An `Input.t` is now a plain value, not a function.
- The monitor API has changed to split creation from use.
- `Input.register_actions` has been split into two functions, since it did two unrelated things.

This will allow changing `Input.t` into an incremental value later, but it's also a simpler API.