### PR TITLE
Avoid unnecessary re-evaluations in Current.list_map

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -15,6 +15,7 @@
    capnp-rpc-unix
    cmdliner
    current
+   current.term
    current.cache
    current.fs
    current_docker

--- a/examples/github_app.ml
+++ b/examples/github_app.ml
@@ -38,11 +38,11 @@ let pipeline ~app () =
     let+ base = Docker.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08" in
     `Contents (dockerfile ~base)
   in
-  Github.App.installations app |> Current.list_iter ~pp:Github.Installation.pp @@ fun installation ->
+  Github.App.installations app |> Current.list_iter (module Github.Installation) @@ fun installation ->
   let repos = Github.Installation.repositories installation in
-  repos |> Current.list_iter ~pp:Github.Api.Repo.pp @@ fun repo ->
+  repos |> Current.list_iter (module Github.Api.Repo) @@ fun repo ->
   Github.Api.Repo.ci_refs repo
-  |> Current.list_iter ~pp:Github.Api.Commit.pp @@ fun head ->
+  |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   Docker.build ~pool ~pull:false ~dockerfile (`Git src)
   |> Current.state

--- a/lib_incr/current_incr.ml
+++ b/lib_incr/current_incr.ml
@@ -23,3 +23,5 @@ let change ?(eq=(==)) = Modifiable.change ~eq
 let propagate = Modifiable.propagate
 let observe = Modifiable.deref
 let on_release = Modifiable.on_release
+
+module Separate = Modifiable.Separate

--- a/lib_incr/current_incr.mli
+++ b/lib_incr/current_incr.mli
@@ -54,6 +54,15 @@ val on_release : (unit -> unit) -> unit
 val map : ('a -> 'b) -> 'a t -> 'b t
 (** A convenience function to read a value, apply a function to it, and write the result. *)
 
