### PR TITLE
Evaluate pipelines incrementally

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -23,6 +23,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
+  "current_incr" {= version}
   "fmt"
   "bos"
   "ppx_deriving"

--- a/current_incr.opam
+++ b/current_incr.opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Self-adjusting computations"
+description: """
+This is a small, self-contained library for self-adjusting (incremental) computations.
+It was written for OCurrent, but can be used separately too.
+
+It is similar to Jane Street's incremental library, but much smaller and
+has no external dependencies.
+
+It is also similar to the react library, but the results do not depend on the
+behaviour of the garbage collector. In particular, functions stop being called
+as soon as they are no longer needed.
+"""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+doc: "https://ocurrent.github.io/ocurrent/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9"}
+]

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -32,7 +32,9 @@ let v ?auto_release ?confirm () =
 
 let default = v ()
 
-let now : t option ref = ref None
+let active_config : t option Current_incr.var = Current_incr.var None
+
+let now = Current_incr.of_var active_config
 
 let rec confirmed l t =
   match t.confirm with

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -18,8 +18,8 @@ module Config : sig
 
   val cmdliner : t Cmdliner.Term.t
 
-  val now : t option ref
-  (** [None] initially, then set to the configuration and never changes. *)
+  val now : t option Current_incr.t
+  (** The configuration of the engine, if any. *)
 end
 
 type job_id = string
@@ -34,7 +34,7 @@ class type actions = object
 end
 
 module Input : sig
-  type 'a t = 'a Current_term.Output.t * job_id option
+  type 'a t = ('a Current_term.Output.t * job_id option) Current_incr.t
 
   val const : 'a -> 'a t
   (** [const x] is an input that always evaluates to [x] and never needs to be updated. *)
