### PR TITLE
Update README.md to link the API Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,19 @@ An OCurrent pipeline is written using an OCaml eDSL. When OCurrent evaluates it,
 it records the inputs used (e.g. the current set of open PRs and the head of each
 one), monitors them, and automatically recalculates when an input changes.
 
-The [OCurrent wiki][] contains documentation and examples.
-In particular, you might like to start by reading about the
-[example pipelines][] or how to [write your own plugins][writing-plugins].
-
 Larger uses of OCurrent include the
 [OCaml Docker base image builder][docker-base-images] and
 [ocaml-ci][], which is the CI that tests this repository itself.
 
-# Licensing
+## Documentation
+
+The [OCurrent wiki][] contains user documentation and examples.
+In particular, you might like to start by reading about the
+[example pipelines][] or how to [write your own plugins][writing-plugins].
+
+For technical docs, see the [API Documentation][].
+
+## Licensing
 
 OCurrent is licensed under the Apache License, Version 2.0.
 See [LICENSE][] for the full license text.
@@ -38,4 +42,5 @@ See [LICENSE][] for the full license text.
 [writing-plugins]: https://github.com/ocurrent/ocurrent/wiki/Writing-plugins
 [example pipelines]: https://github.com/ocurrent/ocurrent/wiki/Example-pipelines
 [OCurrent wiki]: https://github.com/ocurrent/ocurrent/wiki
+[API Documentation]: https://ocurrent.github.io/ocurrent/index.html
 [LICENSE]: ./LICENSE


### PR DESCRIPTION
Just suggesting a slight change to the README to 

- make the documentation very easy to find, by adding a heading
- make license an h2 sub-heading (assuming the h1 **Ocurrent** is supposed to be the title)
- Link the API docs directly from the readme (so users don't have to go hunting for  it through the wiki)