### PR TITLE
Evaluate individual test pipelines inside test_pipeline

### DIFF
--- a/test/expected/option-none.1.dot
+++ b/test/expected/option-none.1.dot
@@ -1,13 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n1 [label="analyse",fillcolor="#d3d3d3",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n3 [label="analyse",fillcolor="#d3d3d3",style="filled"]
   subgraph cluster_0 {
-  style="dotted"n4 [label="lint",fillcolor="#d3d3d3",style="filled"]
+  style="dotted"n6 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
-  n1 -> n4
+  n3 -> n6
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/option-none.2.dot
+++ b/test/expected/option-none.2.dot
@@ -1,13 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n4 [label="head",fillcolor="#90ee90",style="filled"]
-  n3 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n2 [label="analyse",fillcolor="#90ee90",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n4 [label="analyse",fillcolor="#90ee90",style="filled"]
   subgraph cluster_0 {
-  style="dotted"n5 [label="lint",fillcolor="#d3d3d3",style="filled"]
+  style="dotted"n7 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
-  n2 -> n5
-  n3 -> n2
-  n4 -> n3
+  n4 -> n7
+  n5 -> n4
+  n6 -> n5
+  n1 -> n6
+  n2 -> n1
   }

--- a/test/expected/option-some.1.dot
+++ b/test/expected/option-some.1.dot
@@ -1,13 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n1 [label="analyse",fillcolor="#d3d3d3",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n3 [label="analyse",fillcolor="#d3d3d3",style="filled"]
   subgraph cluster_0 {
-  style="dotted"n4 [label="lint",fillcolor="#d3d3d3",style="filled"]
+  style="dotted"n6 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
-  n1 -> n4
+  n3 -> n6
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/option-some.2.dot
+++ b/test/expected/option-some.2.dot
@@ -1,13 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n4 [label="head",fillcolor="#90ee90",style="filled"]
-  n3 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n2 [label="analyse",fillcolor="#90ee90",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n4 [label="analyse",fillcolor="#90ee90",style="filled"]
   subgraph cluster_0 {
-  style="dotted"n6 [label="lint",fillcolor="#90ee90",style="filled"]
+  style="dotted"n8 [label="lint",fillcolor="#90ee90",style="filled"]
   }
-  n2 -> n6
-  n3 -> n2
-  n4 -> n3
+  n4 -> n8
+  n5 -> n4
+  n6 -> n5
+  n1 -> n6
+  n2 -> n1
   }

--- a/test/expected/state.1.dot
+++ b/test/expected/state.1.dot
@@ -1,7 +1,9 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="(const)",fillcolor="#ffff00",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
   n1 [label="set-status",fillcolor="#90ee90",style="filled"]
-  n3 -> n1
+  n2 -> n1
+  n3 -> n2
   }

--- a/test/expected/v1.1.dot
+++ b/test/expected/v1.1.dot
@@ -1,11 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n1 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n3 [label="build",fillcolor="#d3d3d3",style="filled"]
   n0 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n1 -> n0
+  n3 -> n0
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/v1.2.dot
+++ b/test/expected/v1.2.dot
@@ -1,11 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="build",fillcolor="#90ee90",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n3 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n1 -> n0
+  n3 -> n0
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/v1.3.dot
+++ b/test/expected/v1.3.dot
@@ -1,11 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="build",fillcolor="#90ee90",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n3 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n1 -> n0
+  n3 -> n0
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/v1c.1.dot
+++ b/test/expected/v1c.1.dot
@@ -1,11 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n1 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n3 [label="build",fillcolor="#d3d3d3",style="filled"]
   n0 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n1 -> n0
+  n3 -> n0
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/v1c.2.dot
+++ b/test/expected/v1c.2.dot
@@ -1,11 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="build",fillcolor="#90ee90",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n3 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n1 -> n0
+  n3 -> n0
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/v1c.3.dot
+++ b/test/expected/v1c.3.dot
@@ -1,11 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="build",fillcolor="#90ee90",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n3 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Cancelled"]
-  n1 -> n0
+  n3 -> n0
+  n4 -> n3
+  n5 -> n4
+  n1 -> n5
   n2 -> n1
-  n3 -> n2
   }

--- a/test/expected/v2.1.dot
+++ b/test/expected/v2.1.dot
@@ -1,16 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n3 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n2 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n1 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n5 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n4 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
   n0 [label="docker push foo/bar",fillcolor="#d3d3d3",style="filled"]
-  n1 -> n0
-  n3 -> n1
-  n2 -> n1 [style="dashed"]
-  n3 -> n2
-  n4 -> n3
+  n3 -> n0
+  n5 -> n3
+  n4 -> n3 [style="dashed"]
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v2.2.dot
+++ b/test/expected/v2.2.dot
@@ -1,16 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n2 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n1 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
   n0 [label="docker push foo/bar",fillcolor="#d3d3d3",style="filled"]
-  n1 -> n0
-  n3 -> n1
-  n2 -> n1 [style="dashed"]
-  n3 -> n2
-  n4 -> n3
+  n3 -> n0
+  n5 -> n3
+  n4 -> n3 [style="dashed"]
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v2.3.dot
+++ b/test/expected/v2.3.dot
@@ -1,16 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n2 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n1 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
   n0 [label="docker push foo/bar",fillcolor="#ffff00",style="filled"]
-  n1 -> n0
-  n3 -> n1
-  n2 -> n1 [style="dashed"]
-  n3 -> n2
-  n4 -> n3
+  n3 -> n0
+  n5 -> n3
+  n4 -> n3 [style="dashed"]
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v2.4.dot
+++ b/test/expected/v2.4.dot
@@ -1,16 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n2 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n1 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
   n0 [label="docker push foo/bar",fillcolor="#90ee90",style="filled"]
-  n1 -> n0
-  n3 -> n1
-  n2 -> n1 [style="dashed"]
-  n3 -> n2
-  n4 -> n3
+  n3 -> n0
+  n5 -> n3
+  n4 -> n3 [style="dashed"]
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v3.1.dot
+++ b/test/expected/v3.1.dot
@@ -1,40 +1,44 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n9 [label="head",fillcolor="#90ee90",style="filled"]
-  n8 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n7 [label="build-win",fillcolor="#d3d3d3",style="filled"]
-  n6 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n11 [label="build-mac",fillcolor="#d3d3d3",style="filled"]
-  n10 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n13 [label="build-lin",fillcolor="#d3d3d3",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n11 [label="head",fillcolor="#90ee90",style="filled"]
+  n10 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n9 [label="build-win",fillcolor="#d3d3d3",style="filled"]
+  n8 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="build-mac",fillcolor="#d3d3d3",style="filled"]
   n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n2 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
-  n15 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n14 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n15 [label="build-lin",fillcolor="#d3d3d3",style="filled"]
+  n14 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n4 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
   n17 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n16 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n16 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n19 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n18 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n19 -> n18
+  n15 -> n19
+  n14 -> n19 [style="dashed"]
+  n12 -> n19 [style="dashed"]
+  n8 -> n19 [style="dashed"]
   n17 -> n16
   n13 -> n17
+  n14 -> n17 [style="dashed"]
   n12 -> n17 [style="dashed"]
-  n10 -> n17 [style="dashed"]
-  n6 -> n17 [style="dashed"]
+  n8 -> n17 [style="dashed"]
+  n5 -> n4
+  n9 -> n5
+  n14 -> n5 [style="dashed"]
+  n12 -> n5 [style="dashed"]
+  n8 -> n5 [style="dashed"]
   n15 -> n14
-  n11 -> n15
-  n12 -> n15 [style="dashed"]
-  n10 -> n15 [style="dashed"]
-  n6 -> n15 [style="dashed"]
-  n3 -> n2
-  n7 -> n3
-  n12 -> n3 [style="dashed"]
-  n10 -> n3 [style="dashed"]
-  n6 -> n3 [style="dashed"]
+  n10 -> n15
   n13 -> n12
-  n8 -> n13
-  n11 -> n10
-  n8 -> n11
-  n7 -> n6
-  n8 -> n7
+  n10 -> n13
   n9 -> n8
+  n10 -> n9
+  n11 -> n10
+  n1 -> n11
+  n2 -> n1
   }

--- a/test/expected/v3.2.dot
+++ b/test/expected/v3.2.dot
@@ -1,40 +1,44 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n9 [label="head",fillcolor="#90ee90",style="filled"]
-  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n7 [label="build-win",fillcolor="#90ee90",style="filled"]
-  n6 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n11 [label="build-mac",fillcolor="#90ee90",style="filled"]
-  n10 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n13 [label="build-lin",fillcolor="#90ee90",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n11 [label="head",fillcolor="#90ee90",style="filled"]
+  n10 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n9 [label="build-win",fillcolor="#90ee90",style="filled"]
+  n8 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n13 [label="build-mac",fillcolor="#90ee90",style="filled"]
   n12 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n2 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
-  n15 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n14 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n15 [label="build-lin",fillcolor="#90ee90",style="filled"]
+  n14 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n4 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
   n17 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n16 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n16 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n19 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n18 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n19 -> n18
+  n15 -> n19
+  n14 -> n19 [style="dashed"]
+  n12 -> n19 [style="dashed"]
+  n8 -> n19 [style="dashed"]
   n17 -> n16
   n13 -> n17
+  n14 -> n17 [style="dashed"]
   n12 -> n17 [style="dashed"]
-  n10 -> n17 [style="dashed"]
-  n6 -> n17 [style="dashed"]
+  n8 -> n17 [style="dashed"]
+  n5 -> n4
+  n9 -> n5
+  n14 -> n5 [style="dashed"]
+  n12 -> n5 [style="dashed"]
+  n8 -> n5 [style="dashed"]
   n15 -> n14
-  n11 -> n15
-  n12 -> n15 [style="dashed"]
-  n10 -> n15 [style="dashed"]
-  n6 -> n15 [style="dashed"]
-  n3 -> n2
-  n7 -> n3
-  n12 -> n3 [style="dashed"]
-  n10 -> n3 [style="dashed"]
-  n6 -> n3 [style="dashed"]
+  n10 -> n15
   n13 -> n12
-  n8 -> n13
-  n11 -> n10
-  n8 -> n11
-  n7 -> n6
-  n8 -> n7
+  n10 -> n13
   n9 -> n8
+  n10 -> n9
+  n11 -> n10
+  n1 -> n11
+  n2 -> n1
   }

--- a/test/expected/v3.3.dot
+++ b/test/expected/v3.3.dot
@@ -1,40 +1,44 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n9 [label="head",fillcolor="#90ee90",style="filled"]
-  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n7 [label="build-win",fillcolor="#90ee90",style="filled"]
-  n6 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Missing DLL"]
-  n11 [label="build-mac",fillcolor="#90ee90",style="filled"]
-  n10 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n13 [label="build-lin",fillcolor="#90ee90",style="filled"]
-  n12 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n3 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
-  n2 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
-  n15 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
-  n14 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n11 [label="head",fillcolor="#90ee90",style="filled"]
+  n10 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n9 [label="build-win",fillcolor="#90ee90",style="filled"]
+  n8 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Missing DLL"]
+  n13 [label="build-mac",fillcolor="#90ee90",style="filled"]
+  n12 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n15 [label="build-lin",fillcolor="#90ee90",style="filled"]
+  n14 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n5 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
+  n4 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
   n17 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
-  n16 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n16 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n19 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
+  n18 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n19 -> n18
+  n15 -> n19
+  n14 -> n19 [style="dashed"]
+  n12 -> n19 [style="dashed"]
+  n8 -> n19 [style="dashed"]
   n17 -> n16
   n13 -> n17
+  n14 -> n17 [style="dashed"]
   n12 -> n17 [style="dashed"]
-  n10 -> n17 [style="dashed"]
-  n6 -> n17 [style="dashed"]
+  n8 -> n17 [style="dashed"]
+  n5 -> n4
+  n9 -> n5
+  n14 -> n5 [style="dashed"]
+  n12 -> n5 [style="dashed"]
+  n8 -> n5 [style="dashed"]
   n15 -> n14
-  n11 -> n15
-  n12 -> n15 [style="dashed"]
-  n10 -> n15 [style="dashed"]
-  n6 -> n15 [style="dashed"]
-  n3 -> n2
-  n7 -> n3
-  n12 -> n3 [style="dashed"]
-  n10 -> n3 [style="dashed"]
-  n6 -> n3 [style="dashed"]
+  n10 -> n15
   n13 -> n12
-  n8 -> n13
-  n11 -> n10
-  n8 -> n11
-  n7 -> n6
-  n8 -> n7
+  n10 -> n13
   n9 -> n8
+  n10 -> n9
+  n11 -> n10
+  n1 -> n11
+  n2 -> n1
   }

--- a/test/expected/v4.1.dot
+++ b/test/expected/v4.1.dot
@@ -1,9 +1,13 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="head",fillcolor="#90ee90",style="filled"]
-  n1 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n4 [label="head",fillcolor="#90ee90",style="filled"]
+  n3 [label="fetch",fillcolor="#ffa500",style="filled"]
   n0 [label="custom-build",fillcolor="#d3d3d3",style="filled"]
