### PR TITLE
Change the representation of terms to support incremental evaluation

### DIFF
--- a/examples/logging.ml
+++ b/examples/logging.ml
@@ -1,5 +1,3 @@
-open Current.Syntax
-
 module Metrics = struct
   open Prometheus
 
@@ -34,17 +32,6 @@ let init ?(level=Logs.Info) () =
   Fmt_tty.setup_std_outputs ();
   Logs.set_level (Some level);
   Logs.set_reporter reporter
-
-let with_dot ~dotfile f () =
-  let result = f () in
-  let dot_data =
-    let+ a = Current.Analysis.get result in
-    Logs.debug (fun f -> f "Pipeline: @[%a@]" Current.Analysis.pp a);
-    let url _ = None in
-    Fmt.strf "%a" (Current.Analysis.pp_dot ~url) a
-  in
-  let* () = Current_fs.save (Current.return dotfile) dot_data in
-  result
 
 let run x =
   match Lwt_main.run x with

--- a/examples/logging.mli
+++ b/examples/logging.mli
@@ -1,12 +1,5 @@
 val init : ?level:Logs.level -> unit -> unit
 (** Initialise the Logs library with some sensible defaults. *)
 
-val with_dot :
-  dotfile:Fpath.t ->
-  (unit -> 'a Current.t) ->
-  (unit -> 'a Current.t)
-(** [with_dot ~dotfile pipeline] wraps [pipeline] to keep a dot diagram in
-    [dotfile] showing its current state. *)
-
 val run : unit Current.or_error Lwt.t -> unit Current.or_error
 (** [run x] is like [Lwt_main.run x], but logs the returned error, if any. *)

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -254,7 +254,6 @@ module Engine : sig
 
   type results = {
     value : unit Current_term.Output.t;
-    analysis : Analysis.t;
     jobs : actions Job.Map.t;        (** The jobs currently being used (whether running or finished). *)
   }
 
@@ -283,8 +282,10 @@ module Engine : sig
 
   val config : t -> Config.t
 
-  val update_metrics : results -> unit
-  (** [update_metrics results] reports how many pipeline stages are in each state via Prometheus.
+  val pipeline : t -> unit term
+
+  val update_metrics : t -> unit
+  (** [update_metrics t] reports how many pipeline stages are in each state via Prometheus.
       Call this on each metrics collection if you have exactly one pipeline. The default web
       UI does this automatically. *)
 

--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -1,174 +1,45 @@
 module IntSet = Set.Make(struct type t = int let compare = compare end)
 module IntMap = Map.Make(struct type t = int let compare = compare end)
 
-module Make (Job : sig type id end) = struct
-  type state =
-    | Blocked
-    | Active of Output.active
-    | Pass
-    | Fail of string
-
-  type t = {
-    id : Id.t;
-    bind : t option;
-    ty : metadata_ty;
-    state : state;
-  }
-  and metadata_ty =
-    | Constant of string option
-    | Map_input of { source : t; info : (string, [`Blocked | `Empty_list]) result }
-    | Opt_input of { source : t; info : [`Blocked | `Selected | `Not_selected] }
-    | State of { source : t; hidden : bool }
-    | Catch of { source : t; hidden : bool }
-    | Map_failed of t      (* In [map f t], [f] raised an exception. *)
-    | Bind of t * string
-    | Bind_input of {x : t; info : string; id : Job.id option}
-    | Pair of t * t
-    | Gate_on of { ctrl : t; value : t }
-    | List_map of { items : t; fn : t }
-    | Option_map of { item : t; fn : t }
-
-  type env = t option
-
-  let make ~env ty state =
-    { id = Id.mint (); ty; bind = env; state }
-
-  let return ~env label =
-    make ~env (Constant label) Pass
-
-  let map_input ~env source info =
-    make ~env (Map_input {source; info})
-      (match info with
-       | Ok _ -> Pass
-       | Error (`Blocked | `Empty_list) -> Blocked)
-
-  let option_input ~env source info =
-    make ~env (Opt_input {source; info})
-      (match info with
-       | `Selected -> Pass
-       | `Blocked | `Not_selected -> Blocked)
-
-  let fail ~env msg =
-    make ~env (Constant None) (Fail msg)
-
-  let map_failed ~env t msg =
-    make ~env (Map_failed t) (Fail msg)
-
-  let state ~env ~hidden t =
-    make ~env (State { source = t; hidden }) Pass
-
-  let catch ~env ~hidden t =
-    let state =
-      match t.state with
-      | Fail _ -> Pass
-      | _  -> t.state
-    in
-    make ~env (Catch { source = t; hidden }) state
-
-  let active ~env a =
-    make ~env (Constant None) (Active a)
-
-  let of_output ~env = function
-    | Ok _ -> return ~env None
-    | Error `Msg m -> fail ~env m
-    | Error (`Active a) -> active ~env a
-
-  let ( =? ) a b =
-    match a, b with
-    | None, None -> true
-    | Some a, Some b -> a.id = b.id
-    | _ -> false
-
-  let simplify x =
-    match x.ty, x.bind with
-    | Constant None, Some c -> c
-    | _ -> x
-
-  let pair_state a b =
-    match a.state, b.state with
-    | _, Fail m
-    | Fail m, _ -> Fail m
-    | _, (Blocked | Active _)
-    | (Blocked | Active _), _ -> Blocked
-    | Pass, Pass -> Pass
-
-  let pair ~env a b =
-    let state = pair_state a b in
-    let a = simplify a in
-    let b = simplify b in
-    let single_context =
-      a.bind =? b.bind && b.bind =? env
-    in
-    match single_context, a.ty, b.ty with
-    | true, Constant None, _ -> b
-    | true, _, Constant None -> a
-    | _ ->
-      make ~env (Pair (a, b)) state
-
-  let bind ~env ?(info="") x state =
-    match info, env with
-    | "", Some bind -> bind
-    | _ ->
-      let state =
-        match x.state with
-        | Blocked | Active _ | Fail _ -> Blocked
-        | Pass -> state
-      in
-      let x = simplify x in
-      let ty = Bind (x, info) in
-      make ~env ty state
-
-  let bind_input ~env ~info ?id x state =
-    let state =
-      match x.state with
-      | Blocked | Active _ | Fail _ -> Blocked
-      | Pass -> state
-    in
-    let x = simplify x in
-    let ty = Bind_input {x; info; id} in
-    make ~env ty state
-
-  let list_map ~env ~f items =
-    make ~env (List_map { items; fn = f }) items.state
-
-  let option_map ~env ~f item =
-    make ~env (Option_map { item; fn = f }) item.state
-
-  let gate ~env ~on:ctrl value =
-    let ctrl = simplify ctrl in
-    let value = simplify value in
-    make ~env (Gate_on { ctrl; value }) (pair_state ctrl value)
+module Make (Meta : sig type job_id end) = struct
+  module Node = Node.Make(Meta)
+  open Node
 
   let pp f x =
     let seen = ref Id.Set.empty in
-    let rec aux f md =
-      if Id.Set.mem md.id !seen then
+    let rec aux f t =
+      let Term t = t in
+      if Id.Set.mem t.id !seen then
         Fmt.string f "..."
       else (
-        seen := Id.Set.add md.id !seen;
-        match md.ty with
+        seen := Id.Set.add t.id !seen;
+        match t.ty with
         | Constant None ->
-          begin match md.bind with
+          begin match t.bind with
             | Some ctx -> aux f ctx
-            | None -> Fmt.string f (if md.state = Blocked then "(input)" else "(const)")
+            | None ->
+              match Current_incr.observe t.v with
+              | Error (_, `Active _) -> Fmt.string f "(input)"
+              | _ -> Fmt.string f "(const)"
           end
         | Constant (Some l) -> Fmt.string f l
         | Map_input { source = _; info = Ok label } -> Fmt.string f label
         | Map_input { source = _; info = Error `Blocked } -> Fmt.string f "(blocked)"
         | Map_input { source = _; info = Error `Empty_list } -> Fmt.string f "(empty list)"
-        | Opt_input { source; info = _ } -> Fmt.pf f "[%a]" aux source
-        | Bind (x, name) -> Fmt.pf f "%a@;>>=@;%s" aux x name
-        | Bind_input {x; info; id = _} -> Fmt.pf f "%a@;>>=@;%s" aux x info
+        | Opt_input { source } -> Fmt.pf f "[%a]" aux source
+        | Bind_in (x, name) -> Fmt.pf f "%a@;>>=@;%s" aux x name
+        | Bind_out x -> aux f (Current_incr.observe x)
+        | Primitive {x; info; meta = _ } -> Fmt.pf f "%a@;>>=@;%s" aux x info
         | Pair (x, y) -> Fmt.pf f "@[<v>@[%a@]@,||@,@[%a@]@]" aux x aux y
         | Gate_on { ctrl; value } -> Fmt.pf f "%a@;>>@;gate (@[%a@])" aux value aux ctrl
-        | List_map { items; fn } -> Fmt.pf f "%a@;>>@;list_map (@[%a@])" aux items aux fn
-        | Option_map { item; fn } -> Fmt.pf f "%a@;>>@;option_map (@[%a@])" aux item aux fn
+        | List_map { items; output } -> Fmt.pf f "%a@;>>@;list_map (@[%a@])" aux items aux (Current_incr.observe output)
+        | Option_map { item; output } -> Fmt.pf f "%a@;>>@;option_map (@[%a@])" aux item aux (Current_incr.observe output)
         | State x -> Fmt.pf f "state(@[%a@])" aux x.source
         | Catch x -> Fmt.pf f "catch(@[%a@])" aux x.source
-        | Map_failed x -> aux f x
+        | Map x -> aux f x
       )
     in
-    aux f x
+    aux f (Term x)
 
   module Node_set = Set.Make(struct type t = int let compare = compare end)
 
@@ -240,39 +111,48 @@ module Make (Job : sig type id end) = struct
       !pending_edges |> List.iter (fun (style, color, a, b) -> Dot.edge f ?style ?color a b);
       pending_edges := []
     in
-    let rec aux md =
-      match Id.Map.find_opt md.id !seen with
+    let rec aux (Term t) =
+      match Id.Map.find_opt t.id !seen with
       | Some x -> x
       | None ->
         let i = !next in
         incr next;
         let ctx =
-          match md.bind with
+          match t.bind with
           | None -> Out_node.empty
           | Some c -> aux c
         in
+        let v = Current_incr.observe t.v in
+        let error_from_self =
+          match v with
+          | Error (id, _) -> Id.equal id t.id
+          | Ok _ -> false
+        in
         let bg =
-          match md.state with
-          | Blocked -> "#d3d3d3"
-          | Active `Ready -> "#ffff00"
-          | Active `Running -> "#ffa500"
-          | Pass -> "#90ee90"
-          | Fail _ -> "#ff4500"
+          match v with
+          | Ok _ -> "#90ee90"
+          | Error _ when not error_from_self -> "#d3d3d3" (* Blocked *)
+          | Error (_, `Active `Ready) -> "#ffff00"
+          | Error (_, `Active `Running) -> "#ffa500"
+          | Error (_, `Msg _) -> "#ff4500"
         in
         let tooltip =
-          match md.state with
-          | Fail msg -> Some msg
+          match v with
+          | Error (_, `Msg msg) when error_from_self -> Some msg
           | _ -> None
         in
         let node ?id =
           let url = match id with None -> None | Some id -> url id in
           Dot.node ~style:"filled" ~bg ?tooltip ?url f in
         let outputs =
-          match md.ty with
+          match t.ty with
           | Constant (Some l) -> node i l; Out_node.singleton ~deps:ctx.Out_node.trans i
           | Constant None when Out_node.is_empty ctx ->
-            node i (if md.state = Blocked then "(input)" else "(const)");
-            Out_node.singleton ~deps:ctx.Out_node.trans i
+            if Result.is_ok v then ctx
+            else (
+              node i (if error_from_self then "(const)" else "(input)");
+              Out_node.singleton ~deps:ctx.Out_node.trans i
+            )
           | Constant None -> ctx
           | Map_input { source; info } ->
             let label =
@@ -286,11 +166,11 @@ module Make (Job : sig type id end) = struct
             Out_node.connect (edge_to i) source;
             let deps = Node_set.union source.Out_node.trans ctx.Out_node.trans in
             Out_node.singleton ~deps i
-          | Opt_input { source; info = _ } ->
+          | Opt_input { source } ->
             aux source
-          | Bind (x, name) ->
+          | Bind_in (x, name) ->
             let inputs =
-              match x.ty with
+              match t.ty with
               | Constant None -> Out_node.empty
               | _ -> aux x
             in
@@ -298,12 +178,14 @@ module Make (Job : sig type id end) = struct
             let all_inputs = Out_node.union inputs ctx in
             Out_node.connect (edge_to i) all_inputs;
             Out_node.singleton ~deps:all_inputs.Out_node.trans i
-          | Bind_input {x; info; id} ->
+          | Bind_out x -> aux (Current_incr.observe x)
+          | Primitive {x; info; meta} ->
             let inputs =
-              match x.ty with
-              | Constant None -> Out_node.empty
+              match x with
+              | Term { ty = Constant None; _ } -> Out_node.empty
               | _ -> aux x
             in
+            let id = Current_incr.observe meta in
             node ?id i info;
             let all_inputs = Out_node.union inputs ctx in
             Out_node.connect (edge_to i) all_inputs;
@@ -339,35 +221,40 @@ module Make (Job : sig type id end) = struct
             let all_inputs = Out_node.union inputs ctx in
             Out_node.connect (edge_to i) all_inputs;
             Out_node.singleton ~deps:all_inputs.trans i
-          | Map_failed x ->
-            (* Normally, we don't show separate boxes for map functions.
-               But we do if one fails. *)
+          | Map x ->
             let inputs = aux x in
-            node i "map";
-            let all_inputs = Out_node.union inputs ctx in
-            Out_node.connect (edge_to i) all_inputs;
-            Out_node.singleton ~deps:all_inputs.Out_node.trans i
-          | List_map { items; fn } ->
+            begin match v with
+              | Error (_, `Msg _) when error_from_self ->
+                (* Normally, we don't show separate boxes for map functions.
+                   But we do if one fails. *)
+                node i "map";
+                let all_inputs = Out_node.union inputs ctx in
+                Out_node.connect (edge_to i) all_inputs;
+                Out_node.singleton ~deps:all_inputs.Out_node.trans i
+              | _ ->
+                aux x
+            end
+          | List_map { items; output } ->
             ignore (aux items);
             Dot.begin_cluster f i;
-            let outputs = aux fn in
+            let outputs = aux (Current_incr.observe output) in
             Dot.end_cluster f;
             outputs
-          | Option_map { item; fn } ->
+          | Option_map { item; output } ->
             ignore (aux item);
             Dot.begin_cluster f i;
             Dot.pp_option f ("style", "dotted");
-            let outputs = aux fn in
+            let outputs = aux (Current_incr.observe output) in
             Dot.end_cluster f;
             outputs
         in
-        seen := Id.Map.add md.id outputs !seen;
+        seen := Id.Map.add t.id outputs !seen;
         outputs
     in
     Fmt.pf f "@[<v2>digraph pipeline {@,\
-                node [shape=\"box\"]@,\
-                rankdir=LR@,";
-    let _ = aux x in
+              node [shape=\"box\"]@,\
+              rankdir=LR@,";
+    let _ = aux (Term x) in
     flush_pending ();
     Fmt.pf f "}@]@."
 
@@ -380,51 +267,62 @@ module Make (Job : sig type id end) = struct
     let running = ref 0 in
     let failed = ref 0 in
     let blocked = ref 0 in
-    let rec aux md =
-      match Id.Map.find_opt md.id !seen with
+    let rec aux (Term t) =
+      match Id.Map.find_opt t.id !seen with
       | Some x -> x
       | None ->
         let i = !next in
         incr next;
         let ctx =
-          match md.bind with
+          match t.bind with
           | None -> Out_node.empty
           | Some c -> aux c
         in
+        let v = Current_incr.observe t.v in
+        let error_from_self =
+          match v with
+          | Error (id, _) -> Id.equal id t.id
+          | Ok _ -> false
+        in
         let count () =
-          match md.state with
-          | Pass -> incr ok
-          | Blocked -> incr blocked
-          | Active `Ready -> incr ready
-          | Active `Running -> incr running
-          | Fail _ -> incr failed
+          match v with
+          | Ok _ -> incr ok
+          | _ when not error_from_self -> incr blocked
+          | Error (_, `Active `Ready) -> incr ready
+          | Error (_, `Active `Running) -> incr running
+          | Error (_, `Msg _) -> incr failed
         in
         let outputs =
-          match md.ty with
+          match t.ty with
           | Constant (Some _) -> count (); Out_node.singleton ~deps:ctx.Out_node.trans i
           | Constant None when Out_node.is_empty ctx ->
-            count ();
-            Out_node.singleton ~deps:ctx.Out_node.trans i
+            if Result.is_ok v then ctx
+            else (
+              count ();
+              Out_node.singleton ~deps:ctx.Out_node.trans i
+            )
           | Constant None -> ctx
           | Map_input { source; info = _ } ->
             count ();
             let source = aux source in
             let deps = Node_set.union source.Out_node.trans ctx.Out_node.trans in
             Out_node.singleton ~deps i
-          | Opt_input { source; info = _ } -> aux source
-          | Bind (x, _) ->
+          | Opt_input { source } ->
+            aux source
+          | Bind_in (x, _name) ->
             let inputs =
-              match x.ty with
+              match t.ty with
               | Constant None -> Out_node.empty
               | _ -> aux x
             in
             count ();
             let all_inputs = Out_node.union inputs ctx in
             Out_node.singleton ~deps:all_inputs.Out_node.trans i
-          | Bind_input {x; info = _; id = _} ->
+          | Bind_out x -> aux (Current_incr.observe x)
+          | Primitive {x; info = _; meta = _} ->
             let inputs =
-              match x.ty with
-              | Constant None -> Out_node.empty
+              match x with
+              | Term { ty = Constant None; _ } -> Out_node.empty
               | _ -> aux x
             in
             count ();
@@ -448,30 +346,26 @@ module Make (Job : sig type id end) = struct
             if not hidden then count ();
             let all_inputs = Out_node.union inputs ctx in
             Out_node.singleton ~deps:all_inputs.trans i
-          | Map_failed x ->
+          | Map x ->
             let inputs = aux x in
-            count ();
             let all_inputs = Out_node.union inputs ctx in
-            Out_node.singleton ~deps:all_inputs.Out_node.trans i
-          | List_map { items; fn } ->
+            begin match v with
+              | Error (_, `Msg _) when error_from_self ->
+                count ();
+                Out_node.singleton ~deps:all_inputs.Out_node.trans i
+              | _ ->
+                aux x
+            end
+          | List_map { items; output } ->
             ignore (aux items);
-            aux fn
-          | Option_map { item; fn } ->
+            aux (Current_incr.observe output)
+          | Option_map { item; output } ->
             ignore (aux item);
-            aux fn
+            aux (Current_incr.observe output)
         in
-        seen := Id.Map.add md.id outputs !seen;
+        seen := Id.Map.add t.id outputs !seen;
         outputs
     in
-    ignore (aux x);
+    ignore (aux (Term x));
     { S.ok = !ok; ready = !ready; running = !running; failed = !failed; blocked = !blocked  }
-
-  let booting =
-    active ~env:None `Running
-
-  let rec job_id t =
-    match t.ty with
-    | Bind_input i -> i.id
-    | Option_map x -> job_id x.fn
-    | _ -> None
 end

--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -1,25 +1,6 @@
 module IntSet = Set.Make(struct type t = int let compare = compare end)
 module IntMap = Map.Make(struct type t = int let compare = compare end)
 
-module Id : sig
-  type t
-  val mint : unit -> t
-
-  module Set : Set.S with type elt = t
-  module Map : Map.S with type key = t
-end = struct
-  module Key = struct
-    type t = < >
-    let compare = compare
-  end
-
-  type t = Key.t
-  let mint () = object end
-
-  module Set = Set.Make(Key)
-  module Map = Map.Make(Key)
-end
-
 module Make (Job : sig type id end) = struct
   type state =
     | Blocked

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -1,42 +1,10 @@
 (* Static analysis of a build pipeline. *)
 
-module Make (Job : sig type id end) : sig
-  type t
+module Make (Meta : sig type job_id end) : sig
+  type 'a t
 
-  type state =
-    | Blocked
-    | Active of Output.active
-    | Pass
-    | Fail of string
+  val stats : _ t -> S.stats
 
-  type env = t option
-  (** When evaluating a bind function we need to record that everything also
-      depends on the bind itself, so all the constructors take this in an
-      [~env] argument. This will be [None] if the node wasn't created by
-      a bind. *)
-
-  val return       : env:env -> string option -> t
-  val fail         : env:env -> string -> t
-  val map_input    : env:env -> t -> (string, [`Blocked | `Empty_list]) result -> t
-  val map_failed   : env:env -> t -> string -> t
-  val option_input : env:env -> t -> [`Blocked | `Selected | `Not_selected] -> t
-  val state        : env:env -> hidden:bool -> t -> t
-  val catch        : env:env -> hidden:bool -> t -> t
-  val active       : env:env -> Output.active -> t
-  val of_output    : env:env -> _ Output.t -> t
-  val pair         : env:env -> t -> t -> t
-  val bind         : env:env -> ?info:string -> t -> state -> t
-  val bind_input   : env:env -> info:string -> ?id:Job.id -> t -> state -> t
-  val list_map     : env:env -> f:t -> t -> t
-  val option_map   : env:env -> f:t -> t -> t
-  val gate         : env:env -> on:t -> t -> t
-
-  val booting : t
-
-  val job_id : t -> Job.id option
-
-  val stats : t -> S.stats
-
-  val pp : t Fmt.t
-  val pp_dot : url:(Job.id -> string option) -> t Fmt.t
-end
+  val pp : _ t Fmt.t
+  val pp_dot : url:(Meta.job_id -> string option) -> _ t Fmt.t
+end with type 'a t := 'a Node.Make(Meta).t

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -2,152 +2,108 @@ module S = S
 module Output = Output
 
 module Make (Input : S.INPUT) = struct
-  module An = Analysis.Make(struct type id = Input.job_id end)
-
-  type 'a node = {
-    md : An.t;
-    fn : 'a Dyn.t;
-  }
-
-  type 'a t = 'a node Current_incr.t
-
   type description = string
 
-  let make md fn =
-    Current_incr.const { md; fn }
+  module Node = Node.Make(Input)
+  open Node
 
-  let make_cc md fn =
-    Current_incr.write { md; fn }
+  type 'a t = 'a Node.t
 
-  let bind_context = ref None
+  let bind_context : bind_context ref = ref None
 
-  let with_bind_context bc f x =
+  let node ?(id=Id.mint ()) ty v = { id; v; ty; bind = !bind_context }
+
+  let with_bind_context bc f =
     let old = !bind_context in
     bind_context := Some bc;
     Fun.protect
-      (fun () -> f x)
+      (fun () -> f ())
       ~finally:(fun () -> bind_context := old)
 
+  let with_id id = function
+    | Ok _ as v -> v
+    | Error e -> Error (id, e)
+
   let active s =
-    let env = !bind_context in
-    make (An.active ~env s) (Dyn.active s)
+    let id = Id.mint () in
+    node ~id (Constant None) @@ Current_incr.const (Dyn.active ~id s)
 
   let return ?label x =
-    let env = !bind_context in
-    make (An.return ~env label) (Dyn.return x)
+    node (Constant label) @@ Current_incr.const (Dyn.return x)
 
   let map_input ~label source x =
-    let env = !bind_context in
-    make (An.map_input ~env source label) (Dyn.of_output x)
+    node (Map_input {source = Term source; info = label}) @@ Current_incr.const x
 
-  let option_input ~label source x =
-    let env = !bind_context in
-    make (An.option_input ~env source label) (Dyn.of_output x)
+  let option_input source x =
+    node (Opt_input {source = Term source }) @@ Current_incr.const x
 
   let fail msg =
-    let env = !bind_context in
-    make (An.fail ~env msg) (Dyn.fail msg)
+    let id = Id.mint () in
+    node ~id (Constant None) @@ Current_incr.const (Dyn.fail ~id msg)
 
   let state ?(hidden=false) t =
-    let env = !bind_context in
-    Current_incr.of_cc begin
-      Current_incr.read t @@ fun t ->
-      let an = An.state ~env ~hidden t.md in
-      make_cc an (Dyn.state t.fn)
-    end
+    node (State { source = Term t; hidden }) @@ Current_incr.map Dyn.state t.v
 
   let catch ?(hidden=false) t =
-    Current_incr.of_cc begin
-      let env = !bind_context in
-      Current_incr.read t @@ fun t ->
-      let an = An.catch ~env ~hidden t.md in
-      make_cc an (Dyn.catch t.fn)
-    end
-
-  let of_output x =
-    let env = !bind_context in
-    make (An.of_output ~env x) (Dyn.of_output x)
+    node (Catch { source = Term t; hidden }) @@ Current_incr.map Dyn.catch t.v
 
   let component fmt = Fmt.strf ("@[<v>" ^^ fmt ^^ "@]")
 
-  let bind ?info (f:'a -> 'b t) (x:'a t) =
-    let env = !bind_context in
+  let join x =
     Current_incr.of_cc begin
-      Current_incr.read x @@ fun x ->
-      let md = An.bind ~env ?info x.md in
-      match Dyn.run x.fn with
-      | Error (`Msg e) -> make_cc (md (An.Fail e)) (Dyn.fail e)
-      | Error (`Active a) -> make_cc (md (An.Active a)) (Dyn.active a)
-      | Ok y ->
-        let md = md An.Pass in
-        let f2 = with_bind_context md f y in
-        Current_incr.read f2 @@ fun r ->
-        Current_incr.write r
+      Current_incr.read x @@ fun y ->
+      Current_incr.read y.v Current_incr.write
     end
 
-  let msg_of_exn = function
-    | Failure m -> m
-    | ex -> Printexc.to_string ex
+  let bind ?(info="") (f:'a -> 'b t) (x:'a t) =
+    let bind_in = node (Bind_in (Term x, info)) x.v in
+    let t =
+      x.v |> Current_incr.map @@ fun v ->
+      with_bind_context (Term bind_in) @@ fun () ->
+      match v with
+      | Error _ as e -> node (Constant None) @@ Current_incr.const e
+      | Ok y -> f y
+    in
+    let nested = Current_incr.map (fun t -> Term t) t in
+    node (Bind_out nested) (join t)
 
   let map f x =
-    Current_incr.of_cc begin
-      let env = !bind_context in
-      Current_incr.read x @@ fun x ->
-      match Dyn.map f x.fn with
-      | fn -> make_cc x.md fn
-      | exception ex ->
-        let msg = msg_of_exn ex in
-        make_cc (An.map_failed ~env x.md msg) (Dyn.fail msg)
-    end
+    let id = Id.mint () in
+    node ~id (Map (Term x)) @@ Current_incr.map (Dyn.map ~id f) x.v
 
   let map_error f x =
-    let env = !bind_context in
-    Current_incr.of_cc begin
-      Current_incr.read x @@ fun x ->
-      match Dyn.map_error f x.fn with
-      | fn -> make_cc x.md fn
-      | exception ex ->
-        let msg = msg_of_exn ex in
-        make_cc (An.map_failed ~env x.md msg) (Dyn.fail msg)
-    end
+    let id = Id.mint () in
+    node ~id (Map (Term x)) @@ Current_incr.map (Dyn.map_error ~id f) x.v
 
   let ignore_value x = map ignore x
 
   let pair a b =
-    let env = !bind_context in
-    Current_incr.of_cc begin
-      Current_incr.read a @@ fun a ->
-      Current_incr.read b @@ fun b ->
-      let md = An.pair ~env a.md b.md in
-      let fn = Dyn.pair a.fn b.fn in
-      make_cc md fn
+    node (Pair (Term a, Term b)) @@ Current_incr.of_cc begin
+      Current_incr.read a.v @@ fun a ->
+      Current_incr.read b.v @@ fun b ->
+      Current_incr.write @@ Dyn.pair a b
     end
 
-  let bind_input ~info (f:'a -> 'b Input.t) (x:'a t) =
-    let env = !bind_context in
-    Current_incr.of_cc begin
-      Current_incr.read x @@ fun x ->
-      let md = An.bind_input ~env ~info x.md in
-      match Dyn.run x.fn with
-      | Error (`Msg e) -> make_cc (md (An.Fail e)) (Dyn.fail e)
-      | Error (`Active a) -> make_cc (md (An.Active a)) (Dyn.active a)
-      | Ok y ->
-        let input = f y in
-        Current_incr.read (Input.get input) @@ fun (v, id) ->
-        let md = An.bind_input ~env ~info x.md ?id (
-            match v with
-            | Error (`Msg e) -> An.Fail e
-            | Error (`Active a) -> An.Active a
-            | Ok _ -> An.Pass
-          )
-        in
-        make_cc md (Dyn.of_output v)
-    end
+  let primitive ~info (f:'a -> 'b Input.t) (x:'a t) =
+    let id = Id.mint () in
+    let v_meta =
+      Current_incr.of_cc begin
+        Current_incr.read x.v @@ function
+        | Error _ as e -> Current_incr.write (e, None)
+        | Ok y ->
+          let input = f y in
+          Current_incr.read (Input.get input) @@ fun (v, job) ->
+          Current_incr.write (with_id id v, job)
+      end
+    in
+    let v = Current_incr.map fst v_meta in
+    let meta = Current_incr.map snd v_meta in
+    node ~id (Primitive { x = Term x; info; meta }) v
 
   module Syntax = struct
     let (let**) x f info = bind ~info f x
 
-    let (let>) x f info = bind_input ~info f x
+    let (let>) x f info = primitive ~info f x
     let (and>) = pair
 
     let (let*) x f = bind f x
@@ -189,56 +145,59 @@ module Make (Input : S.INPUT) = struct
     | Error (`Same (ls, e)) -> fail (Fmt.strf "%a failed: %s" Fmt.(list ~sep:(unit ", ") string) ls e)
     | Error (`Diff ls) -> fail (Fmt.strf "%a failed" Fmt.(list ~sep:(unit ", ") string) ls)
 
-  let option_map (f : 'a t -> 'b t) (input : 'a option t) : 'b option t =
-    let env = !bind_context in
-    Current_incr.of_cc begin
-      Current_incr.read input @@ fun input ->
-      match Dyn.run input.fn with
+  (* A node with the constant value [v], but that depends on [old]. *)
+  let replace old v =
+    {
+      id = Id.mint ();
+      v = Current_incr.const v;
+      ty = Constant None;
+      bind = Some (Term old)
+    }
+
+  let option_map (type a b) (f : a t -> b t) (input : a option t) : b option t =
+    let results =
+      input.v |> Current_incr.map @@ function
       | Error _ as r ->
         (* Not ready; use static version. *)
-        Current_incr.read (f (option_input ~label:`Blocked input.md r)) @@ fun f ->
-        let md = An.option_map ~env ~f:f.md input.md in
-        make_cc md (Dyn.of_output r)
+        let output = f (option_input input r) in
+        replace output r
       | Ok None ->
         (* Show what would have been done. *)
-        let r = Error (`Msg "(none)") in
-        Current_incr.read (f (option_input input.md ~label:`Not_selected r)) @@ fun f ->
-        let md = An.option_map ~env ~f:f.md input.md in
-        make_cc md (Dyn.of_output (Ok None))
+        let no_item = Error (Id.mint (), `Active `Ready) in
+        let output = f (option_input input no_item) in
+        replace output (Ok None)
       | Ok (Some item) ->
-        Current_incr.read (f (option_input input.md ~label:`Selected (Ok item))) @@ fun (results : 'b node) ->
-        let fn = Dyn.map Option.some results.fn in
-        Current_incr.write { fn; md = An.option_map ~env ~f:results.md input.md }
-    end
+        let output = f (option_input input (Ok item)) in
+        { output with v = Current_incr.map (Result.map Option.some) output.v }
+    in
+    let output = Current_incr.map (fun x -> Term x) results in
+    node (Option_map { item = Term input; output }) (join results)
 
   let list_map ~pp (f : 'a t -> 'b t) (input : 'a list t) =
-    let env = !bind_context in
-    Current_incr.of_cc begin
-      Current_incr.read input @@ fun input ->
-      match Dyn.run input.fn with
+    let results =
+      input.v |> Current_incr.map @@ function
       | Error _ as r ->
         (* Not ready; use static version of map. *)
-        Current_incr.read (f (map_input input.md ~label:(Error `Blocked) r)) @@ fun f ->
-        let md = An.list_map ~env ~f:f.md input.md in
-        make_cc md (Dyn.of_output r)
+        let output = f (map_input input ~label:(Error `Blocked) r) in
+        replace output r
       | Ok [] ->
         (* Empty list; show what would have been done. *)
-        let no_items = Error (`Msg "(empty list)") in
-        Current_incr.read (f (map_input input.md ~label:(Error `Empty_list) no_items)) @@ fun f ->
-        let md = An.list_map ~env ~f:f.md input.md in
-        make_cc md (Dyn.return [])
+        let no_items = Error (Id.mint (), `Active `Ready) in
+        let output = f (map_input input ~label:(Error `Empty_list) no_items) in
+        replace output (Ok [])
       | Ok items ->
         (* Ready. Expand inputs. *)
         let rec aux = function
           | [] -> return []
           | x :: xs ->
-            let+ y = f (map_input ~label:(Ok (Fmt.to_to_string pp x)) input.md (Ok x))
+            let+ y = f (map_input ~label:(Ok (Fmt.to_to_string pp x)) input (Ok x))
             and+ ys = aux xs in
             y :: ys
         in
-        Current_incr.read (aux items) @@ fun results ->
-        Current_incr.write { results with md = An.list_map ~env ~f:results.md input.md }
-    end
+        aux items
+    in
+    let output = Current_incr.map (fun x -> Term x) results in
+    node (List_map { items = Term input; output }) (join results)
 
   let list_iter ~pp f xs =
     let+ (_ : unit list) = list_map ~pp f xs in
@@ -256,39 +215,31 @@ module Make (Input : S.INPUT) = struct
     | Some x -> let+ y = x in Some y
 
   let gate ~on t =
-    let env = !bind_context in
-    Current_incr.of_cc begin
-      Current_incr.read t @@ fun t ->
-      Current_incr.read on @@ fun on ->
-      let md = An.gate ~env ~on:on.md t.md in
-      let fn =
-        Dyn.bind on.fn @@ fun () ->
-        t.fn
-      in
-      make_cc md fn
+    node (Gate_on { ctrl = Term on; value = Term t }) @@ Current_incr.of_cc begin
+      Current_incr.read t.v @@ fun t ->
+      Current_incr.read on.v @@ fun on ->
+      Current_incr.write @@ Dyn.bind on (fun () -> t)
     end
 
+  let of_output x =
+    let id = Id.mint () in
+    node ~id (Constant None) @@ Current_incr.const (with_id id x)
+
   module Executor = struct
-    let run (f : unit -> 'a t) =
-      try
-        Current_incr.of_cc begin
-          Current_incr.read (f ()) @@ fun { md; fn } ->
-          Current_incr.write (Dyn.run fn, md)
-        end
-      with ex ->
-        let msg = Printexc.to_string ex in
-        let fn = Dyn.fail msg in
-        let md = An.fail ~env:None msg in
-        Current_incr.const (Dyn.run fn, md)
+    let run (t : 'a t) = Current_incr.map Dyn.run t.v
   end
 
   module Analysis = struct
-    include An
+    include Analysis.Make(Input)
 
-    let get t =
-      Current_incr.of_cc begin
-        Current_incr.read t @@ fun t ->
-        make_cc t.md @@ Dyn.return t.md
-      end
+    (* This is a bit of a hack. *)
+    let job_id t =
+      let rec aux (Term t) =
+        match t.ty with
+        | Primitive p -> p.meta
+        | Map t -> aux t
+        | _ -> failwith "job_id: this is not a job term!"
+      in
+      node (Constant None) @@ Current_incr.map Result.ok @@ aux (Term t)
   end
 end

--- a/lib_term/current_term.mli
+++ b/lib_term/current_term.mli
@@ -12,6 +12,5 @@ module Make (Input : S.INPUT) : sig
     type job_id := Input.job_id
 
   module Executor : S.EXECUTOR with
-    type 'a term := 'a t and
-    type analysis := Analysis.t
+    type 'a term := 'a t
 end

--- a/lib_term/dyn.mli
+++ b/lib_term/dyn.mli
@@ -1,16 +1,17 @@
 (* The runtime CI monad, similar to DataKitCI.
    Nothing interesting here. *)
 
-type +'a t
+type 'a t = ('a, Id.t * [`Active of Output.active | `Msg of string]) result
+(** For the error case, the `Id.t` indicates the component which is active or failed.
+    This is used to show downstream components as blocked. *)
 
-val active : Output.active -> 'a t
+val active : id:Id.t -> Output.active -> 'a t
 val return : 'a -> 'a t
-val fail : string -> 'a t
+val fail : id:Id.t -> string -> 'a t
 val state : 'a t -> ('a, [`Active of Output.active | `Msg of string]) result t
 val catch : 'a t -> 'a S.or_error t
-val of_output : 'a Output.t -> 'a t
-val map : ('a -> 'b) -> 'a t -> 'b t
-val map_error : (string -> string) -> 'a t -> 'a t
+val map : id:Id.t -> ('a -> 'b) -> 'a t -> 'b t
+val map_error : id:Id.t -> (string -> string) -> 'a t -> 'a t
 val bind : 'a t -> ('a -> 'b t) -> 'b t
 val pair : 'a t -> 'b t -> ('a * 'b) t
 val pp : 'a Fmt.t -> 'a t Fmt.t

--- a/lib_term/id.ml
+++ b/lib_term/id.ml
@@ -5,6 +5,7 @@ end
 
 type t = Key.t
 let mint () = object end
+let equal = (=)
 
 module Set = Set.Make(Key)
 module Map = Map.Make(Key)

--- a/lib_term/id.ml
+++ b/lib_term/id.ml
@@ -1,0 +1,10 @@
+module Key = struct
+  type t = < >
+  let compare = compare
+end
+
+type t = Key.t
+let mint () = object end
+
+module Set = Set.Make(Key)
+module Map = Map.Make(Key)

--- a/lib_term/id.mli
+++ b/lib_term/id.mli
@@ -1,0 +1,5 @@
+type t
+val mint : unit -> t
+
+module Set : Set.S with type elt = t
+module Map : Map.S with type key = t

--- a/lib_term/id.mli
+++ b/lib_term/id.mli
@@ -1,5 +1,7 @@
 type t
+
 val mint : unit -> t
+val equal : t -> t -> bool
 
 module Set : Set.S with type elt = t
 module Map : Map.S with type key = t

--- a/lib_term/node.ml
+++ b/lib_term/node.ml
@@ -1,0 +1,24 @@
+module Make (Meta : sig type job_id end) = struct
+  type 'a t = {
+    id : Id.t;
+    bind : bind_context;
+    ty : metadata_ty;
+    v : 'a Dyn.t Current_incr.t;
+  }
+  and generic = Term : 'a t -> generic
+  and bind_context = generic option
+  and metadata_ty =
+    | Constant of string option
+    | Map_input of { source : generic; info : (string, [`Blocked | `Empty_list]) result }
+    | Opt_input of { source : generic }
+    | State of { source : generic; hidden : bool }
+    | Catch of { source : generic; hidden : bool }
+    | Map of generic
+    | Bind_in of generic * string
+    | Bind_out of generic Current_incr.t
+    | Primitive of {x : generic; info : string; meta : Meta.job_id option Current_incr.t }
+    | Pair of generic * generic
+    | Gate_on of { ctrl : generic; value : generic }
+    | List_map of { items : generic; output : generic Current_incr.t }
+    | Option_map of { item : generic; output : generic Current_incr.t }
+end

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -150,8 +150,7 @@ let handle_request ~engine ~webhooks _conn request body =
       Style.get ()
     | `GET, ["pipeline.svg"] ->
       begin
-        let state = Current.Engine.state engine in
-        render_svg state.Current.Engine.analysis >>= function
+        render_svg (Current.Engine.pipeline engine) >>= function
         | Ok body ->
           let headers = Cohttp.Header.init_with "Content-Type" "image/svg+xml" in
           Server.respond_string ~status:`OK ~headers ~body ()
@@ -167,7 +166,7 @@ let handle_request ~engine ~webhooks _conn request body =
       let body = Jobs.render () in
       Server.respond_string ~status:`OK ~body ()
     | `GET, ["metrics"] ->
-      Current.Engine.(update_metrics (state engine));
+      Current.Engine.(update_metrics engine);
       let data = Prometheus.CollectorRegistry.(collect default) in
       let body = Fmt.to_to_string Prometheus_app.TextFormat_0_0_4.output data in
       let headers = Cohttp.Header.init_with "Content-Type" "text/plain; version=0.0.4" in

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -56,7 +56,7 @@ let settings config =
 
 let dashboard engine =
   let config = Current.Engine.config engine in
-  let { Current.Engine.value; analysis = _; jobs = _ } = Current.Engine.state engine in
+  let { Current.Engine.value; jobs = _ } = Current.Engine.state engine in
   template [
     div [
       object_ ~a:[a_data "/pipeline.svg"] [txt "Pipeline diagram"];

--- a/test/driver.mli
+++ b/test/driver.mli
@@ -2,6 +2,7 @@ val init_logging : unit -> unit
 
 val test :
   ?config:Current.Config.t ->
+  ?final_stats:Current_term.S.stats ->
   name:string ->
   (unit -> unit Current.t) ->
   (int -> unit) ->

--- a/test/expected/option-none.1.dot
+++ b/test/expected/option-none.1.dot
@@ -1,17 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n3 [label="analyse",fillcolor="#d3d3d3",style="filled"]
-  subgraph cluster_0 {
-  style="dotted"n6 [label="lint",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n7 [label="analyse",fillcolor="#d3d3d3",style="filled"]
+  subgraph cluster_4 {
+  style="dotted"n13 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
-  n3 -> n6
-  n4 -> n3
-  n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n7 -> n13
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/option-none.2.dot
+++ b/test/expected/option-none.2.dot
@@ -1,17 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n6 [label="head",fillcolor="#90ee90",style="filled"]
-  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n4 [label="analyse",fillcolor="#90ee90",style="filled"]
-  subgraph cluster_0 {
-  style="dotted"n7 [label="lint",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="analyse",fillcolor="#90ee90",style="filled"]
+  subgraph cluster_4 {
+  style="dotted"n13 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
-  n4 -> n7
-  n5 -> n4
-  n6 -> n5
-  n1 -> n6
-  n2 -> n1
+  n7 -> n13
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/option-some.1.dot
+++ b/test/expected/option-some.1.dot
@@ -1,17 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n3 [label="analyse",fillcolor="#d3d3d3",style="filled"]
-  subgraph cluster_0 {
-  style="dotted"n6 [label="lint",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n7 [label="analyse",fillcolor="#d3d3d3",style="filled"]
+  subgraph cluster_4 {
+  style="dotted"n13 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
-  n3 -> n6
-  n4 -> n3
-  n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n7 -> n13
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/option-some.2.dot
+++ b/test/expected/option-some.2.dot
@@ -1,17 +1,17 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n6 [label="head",fillcolor="#90ee90",style="filled"]
-  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n4 [label="analyse",fillcolor="#90ee90",style="filled"]
-  subgraph cluster_0 {
-  style="dotted"n8 [label="lint",fillcolor="#90ee90",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="analyse",fillcolor="#90ee90",style="filled"]
+  subgraph cluster_4 {
+  style="dotted"n12 [label="lint",fillcolor="#90ee90",style="filled"]
   }
-  n4 -> n8
-  n5 -> n4
-  n6 -> n5
-  n1 -> n6
-  n2 -> n1
+  n7 -> n12
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/pair.1.dot
+++ b/test/expected/pair.1.dot
@@ -1,19 +1,19 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="Blocked-3",fillcolor="#d3d3d3",style="filled"]
-  n4 [label="state",fillcolor="#90ee90",style="filled"]
-  n8 [label="Blocked-2",fillcolor="#d3d3d3",style="filled"]
-  n7 [label="state",fillcolor="#90ee90",style="filled"]
-  n12 [label="Blocked-1",fillcolor="#d3d3d3",style="filled"]
-  n11 [label="state",fillcolor="#90ee90",style="filled"]
-  n12 -> n11
-  n1 -> n12
-  n8 -> n7
-  n1 -> n8
-  n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="Blocked-3",fillcolor="#d3d3d3",style="filled"]
+  n8 [label="state",fillcolor="#90ee90",style="filled"]
+  n16 [label="Blocked-2",fillcolor="#d3d3d3",style="filled"]
+  n15 [label="state",fillcolor="#90ee90",style="filled"]
+  n24 [label="Blocked-1",fillcolor="#d3d3d3",style="filled"]
+  n23 [label="state",fillcolor="#90ee90",style="filled"]
+  n24 -> n23
+  n2 -> n24
+  n16 -> n15
+  n2 -> n16
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/state.1.dot
+++ b/test/expected/state.1.dot
@@ -3,7 +3,7 @@ digraph pipeline {
   rankdir=LR
   n3 [label="current-test",fillcolor="#90ee90",style="filled"]
   n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n1 [label="set-status",fillcolor="#90ee90",style="filled"]
-  n2 -> n1
+  n5 [label="set-status",fillcolor="#90ee90",style="filled"]
+  n2 -> n5
   n3 -> n2
   }

--- a/test/expected/v1.1.dot
+++ b/test/expected/v1.1.dot
@@ -1,15 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n3 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n0 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n3 -> n0
-  n4 -> n3
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n4 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n1 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n4 -> n1
   n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
   }

--- a/test/expected/v1.2.dot
+++ b/test/expected/v1.2.dot
@@ -1,15 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n0 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n3 -> n0
-  n4 -> n3
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n4 [label="build",fillcolor="#90ee90",style="filled"]
+  n1 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n4 -> n1
   n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
   }

--- a/test/expected/v1.3.dot
+++ b/test/expected/v1.3.dot
@@ -1,15 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n0 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n3 -> n0
-  n4 -> n3
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n4 [label="build",fillcolor="#90ee90",style="filled"]
+  n1 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n4 -> n1
   n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
   }

--- a/test/expected/v1c.1.dot
+++ b/test/expected/v1c.1.dot
@@ -1,15 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n3 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n0 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n3 -> n0
-  n4 -> n3
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n4 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n1 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n4 -> n1
   n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
   }

--- a/test/expected/v1c.2.dot
+++ b/test/expected/v1c.2.dot
@@ -1,15 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n0 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n3 -> n0
-  n4 -> n3
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n4 [label="build",fillcolor="#90ee90",style="filled"]
+  n1 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n4 -> n1
   n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
   }

--- a/test/expected/v1c.3.dot
+++ b/test/expected/v1c.3.dot
@@ -1,15 +1,15 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n3 [label="build",fillcolor="#90ee90",style="filled"]
-  n0 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Cancelled"]
-  n3 -> n0
-  n4 -> n3
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n4 [label="build",fillcolor="#90ee90",style="filled"]
+  n1 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Cancelled"]
+  n4 -> n1
   n5 -> n4
-  n1 -> n5
-  n2 -> n1
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
   }

--- a/test/expected/v2.1.dot
+++ b/test/expected/v2.1.dot
@@ -1,20 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n5 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n4 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n0 [label="docker push foo/bar",fillcolor="#d3d3d3",style="filled"]
-  n3 -> n0
-  n5 -> n3
-  n4 -> n3 [style="dashed"]
-  n5 -> n4
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n8 [label="head",fillcolor="#90ee90",style="filled"]
+  n7 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n6 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n5 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n4 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n1 [label="docker push foo/bar",fillcolor="#d3d3d3",style="filled"]
+  n4 -> n1
+  n6 -> n4
+  n5 -> n4 [style="dashed"]
   n6 -> n5
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n2 -> n8
+  n3 -> n2
   }

--- a/test/expected/v2.2.dot
+++ b/test/expected/v2.2.dot
@@ -1,20 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n5 [label="build",fillcolor="#90ee90",style="filled"]
-  n4 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n0 [label="docker push foo/bar",fillcolor="#d3d3d3",style="filled"]
-  n3 -> n0
-  n5 -> n3
-  n4 -> n3 [style="dashed"]
-  n5 -> n4
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n8 [label="head",fillcolor="#90ee90",style="filled"]
+  n7 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n6 [label="build",fillcolor="#90ee90",style="filled"]
+  n5 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n4 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n1 [label="docker push foo/bar",fillcolor="#d3d3d3",style="filled"]
+  n4 -> n1
+  n6 -> n4
+  n5 -> n4 [style="dashed"]
   n6 -> n5
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n2 -> n8
+  n3 -> n2
   }

--- a/test/expected/v2.3.dot
+++ b/test/expected/v2.3.dot
@@ -1,20 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n5 [label="build",fillcolor="#90ee90",style="filled"]
-  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
-  n0 [label="docker push foo/bar",fillcolor="#ffff00",style="filled"]
-  n3 -> n0
-  n5 -> n3
-  n4 -> n3 [style="dashed"]
-  n5 -> n4
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n8 [label="head",fillcolor="#90ee90",style="filled"]
+  n7 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n6 [label="build",fillcolor="#90ee90",style="filled"]
+  n5 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n4 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  n1 [label="docker push foo/bar",fillcolor="#ffff00",style="filled"]
+  n4 -> n1
+  n6 -> n4
+  n5 -> n4 [style="dashed"]
   n6 -> n5
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n2 -> n8
+  n3 -> n2
   }

--- a/test/expected/v2.4.dot
+++ b/test/expected/v2.4.dot
@@ -1,20 +1,20 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n5 [label="build",fillcolor="#90ee90",style="filled"]
-  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
-  n0 [label="docker push foo/bar",fillcolor="#90ee90",style="filled"]
-  n3 -> n0
-  n5 -> n3
-  n4 -> n3 [style="dashed"]
-  n5 -> n4
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n8 [label="head",fillcolor="#90ee90",style="filled"]
+  n7 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n6 [label="build",fillcolor="#90ee90",style="filled"]
+  n5 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n4 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  n1 [label="docker push foo/bar",fillcolor="#90ee90",style="filled"]
+  n4 -> n1
+  n6 -> n4
+  n5 -> n4 [style="dashed"]
   n6 -> n5
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n2 -> n8
+  n3 -> n2
   }

--- a/test/expected/v3.1.dot
+++ b/test/expected/v3.1.dot
@@ -1,44 +1,44 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n11 [label="head",fillcolor="#90ee90",style="filled"]
-  n10 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n9 [label="build-win",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n13 [label="build-mac",fillcolor="#d3d3d3",style="filled"]
-  n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n15 [label="build-lin",fillcolor="#d3d3d3",style="filled"]
-  n14 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n4 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
-  n17 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n16 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
-  n19 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n18 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
-  n19 -> n18
-  n15 -> n19
-  n14 -> n19 [style="dashed"]
-  n12 -> n19 [style="dashed"]
-  n8 -> n19 [style="dashed"]
-  n17 -> n16
-  n13 -> n17
-  n14 -> n17 [style="dashed"]
-  n12 -> n17 [style="dashed"]
-  n8 -> n17 [style="dashed"]
-  n5 -> n4
-  n9 -> n5
-  n14 -> n5 [style="dashed"]
-  n12 -> n5 [style="dashed"]
-  n8 -> n5 [style="dashed"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n16 [label="head",fillcolor="#90ee90",style="filled"]
+  n15 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n14 [label="build-win",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n18 [label="build-mac",fillcolor="#d3d3d3",style="filled"]
+  n17 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n20 [label="build-lin",fillcolor="#d3d3d3",style="filled"]
+  n19 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n8 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n7 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
+  n22 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n21 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n24 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n23 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n24 -> n23
+  n20 -> n24
+  n19 -> n24 [style="dashed"]
+  n17 -> n24 [style="dashed"]
+  n13 -> n24 [style="dashed"]
+  n22 -> n21
+  n18 -> n22
+  n19 -> n22 [style="dashed"]
+  n17 -> n22 [style="dashed"]
+  n13 -> n22 [style="dashed"]
+  n8 -> n7
+  n14 -> n8
+  n19 -> n8 [style="dashed"]
+  n17 -> n8 [style="dashed"]
+  n13 -> n8 [style="dashed"]
+  n20 -> n19
+  n15 -> n20
+  n18 -> n17
+  n15 -> n18
+  n14 -> n13
   n15 -> n14
-  n10 -> n15
-  n13 -> n12
-  n10 -> n13
-  n9 -> n8
-  n10 -> n9
-  n11 -> n10
-  n1 -> n11
-  n2 -> n1
+  n16 -> n15
+  n2 -> n16
+  n3 -> n2
   }

--- a/test/expected/v3.2.dot
+++ b/test/expected/v3.2.dot
@@ -1,44 +1,44 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n11 [label="head",fillcolor="#90ee90",style="filled"]
-  n10 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n9 [label="build-win",fillcolor="#90ee90",style="filled"]
-  n8 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n13 [label="build-mac",fillcolor="#90ee90",style="filled"]
-  n12 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n15 [label="build-lin",fillcolor="#90ee90",style="filled"]
-  n14 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n4 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
-  n17 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n16 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
-  n19 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  n18 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
-  n19 -> n18
-  n15 -> n19
-  n14 -> n19 [style="dashed"]
-  n12 -> n19 [style="dashed"]
-  n8 -> n19 [style="dashed"]
-  n17 -> n16
-  n13 -> n17
-  n14 -> n17 [style="dashed"]
-  n12 -> n17 [style="dashed"]
-  n8 -> n17 [style="dashed"]
-  n5 -> n4
-  n9 -> n5
-  n14 -> n5 [style="dashed"]
-  n12 -> n5 [style="dashed"]
-  n8 -> n5 [style="dashed"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n16 [label="head",fillcolor="#90ee90",style="filled"]
+  n15 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n14 [label="build-win",fillcolor="#90ee90",style="filled"]
+  n13 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n18 [label="build-mac",fillcolor="#90ee90",style="filled"]
+  n17 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n20 [label="build-lin",fillcolor="#90ee90",style="filled"]
+  n19 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n8 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n7 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
+  n22 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n21 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n24 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n23 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n24 -> n23
+  n20 -> n24
+  n19 -> n24 [style="dashed"]
+  n17 -> n24 [style="dashed"]
+  n13 -> n24 [style="dashed"]
+  n22 -> n21
+  n18 -> n22
+  n19 -> n22 [style="dashed"]
+  n17 -> n22 [style="dashed"]
+  n13 -> n22 [style="dashed"]
+  n8 -> n7
+  n14 -> n8
+  n19 -> n8 [style="dashed"]
+  n17 -> n8 [style="dashed"]
+  n13 -> n8 [style="dashed"]
+  n20 -> n19
+  n15 -> n20
+  n18 -> n17
+  n15 -> n18
+  n14 -> n13
   n15 -> n14
-  n10 -> n15
-  n13 -> n12
-  n10 -> n13
-  n9 -> n8
-  n10 -> n9
-  n11 -> n10
-  n1 -> n11
-  n2 -> n1
+  n16 -> n15
+  n2 -> n16
+  n3 -> n2
   }

--- a/test/expected/v3.3.dot
+++ b/test/expected/v3.3.dot
@@ -1,44 +1,44 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n11 [label="head",fillcolor="#90ee90",style="filled"]
-  n10 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n9 [label="build-win",fillcolor="#90ee90",style="filled"]
-  n8 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Missing DLL"]
-  n13 [label="build-mac",fillcolor="#90ee90",style="filled"]
-  n12 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n15 [label="build-lin",fillcolor="#90ee90",style="filled"]
-  n14 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n5 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
-  n4 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
-  n17 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
-  n16 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
-  n19 [label="",fillcolor="#ff4500",style="filled",shape="circle",tooltip="Missing DLL"]
-  n18 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
-  n19 -> n18
-  n15 -> n19
-  n14 -> n19 [style="dashed"]
-  n12 -> n19 [style="dashed"]
-  n8 -> n19 [style="dashed"]
-  n17 -> n16
-  n13 -> n17
-  n14 -> n17 [style="dashed"]
-  n12 -> n17 [style="dashed"]
-  n8 -> n17 [style="dashed"]
-  n5 -> n4
-  n9 -> n5
-  n14 -> n5 [style="dashed"]
-  n12 -> n5 [style="dashed"]
-  n8 -> n5 [style="dashed"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n16 [label="head",fillcolor="#90ee90",style="filled"]
+  n15 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n14 [label="build-win",fillcolor="#90ee90",style="filled"]
+  n13 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Missing DLL"]
+  n18 [label="build-mac",fillcolor="#90ee90",style="filled"]
+  n17 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n20 [label="build-lin",fillcolor="#90ee90",style="filled"]
+  n19 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n8 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n7 [label="docker push foo/win",fillcolor="#d3d3d3",style="filled"]
+  n22 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n21 [label="docker push foo/mac",fillcolor="#d3d3d3",style="filled"]
+  n24 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  n23 [label="docker push foo/lin",fillcolor="#d3d3d3",style="filled"]
+  n24 -> n23
+  n20 -> n24
+  n19 -> n24 [style="dashed"]
+  n17 -> n24 [style="dashed"]
+  n13 -> n24 [style="dashed"]
+  n22 -> n21
+  n18 -> n22
+  n19 -> n22 [style="dashed"]
+  n17 -> n22 [style="dashed"]
+  n13 -> n22 [style="dashed"]
+  n8 -> n7
+  n14 -> n8
+  n19 -> n8 [style="dashed"]
+  n17 -> n8 [style="dashed"]
+  n13 -> n8 [style="dashed"]
+  n20 -> n19
+  n15 -> n20
+  n18 -> n17
+  n15 -> n18
+  n14 -> n13
   n15 -> n14
-  n10 -> n15
-  n13 -> n12
-  n10 -> n13
-  n9 -> n8
-  n10 -> n9
-  n11 -> n10
-  n1 -> n11
-  n2 -> n1
+  n16 -> n15
+  n2 -> n16
+  n3 -> n2
   }

--- a/test/expected/v4.1.dot
+++ b/test/expected/v4.1.dot
@@ -1,13 +1,13 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n4 [label="head",fillcolor="#90ee90",style="filled"]
-  n3 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n0 [label="custom-build",fillcolor="#d3d3d3",style="filled"]
-  n3 -> n0
-  n4 -> n3
-  n1 -> n4
-  n2 -> n1
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n5 [label="custom-build",fillcolor="#d3d3d3",style="filled"]
+  n6 -> n5
+  n7 -> n6
+  n2 -> n7
+  n3 -> n2
   }

--- a/test/expected/v4.2.dot
+++ b/test/expected/v4.2.dot
@@ -3,15 +3,15 @@ digraph pipeline {
   rankdir=LR
   n3 [label="current-test",fillcolor="#90ee90",style="filled"]
   n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="custom-build",fillcolor="#90ee90",style="filled"]
-  n6 [label="build",fillcolor="#90ee90",style="filled"]
-  n0 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n6 -> n0
-  n1 -> n6
-  n4 -> n1
-  n5 -> n4
-  n2 -> n5
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="custom-build",fillcolor="#90ee90",style="filled"]
+  n8 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n8 -> n4
+  n5 -> n8
+  n6 -> n5
+  n7 -> n6
+  n2 -> n7
   n3 -> n2
   }

--- a/test/expected/v4.3.dot
+++ b/test/expected/v4.3.dot
@@ -3,15 +3,15 @@ digraph pipeline {
   rankdir=LR
   n3 [label="current-test",fillcolor="#90ee90",style="filled"]
   n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n5 [label="head",fillcolor="#90ee90",style="filled"]
-  n4 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n1 [label="custom-build",fillcolor="#90ee90",style="filled"]
-  n6 [label="build",fillcolor="#90ee90",style="filled"]
-  n0 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Failed"]
-  n6 -> n0
-  n1 -> n6
-  n4 -> n1
-  n5 -> n4
-  n2 -> n5
+  n7 [label="head",fillcolor="#90ee90",style="filled"]
+  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n5 [label="custom-build",fillcolor="#90ee90",style="filled"]
+  n8 [label="build",fillcolor="#90ee90",style="filled"]
+  n4 [label="docker run make test",fillcolor="#ff4500",style="filled",tooltip="Failed"]
+  n8 -> n4
+  n5 -> n8
+  n6 -> n5
+  n7 -> n6
+  n2 -> n7
   n3 -> n2
   }

--- a/test/expected/v5.1.dot
+++ b/test/expected/v5.1.dot
@@ -1,30 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n5 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n4 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_0 {
-  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n7 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n6 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
+  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  subgraph cluster_4 {
+  n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n10 -> n9
-  n11 -> n10
-  n12 -> n11
-  n3 -> n12
-  n8 -> n3
-  n4 -> n3 [style="dashed"]
-  n6 -> n8
-  n5 -> n4
-  n6 -> n5
+  n13 -> n12
+  n14 -> n13
+  n15 -> n14
+  n5 -> n15
+  n10 -> n5
+  n6 -> n5 [style="dashed"]
+  n8 -> n10
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/v5.2.dot
+++ b/test/expected/v5.2.dot
@@ -1,30 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n5 [label="build",fillcolor="#90ee90",style="filled"]
-  n4 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_0 {
-  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="build",fillcolor="#90ee90",style="filled"]
+  n6 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  subgraph cluster_4 {
+  n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n10 -> n9
-  n11 -> n10
-  n12 -> n11
-  n3 -> n12
-  n8 -> n3
-  n4 -> n3 [style="dashed"]
-  n6 -> n8
-  n5 -> n4
-  n6 -> n5
+  n13 -> n12
+  n14 -> n13
+  n15 -> n14
+  n5 -> n15
+  n10 -> n5
+  n6 -> n5 [style="dashed"]
+  n8 -> n10
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/v5.3.dot
+++ b/test/expected/v5.3.dot
@@ -1,38 +1,38 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n5 [label="build",fillcolor="#90ee90",style="filled"]
-  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
-  subgraph cluster_0 {
-  n13 [label="example.org/bar#222",fillcolor="#90ee90",style="filled"]
-  n12 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n11 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n10 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n17 [label="example.org/foo#111",fillcolor="#90ee90",style="filled"]
-  n16 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n15 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n14 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="build",fillcolor="#90ee90",style="filled"]
+  n6 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n5 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  subgraph cluster_4 {
+  n19 [label="example.org/bar#222",fillcolor="#90ee90",style="filled"]
+  n18 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n17 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n16 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n23 [label="example.org/foo#111",fillcolor="#90ee90",style="filled"]
+  n22 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n21 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n20 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n15 -> n14
-  n16 -> n15
+  n21 -> n20
+  n22 -> n21
+  n23 -> n22
+  n5 -> n23
   n17 -> n16
-  n3 -> n17
-  n11 -> n10
-  n12 -> n11
-  n13 -> n12
-  n3 -> n13
-  n8 -> n3
-  n4 -> n3 [style="dashed"]
-  n6 -> n8
-  n5 -> n4
-  n6 -> n5
+  n18 -> n17
+  n19 -> n18
+  n5 -> n19
+  n10 -> n5
+  n6 -> n5 [style="dashed"]
+  n8 -> n10
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/v5n.1.dot
+++ b/test/expected/v5n.1.dot
@@ -1,30 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#ffa500",style="filled"]
-  n5 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n4 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
-  n8 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_0 {
-  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n7 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n6 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n10 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
+  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  subgraph cluster_4 {
+  n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n10 -> n9
-  n11 -> n10
-  n12 -> n11
-  n3 -> n12
-  n8 -> n3
-  n4 -> n3 [style="dashed"]
-  n6 -> n8
-  n5 -> n4
-  n6 -> n5
+  n13 -> n12
+  n14 -> n13
+  n15 -> n14
+  n5 -> n15
+  n10 -> n5
+  n6 -> n5 [style="dashed"]
+  n8 -> n10
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/v5n.2.dot
+++ b/test/expected/v5n.2.dot
@@ -1,30 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n5 [label="build",fillcolor="#90ee90",style="filled"]
-  n4 [label="docker run make test",fillcolor="#ffa500",style="filled"]
-  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n3 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_0 {
-  n12 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
-  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="build",fillcolor="#90ee90",style="filled"]
+  n6 [label="docker run make test",fillcolor="#ffa500",style="filled"]
+  n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
+  subgraph cluster_4 {
+  n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
+  n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n10 -> n9
-  n11 -> n10
-  n12 -> n11
-  n3 -> n12
-  n8 -> n3
-  n4 -> n3 [style="dashed"]
-  n6 -> n8
-  n5 -> n4
-  n6 -> n5
+  n13 -> n12
+  n14 -> n13
+  n15 -> n14
+  n5 -> n15
+  n10 -> n5
+  n6 -> n5 [style="dashed"]
+  n8 -> n10
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }

--- a/test/expected/v5n.3.dot
+++ b/test/expected/v5n.3.dot
@@ -1,30 +1,30 @@
 digraph pipeline {
   node [shape="box"]
   rankdir=LR
-  n2 [label="current-test",fillcolor="#90ee90",style="filled"]
-  n1 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
-  n7 [label="head",fillcolor="#90ee90",style="filled"]
-  n6 [label="fetch",fillcolor="#90ee90",style="filled"]
-  n5 [label="build",fillcolor="#90ee90",style="filled"]
-  n4 [label="docker run make test",fillcolor="#90ee90",style="filled"]
-  n8 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
-  n3 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
-  subgraph cluster_0 {
-  n12 [label="(empty list)",fillcolor="#d3d3d3",style="filled"]
-  n11 [label="fetch",fillcolor="#d3d3d3",style="filled"]
-  n10 [label="build",fillcolor="#d3d3d3",style="filled"]
-  n9 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n9 [label="head",fillcolor="#90ee90",style="filled"]
+  n8 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="build",fillcolor="#90ee90",style="filled"]
+  n6 [label="docker run make test",fillcolor="#90ee90",style="filled"]
+  n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
+  n5 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
+  subgraph cluster_4 {
+  n15 [label="(empty list)",fillcolor="#d3d3d3",style="filled"]
+  n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
+  n13 [label="build",fillcolor="#d3d3d3",style="filled"]
+  n12 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   }
-  n10 -> n9
-  n11 -> n10
-  n12 -> n11
-  n3 -> n12
-  n8 -> n3
-  n4 -> n3 [style="dashed"]
-  n6 -> n8
-  n5 -> n4
-  n6 -> n5
+  n13 -> n12
+  n14 -> n13
+  n15 -> n14
+  n5 -> n15
+  n10 -> n5
+  n6 -> n5 [style="dashed"]
+  n8 -> n10
   n7 -> n6
-  n1 -> n7
-  n2 -> n1
+  n8 -> n7
+  n9 -> n8
+  n2 -> n9
+  n3 -> n2
   }


### PR DESCRIPTION
Before, a term was a changeable value containing both the dynamic and "static" analysis results. The static result included a unique ID that changed whenever the result changed. This meant that any change had to propagate to all later stages because the static analysis graph had changed, even though the values might be the same.

In particular, this prevented optimising `list_map` by only recomputing the values that changed, since every result needed to link back to the latest version of the map input.

Now, a node has a fixed static part and a changeable dynamic part. Also, the static part really is static now. Previously it contained anything that should appear on the diagrams, including (for example) the current colour of each box and the link to the current job.

Internally, we now also track where active and error reports come from. This means that we can now show blocked actions on the diagrams without duplicating the logic: an item is blocked if it's active or an error and not the source of that state.

One result of this is that you no longer get a snapshot of the static analysis. Instead, operations such as generating the dot graph or calculating the state metrics are done on the live pipeline (which isn't a problem).

Another change is that simplification of the analysis graph is now done when the graph is generated. For example, we previously created graph nodes for failed map operations but not for successful ones. Since the graph is now static, we always create a node for maps, but skip them at rendering time if the operation succeeded.

Although the analysis part of a node is now static, it can still contain incremental parts. For example, `bind`'s static type contains an incremental part with the pipeline it currently expands to. In fact, bind is now represented as two nodes: one with the operation name that goes before the expanded pipeline, and one afterwards (not shown) to hold the result.

This should unblock #148.