+module Separate (Map : Map.S) : sig
+  (** Processing each item of a set efficiently. *)
+
+  val map : unit Map.t t -> (Map.key -> 'b cc) -> 'b Map.t t
+  (** [map x fn] applies [fn] to each element of [x] and returns a map from
+      input elements to results. When new elements are added to [x], it only
+      runs [fn] on the new elements, rather than on all elements. *)
+end
+
 (** {2 External operations}
 
     These functions are used to interface between the changeable system and other systems (e.g. Lwt). *)

--- a/lib_incr/modifiable.ml
+++ b/lib_incr/modifiable.ml
@@ -22,6 +22,7 @@ type 'a full = {
 type 'a modval =
   | Uninitialised
   | Full of 'a full
+  | Redirect of (eq:('a -> 'a -> bool) -> 'a -> unit)    (* To write here, just call the function instead. *)
 
 (* A modifiable value starts off [Uninitialised] and then becomes [Full] once the
    initial value is known. When the value changes, it is replaced with a new [Full]
@@ -84,6 +85,7 @@ let non_empty (t:'a t) =
   match !t with
   | Full x -> x
   | Uninitialised -> failwith "Modifiable is empty! (this shouldn't happen)"
+  | Redirect _ -> failwith "Got an unexpected Redirect (this shouldn't happen)"
 
 (* If we keep reading a modifiable that doesn't change often, the list of
    readers can build up over time. So each time we add something to the queue,
@@ -113,6 +115,7 @@ let on_release fn =
 let reread t reader () =
   match !t with
   | Uninitialised -> failwith "Modifiable is empty! (this shouldn't happen)"
+  | Redirect _ -> failwith "Modifiable is a redirect! (this shouldn't happen)"
   | Full f ->
     minor_tidy f.readers;
     Queue.add reader f.readers;
@@ -121,10 +124,87 @@ let reread t reader () =
 let write ~eq t value =
   match !t with
   | Uninitialised -> t := Full { value; readers = Queue.create () }
+  | Redirect f -> f ~eq value
   | Full { value = old; readers = _ } when eq old value -> ()
   | Full old ->
     t := Full { value; readers = Queue.create () };
     old.readers |> Queue.iter (fun r -> Pq.add q { r with fn = reread t r })
+
+module Separate (Map : Map.S) = struct
+  (* Normally, if we processed all the elements of a set with a function then
+     then we would automatically invalidate all of the work whenever the set changed.
+     Instead, we pretend that the read of the set finishes before any of the
+     elements are processed, so that changing the set just calls our [update]
+     function. Then we manually remove any time periods that are no longer needed
+     and create any new ones (for newly added elements). The result of the user
+     function is intercepted and turned into an operation to add the result to
+     the results map.
+
+     Note that this might cause the output to be written to many times in a
+     single propagate, but that shouldn't cause any problems. The first write
+     will add all readers to the queue but the final result will be set before
+     any of them actually run. *)
+
+  (* The time period of a computation that processed an element of the set.
+     There is no [fn] here because an input element cannot change, it can only
+     be removed from the set. When an element is removed, times from [start] to
+     [stop] (both inclusive) are erased from history. *)
+  type period = {
+    start : Time.t;               (* When this computation started. *)
+    stop : Time.t;                (* When it produced its result. *)
+  }
+
+  let map xs_incr (f : Map.key -> 'b t -> changeable) : 'b Map.t t =
+    let active : period Map.t ref = ref Map.empty in
+    let result = create (fun d -> write ~eq:(==) d Map.empty) in
+    let start = insert_now () in        (* When we respond to changes in [xs_incr] and update [active]. *)
+    now := Time.after !now;             (* When [result] is written. *)
+    let update xs =
+      (* Called initially and whenever [xs] changes.
+         It runs instantaneously at time [start]. *)
+      let saved = !now in
+      active := Map.merge (fun key a b ->
+          match a, b with
+          | None, Some () ->
+            (* A new element has been added. Add it to the timeline: *)
+            let start = Time.after start in
+            now := start;
+            (* Run [f key]. When it tries to write the result, add that to [results]: *)
+            f key (ref (Redirect (fun ~eq value ->
+                let old_map = (non_empty result).value in
+                match Map.find_opt key old_map with
+                | Some old_value when eq old_value value -> ()
+                | _ -> write result (Map.add key value old_map) ~eq:(==);
+              )));
+            let stop = !now in
+            (* Record the time period during which [f key] ran, so we can erase it later. *)
+            Some { start; stop }
+          | Some _ as existing, Some () ->
+            (* An existing element is still present. Keep it. *)
+            existing
+          | Some old, None ->
+            (* An element has been removed. Erase it from history: *)
+            Time.splice_out (Time.prev old.start) (Time.next old.stop);
+            (* Remove its result from the output: *)
+            let old_map = (non_empty result).value in
+            write result (Map.remove key old_map) ~eq:(==);
+            (* Remove it from [active]: *)
+            None
+          | None, None -> assert false
+        ) !active xs;
+      now := saved;
+    in
+    begin
+      let xs = non_empty xs_incr in
+      minor_tidy xs.readers;
+      update xs.value
+      (* Note: [xs] might have been replaced by now. *)
+    end;
+    (* Arrange to call [update] again if [xs] changes: *)
+    let edge = { start; stop = start; fn = update } in
+    Queue.add edge (non_empty xs_incr).readers;
+    result
+end
 
 let deref t = (non_empty t).value
 

--- a/lib_incr/modifiable.mli
+++ b/lib_incr/modifiable.mli
@@ -38,3 +38,12 @@ val propagate : unit -> unit
 val on_release : (unit -> unit) -> unit
 (** [on_release fn] registers [fn ()] to be called if the containing
     computation needs to be re-evaluated. *)
+
+module Separate (Map : Map.S) : sig
+  (** Processing each item of a set efficiently. *)
+
+  val map : unit Map.t t -> (Map.key -> 'b t -> changeable) -> 'b Map.t t
+  (** [map x fn] applies [fn] to each element of [x] and returns a map from
+      input elements to results. When new elements are added to [x], it only
+      runs [fn] on the new elements, rather than on all elements. *)
+end

--- a/lib_incr/time.ml
+++ b/lib_incr/time.ml
@@ -182,3 +182,11 @@ let clear_forget t =
   assert (is_valid t);
   assert (t.on_forget <> None);
   t.on_forget <- None
+
+let next t =
+  assert (not (is_last t));
+  t.next
+
+let prev t =
+  assert (not (is_first t));
+  t.prev

--- a/lib_incr/time.mli
+++ b/lib_incr/time.mli
@@ -46,6 +46,12 @@ val set_forget : t -> (unit -> unit) -> unit
 val clear_forget : t -> unit
 (** [clear_forget t] reverses the effect of [set_forget]. *)
 
+val next : t -> t
+(** [next t] is the time immediately after [t] (which must not be the last time). *)
+
+val prev : t -> t
+(** [prev t] is the time immediately before [t] (which must not be the first time). *)
+
 (* Algorithm due to:
    Two Simplified Algorithms for Maintaining Order in a List
    Bender et al., 2002 *)

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -173,6 +173,13 @@ module Make (Input : S.INPUT) = struct
     let output = Current_incr.map (fun x -> Term x) results in
     node (Option_map { item = Term input; output }) (join results)
 
+  let rec list_seq : 'a t list -> 'a list t = function
+    | [] -> return []
+    | x :: xs ->
+      let+ y = x
+      and+ ys = list_seq xs in
+      y :: ys
+
   let list_map ~pp (f : 'a t -> 'b t) (input : 'a list t) =
     let results =
       input.v |> Current_incr.map @@ function
@@ -202,13 +209,6 @@ module Make (Input : S.INPUT) = struct
   let list_iter ~pp f xs =
     let+ (_ : unit list) = list_map ~pp f xs in
     ()
-
-  let rec list_seq : 'a t list -> 'a list t = function
-    | [] -> return []
-    | x :: xs ->
-      let+ y = x
-      and+ ys = list_seq xs in
-      y :: ys
 
   let option_seq : 'a t option -> 'a option t = function
     | None -> return None

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -180,34 +180,52 @@ module Make (Input : S.INPUT) = struct
       and+ ys = list_seq xs in
       y :: ys
 
-  let list_map ~pp (f : 'a t -> 'b t) (input : 'a list t) =
-    let results =
+
+  let list_map (type a) (module M : S.ORDERED with type t = a) (f : a t -> 'b t) (input : a list t) =
+    let module Map = Map.Make(M) in
+    let module Sep = Current_incr.Separate(Map) in
+    (* Stage 1 : convert input list to a set.
+       This runs whenever the input list changes. *)
+    let as_map =
       input.v |> Current_incr.map @@ function
-      | Error _ as r ->
-        (* Not ready; use static version of map. *)
-        let output = f (map_input input ~label:(Error `Blocked) r) in
-        replace output r
-      | Ok [] ->
-        (* Empty list; show what would have been done. *)
-        let no_items = Error (Id.mint (), `Active `Ready) in
-        let output = f (map_input input ~label:(Error `Empty_list) no_items) in
-        replace output (Ok [])
-      | Ok items ->
-        (* Ready. Expand inputs. *)
-        let rec aux = function
-          | [] -> return []
-          | x :: xs ->
-            let+ y = f (map_input ~label:(Ok (Fmt.to_to_string pp x)) input (Ok x))
-            and+ ys = aux xs in
-            y :: ys
-        in
-        aux items
+      | Ok items -> items |> List.fold_left (fun acc x -> Map.add x () acc) Map.empty
+      | _ -> Map.empty
+    in
+    (* Stage 2 : process each element separately.
+       We only process an element when it is first added to the set,
+       not on every change to the set. *)
+    let results =
+      Sep.map as_map @@ fun item ->
+      let label = Ok (Fmt.to_to_string M.pp item) in
+      Current_incr.write (f (map_input ~label input (Ok item)))
+    in
+    (* Stage 3 : combine results.
+       This runs whenever either the set of results changes, or the input list changes
+       (since the output order might need to change). *)
+    let results =
+      Current_incr.of_cc begin
+        Current_incr.read input.v @@ function
+        | Error _ as r ->
+          (* Not ready; use static version of map. *)
+          let output = f (map_input input ~label:(Error `Blocked) r) in
+          Current_incr.write @@ replace output r
+        | Ok [] ->
+          (* Empty list; show what would have been done. *)
+          let no_items = Error (Id.mint (), `Active `Ready) in
+          let output = f (map_input input ~label:(Error `Empty_list) no_items) in
+          Current_incr.write @@ replace output (Ok [])
+        | Ok items ->
+          Current_incr.read results @@ fun results ->
+          (* Convert result set to a results list. *)
+          let results = items |> List.map (fun item -> Map.find item results) |> list_seq in
+          Current_incr.write results
+      end
     in
     let output = Current_incr.map (fun x -> Term x) results in
     node (List_map { items = Term input; output }) (join results)
 
-  let list_iter ~pp f xs =
-    let+ (_ : unit list) = list_map ~pp f xs in
+  let list_iter (type a) (module M : S.ORDERED with type t = a) f (xs : a list t) =
+    let+ (_ : unit list) = list_map (module M) f xs in
     ()
 
   let option_seq : 'a t option -> 'a option t = function

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -15,6 +15,11 @@ module type T = sig
   val pp : t Fmt.t
 end
 
+module type ORDERED = sig
+  include Map.OrderedType
+  val pp : t Fmt.t
+end
+
 module type INPUT = sig
   type 'a t
   (** An input that was used while evaluating a term.
@@ -96,12 +101,13 @@ module type TERM = sig
   (** [pair a b] is the pair containing the results of evaluating [a] and [b]
       (in parallel). *)
 
-  val list_map : pp:'a Fmt.t -> ('a t -> 'b t) -> 'a list t -> 'b list t
-  (** [list_map ~pp f xs] adds [f] to the end of each input term
+  val list_map : (module ORDERED with type t = 'a) -> ('a t -> 'b t) -> 'a list t -> 'b list t
+  (** [list_map (module T) f xs] adds [f] to the end of each input term
       and collects all the results into a single list.
-      @param pp Label the instances. *)
+      @param T Used to display labels for each item, and to avoid recreating pipelines
+               unnecessarily. *)
 
-  val list_iter : pp:'a Fmt.t -> ('a t -> unit t) -> 'a list t -> unit t
+  val list_iter : (module ORDERED with type t = 'a) -> ('a t -> unit t) -> 'a list t -> unit t
   (** Like [list_map] but for the simpler case when the result is unit. *)
 
   val list_seq : 'a t list -> 'a list t

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -122,6 +122,15 @@ module Commit_id = struct
 
   let pp_id = Ref.pp
 
+  let compare {owner_name; id; hash} b =
+    match compare hash b.hash with
+    | 0 ->
+      begin match Ref.compare id b.id with
+        | 0 -> compare owner_name b.owner_name
+        | x -> x
+      end
+    | x -> x
+
   let pp f { owner_name; id; hash } =
     Fmt.pf f "%s@ %a@ %s" owner_name pp_id id (Astring.String.with_range ~len:8 hash)
 
@@ -512,6 +521,8 @@ module Commit = struct
 
   let id (_, commit_id) = Commit_id.to_git commit_id
 
+  let compare (_, a) (_, b) = Commit_id.compare a b
+
   let owner_name (_, id) = id.Commit_id.owner_name
 
   let repo_id t =
@@ -536,6 +547,7 @@ module Repo = struct
 
   let id = snd
   let pp = Fmt.using id Repo_id.pp
+  let compare a b = Repo_id.compare (id a) (id b)
 
   let head_commit t =
     Current.component "head" |>

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -14,6 +14,7 @@ module Commit : sig
   val owner_name : t -> string
   val hash : t -> string
   val pp : t Fmt.t
+  val compare : t -> t -> int
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
   val uri : t -> Uri.t
 end
@@ -42,6 +43,7 @@ module Repo : sig
   val ci_refs : t Current.t -> Commit.t list Current.t
   val head_commit : t Current.t -> Commit.t Current.t
   val pp : t Fmt.t
+  val compare : t -> t -> int
 end
 
 (* Private API *)

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -50,6 +50,7 @@ module Api : sig
     (** [hash t] is the Git commit hash of [t]. *)
 
     val pp : t Fmt.t
+    val compare : t -> t -> int
 
     val uri : t -> Uri.t
     (** [uri t] is a URI for the GitHub web page showing [t]. *)
@@ -60,6 +61,7 @@ module Api : sig
 
     val id : t -> Repo_id.t
     val pp : t Fmt.t
+    val compare : t -> t -> int
 
     val ci_refs : t Current.t -> Commit.t list Current.t
     (** [ci_refs t] evaluates to the list of branches and open PRs in [t], excluding gh-pages. *)
@@ -118,6 +120,9 @@ module Installation : sig
   val repositories : t Current.t -> Api.Repo.t list Current.t
   (** [repositories t] evaluates to the list of repositories which the user
       configured for this installation. *)
+
+  val compare : t -> t -> int
+  (** Order by installation ID. *)
 end
 
 module App : sig

--- a/plugins/github/installation.ml
+++ b/plugins/github/installation.ml
@@ -25,6 +25,8 @@ let input_installation_repositories_webhook () = Lwt_condition.broadcast install
 
 let pp f t = Fmt.string f t.account
 
+let compare a b = compare a.iid b.iid
+
 let list_repositories_endpoint = Uri.of_string "https://api.github.com/installation/repositories"
 
 let list_repositories ~api ~token ~account =

--- a/plugins/github/installation.mli
+++ b/plugins/github/installation.mli
@@ -3,6 +3,7 @@
 type t
 val api : t -> Api.t
 val pp : t Fmt.t
+val compare : t -> t -> int
 
 val repositories : t Current.t -> Api.Repo.t list Current.t
 

--- a/test/plugins/git/current_git_test.ml
+++ b/test/plugins/git/current_git_test.ml
@@ -21,6 +21,7 @@ module Commit = struct
     Fmt.pf f "%s#%s" repo hash
 
   let equal = (=)
+  let compare = compare
   let digest { repo; hash } = Fmt.strf "%s#%s" repo hash
 end
 

--- a/test/plugins/git/current_git_test.mli
+++ b/test/plugins/git/current_git_test.mli
@@ -4,6 +4,7 @@ module Commit : sig
   type t
   val v : repo:string -> hash:string -> t
   val equal : t -> t -> bool
+  val compare : t -> t -> int
   val pp : t Fmt.t
   val digest : t -> string
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -128,7 +128,7 @@ let v5 commit =
   let ok = test bin in
   Opam.revdeps src
   |> Current.gate ~on:ok
-  |> Current.list_iter ~pp:(Git.Commit.pp) (fun s -> s |> fetch |> build |> test)
+  |> Current.list_iter (module Git.Commit) (fun s -> s |> fetch |> build |> test)
 
 let test_v5 _switch () =
   Driver.test ~name:"v5" (with_commit v5) @@ function


### PR DESCRIPTION
- The new `Current_incr.Separate` functor allows processing a set of things independently.

- `list_map` now gets the set of items in the list, processes them this way, and then generates the result list from the output.

For example, this should mean that when a new PR is opened, we only evaluate one pipeline segment for that PR. Before, we would re-evaluate all the PRs.