-  n1 -> n0
+  n3 -> n0
+  n4 -> n3
+  n1 -> n4
   n2 -> n1
   }

--- a/test/expected/v4.2.dot
+++ b/test/expected/v4.2.dot
@@ -1,13 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
   n1 [label="custom-build",fillcolor="#90ee90",style="filled"]
-  n4 [label="build",fillcolor="#90ee90",style="filled"]
+  n6 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n4 -> n0
-  n1 -> n4
-  n2 -> n1
+  n6 -> n0
+  n1 -> n6
+  n4 -> n1
+  n5 -> n4
+  n2 -> n5
   n3 -> n2
   }

--- a/test/expected/v4.3.dot
+++ b/test/expected/v4.3.dot
@@ -1,13 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n3 [label="head",fillcolor="#90ee90",style="filled"]
-  n2 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="head",fillcolor="#90ee90",style="filled"]
+  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
   n1 [label="custom-build",fillcolor="#90ee90",style="filled"]
-  n4 [label="build",fillcolor="#90ee90",style="filled"]
+  n6 [label="build",fillcolor="#90ee90",style="filled"]
   n0 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Failed"]
-  n4 -> n0
-  n1 -> n4
-  n2 -> n1
+  n6 -> n0
+  n1 -> n6
+  n4 -> n1
+  n5 -> n4
+  n2 -> n5
   n3 -> n2
   }