@@ -228,7 +228,7 @@ module Job : sig
   val with_handler : t -> on_cancel:(string -> unit Lwt.t) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
   (** [with_handler t ~on_cancel fn] is like [fn ()], but if the job is cancelled while [fn] is running
       then [on_cancel reason] is called. Even if cancelled, [fn] is still run to completion.
-      If the job has already been cancelled then [fn reason] is called immediately (but [fn] still runs). *)
+      If the job has already been cancelled then [on_cancel reason] is called immediately (but [fn] still runs). *)
 
   val cancel : t -> string -> unit
   (** [cancel msg] requests that [t] be cancelled. This runs all registered cancel hooks and marks the job as cancelled.

--- a/lib/dune
+++ b/lib/dune
@@ -5,6 +5,7 @@
    bos
    cmdliner
    current_term
+   current_incr
    duration
    fmt
    fpath

--- a/lib_cache/dune
+++ b/lib_cache/dune
@@ -4,6 +4,7 @@
  (libraries
    current
    current.term
+   current_incr
    duration
    fmt
    logs

--- a/lib_incr/current_incr.ml
+++ b/lib_incr/current_incr.ml
@@ -1,0 +1,23 @@
+type 'a t = 'a Modifiable.t
+type 'a cc = 'a t -> Modifiable.changeable
+type 'a var = 'a t
+
+let var x =
+  Modifiable.create (fun d -> Modifiable.write ~eq:(==) d x)
+
+let of_var x = x
+
+(* For now, a constant is just a variable that the type system won't let you change.
+   But we could be more efficient, since we don't need to record readers of a const. *)
+let const = var
+
+let write ?(eq=(==)) x d = Modifiable.write ~eq d x
+
+let read x f d = Modifiable.read x (fun y -> f y d)
+
+let of_cc = Modifiable.create
+
+let change ?(eq=(==)) = Modifiable.change ~eq
+let propagate = Modifiable.propagate
+let observe = Modifiable.deref
+let on_release = Modifiable.on_release

--- a/lib_incr/current_incr.mli
+++ b/lib_incr/current_incr.mli
@@ -1,0 +1,81 @@
+(** A simple library for incremental computations.
+    Based on "Adaptive Functional Programming"
+    https://www.cs.cmu.edu/~guyb/papers/popl02.pdf
+
+    The basic idea is:
+
+    - You run a computation, which produces a result.
+    - The library records information about the dependencies of the result.
+    - You can then change one or more inputs and it will rerun just the
+      parts of the computation that are needed to update the result.
+
+    It is similar to Jane Street's "incremental" library, but much smaller and
+    has no external dependencies.
+
+    It is also similar to "react", but the results do not depend on the
+    behaviour of the garbage collector. In particular, functions stop being
+    called as soon as they are no longer needed, and cannot be called with
+    "impossible" inputs. *)
+
+(** {2 Changeable values} *)
+
+type 'a t
+(** An ['a t] holds a value of type ['a], which will update as necessary. *)
+
+val const : 'a -> 'a t
+(** [const x] is the constant value [x]. *)
+
+(** {2 Changeable computations} *)
+
+type 'a cc
+(** An ['a cc] is a changable computation that can be run to get a value of type ['a].
+    Internally, it is a function that takes a destination variable, reads zero or more
+    other changable values, and then updates the destination. *)
+
+val read : 'a t -> ('a -> 'b cc) -> 'b cc
+(** [read x f] is a computation that depends on [x]. [f] will be called as necessary to
+    ensure that the result stays up-to-date with changes in [x]. *)
+
+val write : ?eq:('a -> 'a -> bool) -> 'a -> 'a cc
+(** [write x] is a computation that always returns [x].
+    @param eq If [eq old_value x = true] then the new value is considered equal
+              and no update is done. The default is [(==)].
+              It is always safe (though inefficient) to return [false] here. *)
+
+val of_cc : 'a cc -> 'a t
+(** [of_cc x] is a changeable value holding the result of evaluating [x]. *)
+
+val on_release : (unit -> unit) -> unit
+(** [on_release fn] calls [fn] if the current computation has to be redone.
+    This may be useful to release external resources when they are no longer needed.
+    Note that the order in which multiple such functions are called is somewhat
+    unpredictable. *)
+
+(** {2 External operations}
+
+    These functions are used to interface between the changeable system and other systems (e.g. Lwt). *)
+
+type 'a var
+(** A mutable value that can be changed using [change]. Internally, [type 'a var = 'a t],
+    but it's useful to distinguish between values that are inputs to the system and
+    values that only change in response to computations being rerun. *)
+
+val var : 'a -> 'a var
+(** [var x] creates a new variable initially set to [x]. *)
+
+val of_var : 'a var -> 'a t
+(** [of_var x] casts [x] to ['a t]. *)
+
+val change : ?eq:('a -> 'a -> bool) -> 'a var -> 'a -> unit
+(** [change x v] sets the current value of [x] to [v] and adds anything
+    that depends on it to the rebuild queue. You must call [propagate] after
+    this to update everything (you can change several things together and then
+    call [propagate] once).
+    This function can only be used from the top-level, not from within a computation. *)
+
+val propagate : unit -> unit
+(** Apply all changes made with [change], so that everything is up-to-date. *)
+
+val observe : 'a t -> 'a
+(** [observe t] is the current value of [t]. If [change] has been used then the value
+    may be stale until [propagate] is called. *)

--- a/lib_incr/dune
+++ b/lib_incr/dune
@@ -1,0 +1,3 @@
+(library
+ (public_name current_incr)
+ (name current_incr))

--- a/lib_incr/modifiable.ml
+++ b/lib_incr/modifiable.ml
@@ -1,0 +1,154 @@
+(* Based on "Adaptive Functional Programming"
+   https://www.cs.cmu.edu/~guyb/papers/popl02.pdf *)
+
+type changeable = unit
+
+(* Detect attempts to change the inputs in the middle of a propagate operation. *)
+let in_propagate = ref false
+
+(* A record of a computation that takes an input of type ['a]. *)
+type 'a edge = {
+  start : Time.t;               (* When this computation started. *)
+  stop : Time.t;                (* When it produced its result. *)
+  fn : 'a -> unit;              (* The operation to run on updates. *)
+}
+
+(* The state of an initialised modifiable. *)
+type 'a full = {
+  value : 'a;                   (* The current value. *)
+  readers : 'a edge Queue.t     (* The computations which read this value. *)
+}
+
+type 'a modval =
+  | Uninitialised
+  | Full of 'a full
+
+(* A modifiable value starts off [Uninitialised] and then becomes [Full] once the
+   initial value is known. When the value changes, it is replaced with a new [Full]
+   value. *)
+type 'a t = 'a modval ref
+
+module Pq : sig
+  (* A priority queue that returns the earliest edge first. *)
+
+  type t
+
+  val create : unit -> t
+
+  val add : t -> unit edge -> unit
+
+  val pop : t -> unit edge option
+  (** [pop t] removes and returns the earliest edge in [t]. *)
+end = struct
+  module Edge_set = Set.Make(struct
+      type t = unit edge
+      let compare a b = Time.compare a.start b.start
+    end)
+
+  type t = Edge_set.t ref
+
+  let create () =
+    ref Edge_set.empty
+
+  let add t edge =
+    if Time.is_valid edge.start then (
+      t := Edge_set.add edge !t;
+      Time.set_forget edge.start (fun () -> t := Edge_set.remove edge !t)
+    )
+
+  let pop t =
+    match Edge_set.min_elt_opt !t with
+    | None -> None
+    | Some edge ->
+      t := Edge_set.remove edge !t;
+      Time.clear_forget edge.start;
+      Some edge
+end
+
+(* The singleton propagation queue. This contains all edges that need to be recalculated. *)
+let q = Pq.create ()
+
+let now = ref (Time.root ())
+
+(* Insert a new time directly after [now]. *)
+let insert_now ?on_forget () =
+  now := Time.after ?on_forget !now;
+  !now
+
+let create init =
+  let t = ref Uninitialised in
+  init t;
+  t
+
+let non_empty (t:'a t) =
+  match !t with
+  | Full x -> x
+  | Uninitialised -> failwith "Modifiable is empty! (this shouldn't happen)"
+
+(* If we keep reading a modifiable that doesn't change often, the list of
+   readers can build up over time. So each time we add something to the queue,
+   we also take one existing item and check that it's still valid. *)
+let minor_tidy q =
+  match Queue.take_opt q with
+  | None -> ()
+  | Some edge ->
+    if Time.is_valid edge.start then Queue.add edge q
+
+let read t fn =
+  let value = (non_empty t).value in
+  let start = insert_now () in
+  fn value;
+  let stop = insert_now () in
+  let readers = (non_empty t).readers in         (* Readers might have changed by now *)
+  let edge = { start; stop; fn } in
+  minor_tidy readers;
+  Queue.add edge readers;
+  t := Full { value; readers }
+
+let on_release fn =
+  let _ : Time.t = insert_now ~on_forget:fn () in
+  ()
+
+(* A more efficient version of [read], when we already know the start and stop times. *)
+let reread t reader () =
+  match !t with
+  | Uninitialised -> failwith "Modifiable is empty! (this shouldn't happen)"
+  | Full f ->
+    minor_tidy f.readers;
+    Queue.add reader f.readers;
+    reader.fn f.value
+
+let write ~eq t value =
+  match !t with
+  | Uninitialised -> t := Full { value; readers = Queue.create () }
+  | Full { value = old; readers = _ } when eq old value -> ()
+  | Full old ->
+    t := Full { value; readers = Queue.create () };
+    old.readers |> Queue.iter (fun r -> Pq.add q { r with fn = reread t r })
+
+let deref t = (non_empty t).value
+
+let change ~eq t v =
+  if !in_propagate then failwith "Current_incr.change called within propagate!";
+  let present = !now in
+  write ~eq t v;
+  now := present
+
+let rec propagate2 () =
+  match Pq.pop q with
+  | None -> ()
+  | Some { start; stop; fn } ->
+    (* Note: The later paper splices out after calling [fn] rather than before - why? *)
+    Time.splice_out start stop;
+    (* They also added a [finger] variable - but never use it. *)
+    now := start;
+    fn ();
+    propagate2 ()
+
+let propagate () =
+  assert (not !in_propagate);
+  in_propagate := true;
+  let ctime = !now in
+  propagate2 ();
+  now := ctime;
+  in_propagate := false

--- a/lib_incr/modifiable.mli
+++ b/lib_incr/modifiable.mli
@@ -1,0 +1,40 @@
+(** The low-level modifiable interface.
+    [Current_incr] provides a similar but safer wrapper around this. *)
+
+type 'a t
+(** A modifiable value. *)
+
+type changeable
+(** Represents the result of a changeable computation. Internally, [type changeable = unit].
+    This is to force changeable computations to end with a write operation. *)
+
+val create :
+  ('a t -> changeable) ->
+  'a t
+(** [create init] creates a new modifiable [t] and then uses [init t] to initialise it.
+    [init] must use [x] exactly once, at the end, in a write operation. *)
+
+val read : 'a t -> ('a -> changeable) -> changeable
+(** [read t fn] calls [fn] with the current value of [t], and also records this access.
+    If [t] later changes, [fn] will be run again as needed to update its result. *)
+
+val write : eq:('a -> 'a -> bool) -> 'a t -> 'a -> changeable
+(** [write ~eq t v] sets [t] to [v] if [eq] says the new value is different to the existing
+    one (if any). This should only be used as the last step of the [init]
+    function passed to [create], to write to the given modifiable. *)
+
+val change : eq:('a -> 'a -> bool) -> 'a t -> 'a -> unit
+(** [change ~eq t v] is similar to [write], but is for use by the top-level for setting inputs
+    to the computation. *)
+
+val deref : 'a t -> 'a
+(** [deref t] is the current value of [t] (which may be stale if [change] has
+    been used since the last [propagate] *)
+
+val propagate : unit -> unit
+(** [propagate ()] updates the computation by rerunning any computations that
+    might have out-of-date results. *)
+
+val on_release : (unit -> unit) -> unit
+(** [on_release fn] registers [fn ()] to be called if the containing
+    computation needs to be re-evaluated. *)

--- a/lib_incr/test/dune
+++ b/lib_incr/test/dune
@@ -1,0 +1,4 @@
+(tests
+ (names test)
+ (package current_incr)
+ (libraries current_incr alcotest))

--- a/lib_incr/test/test.ml
+++ b/lib_incr/test/test.ml
@@ -1,0 +1,150 @@
+open Current_incr
+
+module Msg = Set.Make(String)
+
+let log = ref Msg.empty
+
+let reset_log () =
+  log := Msg.empty
+
+let printf fmt =
+  fmt |> Format.kasprintf @@ fun msg ->
+  log := !log |> Msg.add msg;
+  on_release (fun () -> log := !log |> Msg.remove msg)
+
+(* [y = x + 1]. Check [y] updates when [x] does. *)
+let test_simple () =
+  let x = var 0 in
+  let y =
+    of_cc begin
+      read (of_var x) @@ fun x ->
+      write (x + 1)
+    end
+  in
+  Alcotest.(check int) "Initial run" 1 @@ observe y;
+  change x 3;
+  propagate ();
+  Alcotest.(check int) "Updated run" 4 @@ observe y
+
+(* Check we can undo a (logging) side-effect when recomputing. *)
+let test_release () =
+  reset_log ();
+  let x = var 0 in
+  let y =
+    of_cc begin
+      read (of_var x) @@ fun x ->
+      printf "Got x = %d" x;
+      write (x + 1)
+    end
+  in
+  Alcotest.(check int) "Initial run" 1 @@ observe y;
+  Alcotest.(check (list string)) "Log run" ["Got x = 0"] @@ Msg.elements !log;
+  change x 3;
+  propagate ();
+  Alcotest.(check int) "Updated run" 4 @@ observe y;
+  Alcotest.(check (list string)) "Log run" ["Got x = 3"] @@ Msg.elements !log
+
+(* Check that we stop recomputing when an intermediate value turns out to be the same. *)
+let test_eq () =
+  let i = ref 0 in
+  let x = var 0 in
+  let y =
+    of_cc begin
+      read (of_var x) @@ fun x ->
+      incr i;
+      if x > 0 then write 1
+      else write 2
+    end
+  in
+  let z =
+    of_cc begin
+      read y @@ fun x ->
+      incr i;
+      write (x * 10)
+    end
+  in
+  Alcotest.(check int) "Initial run" 20 @@ observe z;
+  Alcotest.(check int) "Two evals" 2 !i;
+  change x (-1);
+  propagate ();
+  Alcotest.(check int) "Updated run" 20 @@ observe z;
+  Alcotest.(check int) "One more eval" 3 !i;
+  change ~eq:(=) x (-1);
+  propagate ();
+  Alcotest.(check int) "No more eval" 3 !i
+
+(* Check we can cope with the second evaluation creating extra time-points. *)
+let test_expand () =
+  let x = var 0 in
+  let y = var 10 in
+  let z =
+    of_cc begin
+      read (of_var x) @@ fun x ->
+      if x > 0 then (
+        read (of_var y) @@ fun y ->
+        write y
+      ) else write 0
+    end
+  in
+  Alcotest.(check int) "Initial run" 0 @@ observe z;
+  change x 5;
+  propagate ();
+  Alcotest.(check int) "Now using y" 10 @@ observe z;
+  change y 7;
+  propagate ();
+  Alcotest.(check int) "New y" 7 @@ observe z
+
+(* Check that we erase nested functions when their parent is recalculated. *)
+let test_nested () =
+  let i = ref 0 in
+  let x = var 1 in
+  let z =
+    of_cc begin
+      read (of_var x) @@ fun v1 ->
+      read (of_var x) @@ fun v2 ->
+      incr i;
+      write (v1 + v2)
+    end
+  in
+  Alcotest.(check int) "Initial run" 2 @@ observe z;
+  Alcotest.(check int) "One eval" 1 @@ !i;
+  change x 2;
+  propagate ();
+  Alcotest.(check int) "Now double" 4 @@ observe z;
+  Alcotest.(check int) "Only one extra eval" 2 @@ !i
+
+let heap () =
+  Gc.full_major ();
+  Gc.((stat ()).live_words)
+
+(* We keep reading from [y], which never changes. Check we don't leak memory. *)
+let test_leak () =
+  let x = var 0 in
+  let y = var 1 in
+  let z = of_cc begin
+      read (of_var x) @@ fun x ->
+      read (of_var y) @@ fun y ->
+      write (x + y)
+    end
+  in
+  Alcotest.(check int) "Initial run" 1 @@ observe z;
+  let h0 = heap () in
+  for i = 1 to 100 do
+    change x i;
+    propagate ();
+  done;
+  let h1 = heap () in
+  Alcotest.(check int) "Memory usage constant" 0 @@ h1 - h0;
+  change x 0    (* Stop [x] from being GC'd before here *)
+
+let () =
+  Alcotest.run "incr" [
+    "basic", [
+      Alcotest.test_case  "simple"  `Quick test_simple;
+      Alcotest.test_case  "release" `Quick test_release;
+      Alcotest.test_case  "eq"      `Quick test_eq;
+      Alcotest.test_case  "expand"  `Quick test_expand;
+      Alcotest.test_case  "nested"  `Quick test_nested;
+      Alcotest.test_case  "leak"    `Quick test_leak;
+    ]
+  ]

--- a/lib_incr/time.ml
+++ b/lib_incr/time.ml
@@ -1,0 +1,184 @@
+(* Based on https://github.com/let-def/grenier/
+   By Frédéric Bour. Relicensed to Apache 2.0 with permission. *)
+
+type t = {
+  mutable tag: int;
+  mutable prev: t;
+  mutable next: t;
+  counter: int ref;
+  mutable on_forget: (unit -> unit) option;
+}
+
+let average x y = (x land y) + (x lxor y) / 2
+
+let curr_index t = t.tag
+
+let rec sentinel = { tag = 0; prev = sentinel; next = sentinel; counter = ref 0; on_forget = None }
+
+let is_first t = t.prev == t
+let is_last  t = t == t.next
+
+let is_valid t = t.next != sentinel
+
+let prev_index t =
+  if is_first t then
+    min_int
+  else
+    t.prev.tag
+
+let next_index t =
+  if is_last t then
+    max_int
+  else
+    t.next.tag
+
+let consistent _ = ()
+let consistents _ _ = ()
+
+let root () =
+  let rec t = { prev = t; next = t; tag = 0; counter = ref 1; on_forget = None } in
+  consistent t;
+  t
+
+let forget t =
+  if is_valid t then begin
+    Option.iter (fun f -> f ()) t.on_forget;
+    let {prev; next; counter; _} = t in
+    if is_first t then
+      next.prev <- next
+    else if is_last t then
+      prev.next <- prev
+    else (
+      prev.next <- next;
+      next.prev <- prev;
+    );
+    decr counter;
+    t.next <- sentinel;
+    t.prev <- sentinel;
+    consistent prev;
+    consistent next;
+    assert (not (is_valid t));
+  end
+
+let same_order t1 t2 =
+  is_valid t1 &&
+  is_valid t2 &&
+  t1.counter == t2.counter
+
+let compare t1 t2 =
+  assert (same_order t1 t2);
+  compare t1.tag t2.tag
+
+let cardinal t = if is_valid t then !(t.counter) else 0
+
+let uint_size = Sys.word_size - 2
+let pow = 2.0 ** float uint_size
+let inv = 1.0 /. float uint_size
+
+let optimal_t count = (pow /. float count) ** inv
+
+let find_span n =
+  let t = optimal_t !(n.counter) in
+  let count = ref 1
+  and left  = ref n
+  and right = ref n
+  and tag   = n.tag
+  and low   = ref n.tag
+  and high  = ref n.tag
+  and bit = ref 1
+  and thresh = ref 1.0
+  in
+  while !bit > 0 && (float !count >= float !bit *. !thresh) do
+    let to_left = (tag land !bit) <> 0 in
+    if to_left then begin
+      low := !low lxor !bit;
+      while !left.tag > !low && not (is_first !left) do
+        left := !left.prev;
+        incr count;
+      done
+    end else begin
+      high := !high lxor !bit;
+      while !right.tag < !high && not (is_last !right) do
+        right := !right.next;
+        incr count;
+      done
+    end;
+    bit := !bit lsl 1;
+    thresh := !thresh /. t;
+  done;
+  !left, !low, (!bit lsr 1), !count
+
+let rec relabel_span_big root step tag = function
+  | 1 ->
+    root.tag <- tag;
+    assert (tag < next_index root || is_last root)
+  | n ->
+    root.tag <- tag;
+    assert (tag > prev_index root);
+    relabel_span_big root.next step (tag + step) (n - 1)
+
+let rec relabel_span_small node root slack tag = function
+  | 1 ->
+    root.tag <- tag;
+    assert (tag < next_index root || is_last root)
+  | n ->
+    root.tag <- tag;
+    (*Printf.eprintf "assert (%d > %d); slack = %d\n"
+      tag (prev_index root) slack;*)
+    assert (tag > prev_index root);
+    relabel_span_small node root.next slack
+      (tag + if node == root then slack + 1 else 1) (n - 1)
+
+let relabel node =
+  let root, tag, range, count = find_span node in
+  let step = range / count in
+  (*Printf.eprintf "range = %d, count = %d\n" range count;*)
+  if step <= 1 then
+    (assert (range >= count);
+     relabel_span_small node root (range - count) (tag + 1) count)
+  else
+    relabel_span_big root step (tag + step) count;
+  consistents root count
+
+let after ?on_forget t =
+  assert (is_valid t);
+  let tag = average (curr_index t) (next_index t) in
+  let t' = {prev = t; next = t; tag; counter = t.counter; on_forget} in
+  let {next; counter; _} = t in
+  if t == next then
+    t'.next <- t'
+  else (
+    t'.next <- next;
+    next.prev <- t'
+  );
+  t.next <- t';
+  incr counter;
+  if t'.tag = prev_index t' then
+    relabel t';
+  consistent t;
+  consistent t';
+  t'
+
+let splice_out ts te =
+  if ts == te then ()
+  else (
+    assert (compare ts te < 0);
+    let rec aux t =
+      if t != te then (
+        let next = t.next in
+        forget t;
+        aux next
+      )
+    in
+    aux ts.next
+  )
+
+let set_forget t fn =
+  assert (is_valid t);
+  assert (t.on_forget = None);
+  t.on_forget <- Some fn
+
+let clear_forget t =
+  assert (is_valid t);
+  assert (t.on_forget <> None);
+  t.on_forget <- None

--- a/lib_incr/time.mli
+++ b/lib_incr/time.mli
@@ -1,0 +1,51 @@
+(* Based on https://github.com/let-def/grenier/
+   By Frédéric Bour. Relicensed to Apache 2.0 with permission. *)
+
+(** {0 Basic ordering operations} *)
+
+(** An element of an ordering. *)
+type t
+
+(** Create a new ordering with a single element. O(1) *)
+val root : unit -> t
+
+(** [after t] inserts a new element to the ordering, greater than [t] but
+    less than all existing elements greater than [t].
+
+    O(1) amortized. *)
+val after  : ?on_forget:(unit -> unit) -> t -> t
+
+(** Check if two elements belong to the same order. O(1) *)
+val same_order : t -> t -> bool
+
+(** Compare two elements. O(1) *)
+val compare : t -> t -> int
+
+(** How many elements are ordered. O(1) *)
+val cardinal : t -> int
+
+(** {1 Memory management} *)
+
+(** Memory of every element is retained. When you know you are not going to use
+    an element any longer, [forget] it to release memory. O(1). *)
+val forget : t -> unit
+
+(** After calling [forget], an element should not be used.
+    You can check if it is the case with [is_valid]. *)
+val is_valid : t -> bool
+
+(** [splice_out ts te] forgets all times between [ts] and [te], so that
+    afterwards [te] immediately follows [ts]. *)
+val splice_out : t -> t -> unit
+
+val set_forget : t -> (unit -> unit) -> unit
+(** [set_forget t fn] sets [t]'s forget function to [fn].
+    This is called when [t] is forgotten.
+    It is an error if [t] already has a forget function. *)
+
+val clear_forget : t -> unit
+(** [clear_forget t] reverses the effect of [set_forget]. *)
+
+(* Algorithm due to:
+   Two Simplified Algorithms for Maintaining Order in a List
+   Bender et al., 2002 *)

--- a/lib_term/dune
+++ b/lib_term/dune
@@ -3,5 +3,6 @@
  (name current_term)
  (libraries
    bos
-   fmt)
+   fmt
+   current_incr)
  (preprocess (pps ppx_deriving.std)))

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -22,7 +22,7 @@ module type INPUT = sig
 
   type job_id
 
-  val get : 'a t -> 'a Output.t * job_id option
+  val get : 'a t -> ('a Output.t * job_id option) Current_incr.t
 end
 
 module type ANALYSIS = sig
@@ -58,7 +58,7 @@ module type TERM = sig
   type 'a input
   (** See [INPUT]. *)
 
-  type +'a t
+  type 'a t
   (** An ['a t] is a term that produces a value of type ['a]. *)
 
   type description
@@ -208,6 +208,6 @@ module type EXECUTOR = sig
   type analysis
   (** See [ANALYSIS]. *)
 
-  val run : (unit -> 'a term) -> 'a Output.t * analysis
+  val run : (unit -> 'a term) -> ('a Output.t * analysis) Current_incr.t
   (** [run f] evaluates term [f ()], returning the current output and its analysis. *)
 end

--- a/plugins/fs/current_fs.ml
+++ b/plugins/fs/current_fs.ml
@@ -7,17 +7,19 @@ let save path value =
   Current.component "save" |>
   let> path = path
   and> value = value in
-  match Bos.OS.File.read path with
-  | Ok old when old = value ->
-    Log.info (fun f -> f "No change for %a" Fpath.pp path);
-    Ok (), None
-  | Error _ as e when Bos.OS.File.exists path = Ok true ->
-    e, None
-  | _ ->
-    (* Old contents differ, or file doesn't exist. *)
-    match Bos.OS.File.write path value with
-    | Ok () ->
-      Log.info (fun f -> f "Updated %a" Fpath.pp path);
+  Current_incr.const (
+    match Bos.OS.File.read path with
+    | Ok old when old = value ->
+      Log.info (fun f -> f "No change for %a" Fpath.pp path);
       Ok (), None
-    | Error _ as e ->
+    | Error _ as e when Bos.OS.File.exists path = Ok true ->
       e, None
+    | _ ->
+      (* Old contents differ, or file doesn't exist. *)
+      match Bos.OS.File.write path value with
+      | Ok () ->
+        Log.info (fun f -> f "Updated %a" Fpath.pp path);
+          Ok (), None
+        | Error _ as e ->
+          e, None
+  )

--- a/plugins/fs/dune
+++ b/plugins/fs/dune
@@ -5,6 +5,7 @@
    bos
    current
    current.term
+   current_incr
    fmt
    fpath
    logs

--- a/test/driver.mli
+++ b/test/driver.mli
@@ -16,8 +16,4 @@ val cancel : string -> unit
 val rebuild : string -> unit
 (** [rebuild msg] triggers a rebuild of the job named [msg]. *)
 
-exception Expect_skip
-(** The [actions] callback can raise this if it's OK if the next step's inputs
-    are ready immediately. Needed for the case of cache invalidation. *)
-
 val test_case_gc : string -> (Lwt_switch.t -> unit -> unit Lwt.t) -> unit Alcotest_lwt.test_case

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,7 @@
    current
    current.cache
    current.term
+   current_incr
    current_docker_test
    current_fs
    current_git_test

--- a/test/test.ml
+++ b/test/test.ml
@@ -169,13 +169,13 @@ module Test_input = struct
   type 'a t = unit
   type job_id = unit
 
-  let get () = Error (`Msg "Can't happen"), None
+  let get () = Current_incr.const (Error (`Msg "Can't happen"), None)
 end
 
 module Term = Current_term.Make(Test_input)
 
 let test_all_labelled () =
-  let test x = fst (Term.Executor.run (fun () -> Term.all_labelled x)) in
+  let test x = fst (Current_incr.observe (Term.Executor.run (fun () -> Term.all_labelled x))) in
   Alcotest.check engine_result "all_ok" (Ok ()) @@ test [
     "Alpine", Term.return ();
     "Debian", Term.return ();

--- a/test/test_monitor.ml
+++ b/test/test_monitor.ml
@@ -77,6 +77,7 @@ let trace step ~next:_ { Current.Engine.value = out; _ } =
   | 1 ->
     (* Although there is data ready, we shouldn't have started the read yet
        because we're still enabling the watch. *)
+    Lwt.pause () >>= fun () ->
     Alcotest.check result "Initially pending" (Error (`Active `Running)) out;
     assert (!w <> None);
     let w = get_watch () in
@@ -138,6 +139,7 @@ let trace step ~next:_ { Current.Engine.value = out; _ } =
     Lwt.return_unit
   | 9 ->
     Alcotest.check result "Pending again" (Error (`Active `Running)) out;
+    Lwt.pause () >>= fun () ->
     let w = get_watch () in
     Lwt.wakeup w.set_ready ();
     data := Some (Ok "baz");


### PR DESCRIPTION
The first commit adds a small incremental library (a few hundred lines of code, including comments, and no dependencies). It includes some code based on @let-def's orderme library, so I licensed that bit as ISC.

The second commit updates `lib_term` to use this for evaluation, and changes the type for inputs to be incremental too.

I need to do more testing, but it seems to be working so far! Once this is in, there is lots of scope for further improvements (e.g. `list_map` should preserve the existing pipelines where possible), but let's see what this does on its own first.