### PR TITLE
Fix merging of error states for pairs

### DIFF
--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -112,6 +112,7 @@ module Make (Job : sig type id end) = struct
     | Pass, Pass -> Pass
 
   let pair ~env a b =
+    let state = pair_state a b in
     let a = simplify a in
     let b = simplify b in
     let single_context =
@@ -121,29 +122,29 @@ module Make (Job : sig type id end) = struct
     | true, Constant None, _ -> b
     | true, _, Constant None -> a
     | _ ->
-      make ~env (Pair (a, b)) (pair_state a b)
+      make ~env (Pair (a, b)) state
 
   let bind ~env ?(info="") x state =
     match info, env with
     | "", Some bind -> bind
     | _ ->
-      let x = simplify x in
-      let ty = Bind (x, info) in
       let state =
         match x.state with
         | Blocked | Active _ | Fail _ -> Blocked
         | Pass -> state
       in
+      let x = simplify x in
+      let ty = Bind (x, info) in
       make ~env ty state
 
   let bind_input ~env ~info ?id x state =
-    let x = simplify x in
-    let ty = Bind_input {x; info; id} in
     let state =
       match x.state with
       | Blocked | Active _ | Fail _ -> Blocked
       | Pass -> state
     in
+    let x = simplify x in
+    let ty = Bind_input {x; info; id} in
     make ~env ty state
 
   let list_map ~env ~f items =

--- a/lib_term/dyn.ml
+++ b/lib_term/dyn.ml
@@ -27,8 +27,10 @@ let map_error f x =
 
 let pair a b =
   match a, b with
-  | (Error _ as e), _ -> e
-  | _, (Error _ as e) -> e
+  | (Error (`Msg _) as e), _
+  | _, (Error (`Msg _) as e) -> e
+  | (Error (`Active _) as e), _
+  | _, (Error (`Active _) as e) -> e
   | Ok x, Ok y -> Ok (x, y)
 
 let active a = Error (`Active a)

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -3,6 +3,7 @@
           option-none.2.dot
           option-some.1.dot
           option-some.2.dot
+          pair.1.dot
           state.1.dot
           v1.1.dot
           v1.2.dot
@@ -47,6 +48,11 @@
  (name runtest)
  (package current)
  (action (diff expected/option-some.2.dot option-some.2.dot)))
+
+(alias
+ (name runtest)
+ (package current)
+ (action (diff expected/pair.1.dot pair.1.dot)))
 
 (alias
  (name runtest)

--- a/test/expected/pair.1.dot
+++ b/test/expected/pair.1.dot
@@ -1,0 +1,19 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n5 [label="Blocked-3",fillcolor="#d3d3d3",style="filled"]
+  n4 [label="state",fillcolor="#90ee90",style="filled"]
+  n8 [label="Blocked-2",fillcolor="#d3d3d3",style="filled"]
+  n7 [label="state",fillcolor="#90ee90",style="filled"]
+  n12 [label="Blocked-1",fillcolor="#d3d3d3",style="filled"]
+  n11 [label="state",fillcolor="#90ee90",style="filled"]
+  n12 -> n11
+  n1 -> n12
+  n8 -> n7
+  n1 -> n8
+  n5 -> n4
+  n1 -> n5
+  n2 -> n1
+  }


### PR DESCRIPTION
If one component of a pair was pending and the other was failed, the static analysis reported the result as failed, whereas the dynamic part used whichever one came first. The dynamic part now gives priority to failed inputs too.

Also, calculate the new state before simplification, since that can remove failed constant inputs.