--- a/test/expected/v5.1.dot
+++ b/test/expected/v5.1.dot
@@ -1,26 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n3 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n2 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n6 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
-  n1 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n5 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n4 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n8 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
   subgraph cluster_0 {
-  n10 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n7 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n8 -> n7
-  n9 -> n8
   n10 -> n9
-  n1 -> n10
-  n6 -> n1
-  n2 -> n1 [style="dashed"]
-  n4 -> n6
-  n3 -> n2
-  n4 -> n3
+  n11 -> n10
+  n12 -> n11
+  n3 -> n12
+  n8 -> n3
+  n4 -> n3 [style="dashed"]
+  n6 -> n8
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v5.2.dot
+++ b/test/expected/v5.2.dot
@@ -1,26 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n2 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n6 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n1 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
   subgraph cluster_0 {
-  n10 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n7 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n8 -> n7
-  n9 -> n8
   n10 -> n9
-  n1 -> n10
-  n6 -> n1
-  n2 -> n1 [style="dashed"]
-  n4 -> n6
-  n3 -> n2
-  n4 -> n3
+  n11 -> n10
+  n12 -> n11
+  n3 -> n12
+  n8 -> n3
+  n4 -> n3 [style="dashed"]
+  n6 -> n8
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v5.3.dot
+++ b/test/expected/v5.3.dot
@@ -1,34 +1,38 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n2 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n6 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n1 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
   subgraph cluster_0 {
-  n11 [label="example.org/bar#222",fillcolor="#90ee90",style="filled"]
-  n10 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n9 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n15 [label="example.org/foo#111",fillcolor="#90ee90",style="filled"]
-  n14 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n13 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="example.org/bar#222",fillcolor="#90ee90",style="filled"]
+  n12 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n11 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n17 [label="example.org/foo#111",fillcolor="#90ee90",style="filled"]
+  n16 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n15 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n14 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n13 -> n12
-  n14 -> n13
   n15 -> n14
-  n1 -> n15
-  n9 -> n8
-  n10 -> n9
+  n16 -> n15
+  n17 -> n16
+  n3 -> n17
   n11 -> n10
-  n1 -> n11
-  n6 -> n1
-  n2 -> n1 [style="dashed"]
-  n4 -> n6
-  n3 -> n2
-  n4 -> n3
+  n12 -> n11
+  n13 -> n12
+  n3 -> n13
+  n8 -> n3
+  n4 -> n3 [style="dashed"]
+  n6 -> n8
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v5n.1.dot
+++ b/test/expected/v5n.1.dot
@@ -1,26 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n3 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n2 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n6 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
-  n1 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n5 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n4 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n8 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
   subgraph cluster_0 {
-  n10 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n7 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n8 -> n7
-  n9 -> n8
   n10 -> n9
-  n1 -> n10
-  n6 -> n1
-  n2 -> n1 [style="dashed"]
-  n4 -> n6
-  n3 -> n2
-  n4 -> n3
+  n11 -> n10
+  n12 -> n11
+  n3 -> n12
+  n8 -> n3
+  n4 -> n3 [style="dashed"]
+  n6 -> n8
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v5n.2.dot
+++ b/test/expected/v5n.2.dot
@@ -1,26 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n2 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n6 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n1 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
   subgraph cluster_0 {
-  n10 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n7 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n8 -> n7
-  n9 -> n8
   n10 -> n9
-  n1 -> n10
-  n6 -> n1
-  n2 -> n1 [style="dashed"]
-  n4 -> n6
-  n3 -> n2
-  n4 -> n3
+  n11 -> n10
+  n12 -> n11
+  n3 -> n12
+  n8 -> n3
+  n4 -> n3 [style="dashed"]
+  n6 -> n8
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }

--- a/test/expected/v5n.3.dot
+++ b/test/expected/v5n.3.dot
@@ -1,26 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n2 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n6 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n1 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
   subgraph cluster_0 {
-  n10 [label="(empty list)",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n7 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="(empty list)",fillcolor="#d3d3d3",style="filled"]
+  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n8 -> n7
-  n9 -> n8
   n10 -> n9
-  n1 -> n10
-  n6 -> n1
-  n2 -> n1 [style="dashed"]
-  n4 -> n6
-  n3 -> n2
-  n4 -> n3
+  n11 -> n10
+  n12 -> n11
+  n3 -> n12
+  n8 -> n3
+  n4 -> n3 [style="dashed"]
+  n6 -> n8
   n5 -> n4
+  n6 -> n5
+  n7 -> n6
+  n1 -> n7
+  n2 -> n1
   }


### PR DESCRIPTION
This is needed for incremental evaluation so that the evaluation happens during an update and the system knows that the test pipeline should only exist during the test. Otherwise, it will see each test pipeline as a separate top-level thing and try to keep all of them running.

This change is in a separate PR because a side-effect is that the diagrams now show the pipeline-choosing step, which makes the incremental diff hard to check.