### PR TITLE
Rename Input to Primitive and simplify the API

### DIFF
--- a/lib/current.ml
+++ b/lib/current.ml
@@ -26,7 +26,7 @@ class type actions = object
   method rebuild : (unit -> job_id) option
 end
 
-module Input = struct
+module Primitive = struct
   type nonrec job_id = job_id
 
   type 'a t = ('a Current_term.Output.t * job_id option) Current_incr.t
@@ -43,7 +43,7 @@ module Input = struct
     end
 end
 
-include Current_term.Make(Input)
+include Current_term.Make(Primitive)
 
 type 'a term = 'a t
 
@@ -117,7 +117,7 @@ module Engine = struct
       Current_incr.propagate ();
       let t1 = Unix.gettimeofday () in
       Prometheus.Summary.observe Metrics.evaluation_time_seconds (t1 -. t0);
-      (* Release all the old inputs, now we've had a chance to create any replacements. *)
+      (* Release all the old resources, now we've had a chance to create any replacements. *)
       flush_release_queue ();
       let r = Current_incr.observe outcome in
       last_result := {
@@ -125,7 +125,7 @@ module Engine = struct
         jobs = Job.Map.map List.hd !active_jobs;
       };
       trace ~next !last_result >>= fun () ->
-      Log.debug (fun f -> f "Waiting for inputs to change...");
+      Log.debug (fun f -> f "Waiting for an external event...");
       next >>= fun () ->
       Lwt.pause () >>= fun () ->
       Step.advance ();
@@ -213,7 +213,7 @@ module Monitor = struct
     watch : (unit -> unit) -> (unit -> unit Lwt.t) Lwt.t;
     pp : Format.formatter -> unit;
     value : 'a Current_term.Output.t Current_incr.var;
-    mutable ref_count : int;              (* Number of terms using this input *)
+    mutable ref_count : int;              (* Number of terms using this monitor *)
     mutable need_refresh : bool;          (* Update detected after current read started *)
     mutable active : bool;                (* Monitor thread is running *)
     cond : unit Lwt_condition.t;          (* Maybe time to leave the "wait" state *)
@@ -249,7 +249,7 @@ module Monitor = struct
     else if t.need_refresh then get_value ~unwatch t
     else Lwt_condition.wait t.cond >>= fun () -> wait ~unwatch t
 
-  let input t =
+  let get t =
     Current_incr.of_cc begin
       t.ref_count <- t.ref_count + 1;
       Engine.on_disable (fun () ->

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -26,14 +26,12 @@ class type actions = object
   method rebuild : (unit -> job_id) option
 end
 
-module Primitive = struct
-  type nonrec job_id = job_id
+include Current_term.Make(String)
 
-  type 'a t = ('a Current_term.Output.t * job_id option) Current_incr.t
+module Primitive = struct
+  type 'a t = 'a primitive
 
   let const x = Current_incr.const (Ok x, None)
-
-  let get (t : 'a t) = t
 
   let map_result fn t =
     Current_incr.of_cc begin
@@ -42,8 +40,6 @@ module Primitive = struct
       Current_incr.write (y, md)
     end
 end
-
-include Current_term.Make(Primitive)
 
 type 'a term = 'a t
 

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -44,6 +44,10 @@ module Primitive : sig
       If [fn] raises an exception, this is converted to [Error]. *)
 end
 
+include Current_term.S.TERM with
+  type metadata := job_id and
+  type 'a primitive := 'a Primitive.t
+
 module Monitor : sig
   type 'a t
   (** An ['a t] is a monitor that outputs values of type ['a]. *)
@@ -72,14 +76,12 @@ module Monitor : sig
       released, the monitor will be disabled. Call this in your [let>] block. *)
 end
 
-include Current_term.S.TERM with type 'a primitive := 'a Primitive.t
-
 type 'a term = 'a t
 (** An alias of [t] to make it easy to refer to later in this file. *)
 
 module Analysis : Current_term.S.ANALYSIS with
   type 'a term := 'a t and
-  type job_id := job_id
+  type metadata := job_id
 
 module Var (T : Current_term.S.T) : sig
   type t

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -33,11 +33,11 @@ class type actions = object
       or [None] if it is not something that can be repeated. Returns the new job ID. *)
 end
 
-module Input : sig
+module Primitive : sig
   type 'a t = ('a Current_term.Output.t * job_id option) Current_incr.t
 
   val const : 'a -> 'a t
-  (** [const x] is an input that always evaluates to [x] and never needs to be updated. *)
+  (** [const x] is a primitive that always evaluates to [x] and never needs to be updated. *)
 
   val map_result : ('a Current_term.Output.t -> 'b Current_term.Output.t) -> 'a t -> 'b t
   (** [map_result fn t] transforms the result of [t] with [fn]. The metadata remains the same.
@@ -67,12 +67,12 @@ module Monitor : sig
       value then it will wait for the current read to complete and then perform a
       second one. *)
 
-  val input : 'a t -> 'a Input.t
-  (** [input t] enables [t] and returns the input for it. When the input is
+  val get : 'a t -> 'a Primitive.t
+  (** [get t] enables [t] and returns the primitive for it. When the primitive is
       released, the monitor will be disabled. Call this in your [let>] block. *)
 end
 
-include Current_term.S.TERM with type 'a input := 'a Input.t
+include Current_term.S.TERM with type 'a primitive := 'a Primitive.t
 
 type 'a term = 'a t
 (** An alias of [t] to make it easy to refer to later in this file. *)
@@ -268,8 +268,8 @@ module Engine : sig
 
   val update : unit -> unit
   (** Trigger a reevaluation of the pipeline.
-      Inputs should call this whenever they might now produce a different result
-      (e.g. an active input becomes finished). *)
+      Primitives should call this whenever they might now produce a different result
+      (e.g. an active job becomes finished). *)
 
   val state : t -> results
   (** The most recent results from evaluating the pipeline. *)

--- a/lib_cache/current_cache.mli
+++ b/lib_cache/current_cache.mli
@@ -14,7 +14,7 @@ module Schedule : sig
 end
 
 module Make (B : S.BUILDER) : sig
-  val get : ?schedule:Schedule.t -> B.t -> B.Key.t -> B.Value.t Current.Input.t
+  val get : ?schedule:Schedule.t -> B.t -> B.Key.t -> B.Value.t Current.Primitive.t
   (** [get b k] is a term for the result of building [k]. *)
 
   val invalidate : B.Key.t -> unit
@@ -25,7 +25,7 @@ module Make (B : S.BUILDER) : sig
 end
 
 module Output (P : S.PUBLISHER) : sig
-  val set : ?schedule:Schedule.t -> P.t -> P.Key.t -> P.Value.t -> P.Outcome.t Current.Input.t
+  val set : ?schedule:Schedule.t -> P.t -> P.Key.t -> P.Value.t -> P.Outcome.t Current.Primitive.t
   (** [set p k v] is a term for the result of setting [k] to [v]. *)
 
   val reset : unit -> unit

--- a/lib_incr/time.mli
+++ b/lib_incr/time.mli
@@ -1,7 +1,7 @@
 (* Based on https://github.com/let-def/grenier/
    By Frédéric Bour. Relicensed to Apache 2.0 with permission. *)
 
-(** {0 Basic ordering operations} *)
+(** {1 Basic ordering operations} *)
 
 (** An element of an ordering. *)
 type t

--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -3,7 +3,7 @@ module Env = Map.Make(String)
 module IntSet = Set.Make(struct type t = int let compare = compare end)
 module IntMap = Map.Make(struct type t = int let compare = compare end)
 
-module Make (Meta : sig type job_id end) = struct
+module Make (Meta : sig type t end) = struct
   module Node = Node.Make(Meta)
   open Node
 

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -1,10 +1,10 @@
 (* Static analysis of a build pipeline. *)
 
-module Make (Meta : sig type job_id end) : sig
+module Make (Metadata : sig type t end) : sig
   type 'a t
 
   val stats : _ t -> S.stats
 
   val pp : _ t Fmt.t
-  val pp_dot : env:(string * string) list -> url:(Meta.job_id S.link -> string option) -> _ t Fmt.t
-end with type 'a t := 'a Node.Make(Meta).t
+  val pp_dot : env:(string * string) list -> url:(Metadata.t S.link -> string option) -> _ t Fmt.t
+end with type 'a t := 'a Node.Make(Metadata).t

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -1,10 +1,10 @@
 module S = S
 module Output = Output
 
-module Make (Input : S.INPUT) = struct
+module Make (Primitive : S.PRIMITIVE) = struct
   type description = string
 
-  module Node = Node.Make(Input)
+  module Node = Node.Make(Primitive)
   open Node
 
   type 'a t = 'a Node.t
@@ -84,7 +84,7 @@ module Make (Input : S.INPUT) = struct
       Current_incr.write @@ Dyn.pair a b
     end
 
-  let primitive ~info (f:'a -> 'b Input.t) (x:'a t) =
+  let primitive ~info (f:'a -> 'b Primitive.t) (x:'a t) =
     let id = Id.mint () in
     let v_meta =
       Current_incr.of_cc begin
@@ -92,7 +92,7 @@ module Make (Input : S.INPUT) = struct
         | Error _ as e -> Current_incr.write (e, None)
         | Ok y ->
           let input = f y in
-          Current_incr.read (Input.get input) @@ fun (v, job) ->
+          Current_incr.read (Primitive.get input) @@ fun (v, job) ->
           Current_incr.write (with_id id v, job)
       end
     in
@@ -255,7 +255,7 @@ module Make (Input : S.INPUT) = struct
   end
 
   module Analysis = struct
-    include Analysis.Make(Input)
+    include Analysis.Make(Primitive)
 
     (* This is a bit of a hack. *)
     let job_id t =

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -1,10 +1,12 @@
 module S = S
 module Output = Output
 
-module Make (Primitive : S.PRIMITIVE) = struct
+module Make (Metadata : sig type t end) = struct
   type description = string
 
-  module Node = Node.Make(Primitive)
+  type 'a primitive = ('a Output.t * Metadata.t option) Current_incr.t
+
+  module Node = Node.Make(Metadata)
   open Node
 
   type 'a t = 'a Node.t
@@ -84,15 +86,15 @@ module Make (Primitive : S.PRIMITIVE) = struct
       Current_incr.write @@ Dyn.pair a b
     end
 
-  let primitive ~info (f:'a -> 'b Primitive.t) (x:'a t) =
+  let primitive ~info (f:'a -> 'b primitive) (x:'a t) =
     let id = Id.mint () in
     let v_meta =
       Current_incr.of_cc begin
         Current_incr.read x.v @@ function
         | Error _ as e -> Current_incr.write (e, None)
         | Ok y ->
-          let input = f y in
-          Current_incr.read (Primitive.get input) @@ fun (v, job) ->
+          let output = f y in
+          Current_incr.read output @@ fun (v, job) ->
           Current_incr.write (with_id id v, job)
       end
     in
@@ -255,15 +257,15 @@ module Make (Primitive : S.PRIMITIVE) = struct
   end
 
   module Analysis = struct
-    include Analysis.Make(Primitive)
+    include Analysis.Make(Metadata)
 
     (* This is a bit of a hack. *)
-    let job_id t =
+    let metadata t =
       let rec aux (Term t) =
         match t.ty with
         | Primitive p -> p.meta
         | Map t -> aux t
-        | _ -> failwith "job_id: this is not a job term!"
+        | _ -> failwith "metadata: this is not a primitive term!"
       in
       node (Constant None) @@ Current_incr.map Result.ok @@ aux (Term t)
   end

--- a/lib_term/current_term.mli
+++ b/lib_term/current_term.mli
@@ -4,12 +4,14 @@ module S = S
 
 module Output = Output
 
-module Make (Primitive : S.PRIMITIVE) : sig
-  include S.TERM with type 'a primitive := 'a Primitive.t
+module Make (Metadata : sig type t end) : sig
+  include S.TERM with
+    type metadata := Metadata.t and
+    type 'a primitive = ('a Output.t * Metadata.t option) Current_incr.t
 
   module Analysis : S.ANALYSIS with
     type 'a term := 'a t and
-    type job_id := Primitive.job_id
+    type metadata := Metadata.t
 
   module Executor : S.EXECUTOR with
     type 'a term := 'a t

--- a/lib_term/current_term.mli
+++ b/lib_term/current_term.mli
@@ -4,12 +4,12 @@ module S = S
 
 module Output = Output
 
-module Make (Input : S.INPUT) : sig
-  include S.TERM with type 'a input := 'a Input.t
+module Make (Primitive : S.PRIMITIVE) : sig
+  include S.TERM with type 'a primitive := 'a Primitive.t
 
   module Analysis : S.ANALYSIS with
     type 'a term := 'a t and
-    type job_id := Input.job_id
+    type job_id := Primitive.job_id
 
   module Executor : S.EXECUTOR with
     type 'a term := 'a t

--- a/lib_term/node.ml
+++ b/lib_term/node.ml
@@ -1,4 +1,4 @@
-module Make (Meta : sig type job_id end) = struct
+module Make (Metadata : sig type t end) = struct
   type 'a t = {
     id : Id.t;
     bind : bind_context;
@@ -16,7 +16,7 @@ module Make (Meta : sig type job_id end) = struct
     | Map of generic
     | Bind_in of generic * string
     | Bind_out of generic Current_incr.t
-    | Primitive of {x : generic; info : string; meta : Meta.job_id option Current_incr.t }
+    | Primitive of {x : generic; info : string; meta : Metadata.t option Current_incr.t }
     | Pair of generic * generic
     | Gate_on of { ctrl : generic; value : generic }
     | List_map of { items : generic; output : generic Current_incr.t }

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -26,10 +26,10 @@ module type ORDERED = sig
   val pp : t Fmt.t
 end
 
-module type INPUT = sig
+module type PRIMITIVE = sig
   type 'a t
-  (** An input that was used while evaluating a term.
-      If the input changes, the term should be re-evaluated. *)
+  (** A primitive that was used while evaluating a term.
+      If its value changes, the term should be re-evaluated. *)
 
   type job_id
 
@@ -59,8 +59,8 @@ module type ANALYSIS = sig
 end
 
 module type TERM = sig
-  type 'a input
-  (** See [INPUT]. *)
+  type 'a primitive
+  (** See [PRIMITIVE]. *)
 
   type 'a t
   (** An ['a t] is a term that produces a value of type ['a]. *)
@@ -164,7 +164,7 @@ module type TERM = sig
       [x] is ready, so using [bind] makes static analysis less useful. You can
       use the [info] argument to provide some information here. *)
 
-  val primitive : info:description -> ('a -> 'b input) -> 'a t -> 'b t
+  val primitive : info:description -> ('a -> 'b primitive) -> 'a t -> 'b t
   (** [primitive ~info f x] is a term that evaluates [f] on each new value of [x].
       This is used to provide the primitive operations, which can then be
       combined using the other combinators in this module.
@@ -193,7 +193,7 @@ module type TERM = sig
         be determined at runtime by looking at the concrete value. Static
         analysis cannot predict what this will do until the input is ready. *)
 
-    val (let>) : 'a t -> ('a -> 'b input) -> description -> 'b t
+    val (let>) : 'a t -> ('a -> 'b primitive) -> description -> 'b t
     (** [let>] is used to define a component. e.g.:
         {[
           component "my-op" |>

--- a/plugins/docker/dune
+++ b/plugins/docker/dune
@@ -5,6 +5,7 @@
    bos
    current
    current.cache
+   current.term
    current_git
    dockerfile
    duration

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -160,19 +160,19 @@ module Local = struct
   let head t =
     Current.component "head" |>
     let> () = Current.return () in
-    Current.Monitor.input t.head
+    Current.Monitor.get t.head
 
   let head_commit t =
     Current.component "head commit" |>
     let> h = head t in
     match h with
-    | `Commit id -> Current.Input.const { Commit.repo = t.repo; id }
-    | `Ref gref -> Current.Monitor.input @@ commit_of_ref t gref
+    | `Commit id -> Current.Primitive.const { Commit.repo = t.repo; id }
+    | `Ref gref -> Current.Monitor.get @@ commit_of_ref t gref
 
   let commit_of_ref t gref =
     Current.component "commit_of_ref %s" gref |>
     let> () = Current.return () in
-    Current.Monitor.input @@ commit_of_ref t gref
+    Current.Monitor.get @@ commit_of_ref t gref
 
   let read_head repo =
     let path = Fpath.(repo / ".git" / "HEAD") in
@@ -185,7 +185,7 @@ module Local = struct
       | [_;r]  -> Ok (`Ref r)
       | _      -> Error (`Msg (Fmt.strf "Can't parse HEAD %S" contents))
 
-  let make_head_input repo =
+  let make_head repo =
     let dot_git = Fpath.(repo / ".git") in
     let read () = Lwt.return (read_head repo) in
     let watch refresh =
@@ -213,7 +213,7 @@ module Local = struct
 
   let v repo =
     let repo = Fpath.normalize @@ Fpath.append (Fpath.v (Sys.getcwd ())) repo in
-    let head = make_head_input repo in
+    let head = make_head repo in
     let heads = Ref_map.empty in
     { repo; head; heads }
 end

--- a/plugins/git/dune
+++ b/plugins/git/dune
@@ -5,6 +5,7 @@
    bos
    current
    current.cache
+   current.term
    fmt
    fpath
    irmin-watcher

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -305,7 +305,7 @@ let head_commit t repo =
       t.head_monitors <- Repo_map.add repo i t.head_monitors;
       i
   in
-  Current.Monitor.input monitor
+  Current.Monitor.get monitor
 
 let query_branches_and_open_prs = {|
   query($owner: String!, $name: String!) {
@@ -418,7 +418,7 @@ let make_ci_refs_monitor t repo =
   Current.Monitor.create ~read ~watch ~pp
 
 let refs t repo =
-  Current.Monitor.input (
+  Current.Monitor.get (
     match Repo_map.find_opt repo t.ci_refs_monitors with
     | Some i -> i
     | None ->
@@ -445,7 +445,7 @@ let head_of t repo id =
   Current.component "%a@,%a" Repo_id.pp repo Ref.pp id |>
   let> () = Current.return () in
   refs t repo
-  |> Current.Input.map_result @@ function
+  |> Current.Primitive.map_result @@ function
   | Error _ as e -> e
   | Ok refs ->
     match Ref_map.find_opt id refs with
@@ -561,7 +561,7 @@ module Repo = struct
   let head_commit t =
     Current.component "head" |>
     let> (api, repo) = t in
-    Current.Monitor.input (
+    Current.Monitor.get (
       match Repo_map.find_opt repo api.head_monitors with
       | Some i -> i
       | None ->

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -31,7 +31,7 @@ type t
 val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
-val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Input.t
+val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
 val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -97,11 +97,11 @@ module Api : sig
   val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
   (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo], excluding gh-pages. *)
 
-  val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Input.t
-  (** [refs t repo] is the input for all the references in [repo].
+  val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
+  (** [refs t repo] is the primitive for all the references in [repo].
       This is the low-level API for getting the refs.
       It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly.
-      The result is cached (so calling it twice will return the same input). *)
+      The result is cached (so calling it twice will return the same primitive). *)
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub configuration. *)

--- a/plugins/github/installation.ml
+++ b/plugins/github/installation.ml
@@ -76,4 +76,4 @@ let api t = t.api
 let repositories t =
   Current.component "list repos" |>
   let> t = t in
-  Current.Monitor.input t.repos
+  Current.Monitor.get t.repos

--- a/plugins/slack/dune
+++ b/plugins/slack/dune
@@ -7,6 +7,7 @@
    cohttp-lwt-unix
    current
    current.cache
+   current.term
    fmt
    logs
    lwt

--- a/test/plugins/docker/current_docker_test.ml
+++ b/test/plugins/docker/current_docker_test.ml
@@ -29,12 +29,12 @@ end
 let build_on platform ~src =
   Current.component "build-%s" platform |>
   let> c = src in
-  Current.Input.const @@ Fmt.strf "%s-image-%s" platform (Fpath.to_string c)
+  Current.Primitive.const @@ Fmt.strf "%s-image-%s" platform (Fpath.to_string c)
 
 let build c =
   Current.component "build" |>
   let> c = c in
-  Current.Input.const @@ "image-" ^ Fpath.to_string c
+  Current.Primitive.const @@ "image-" ^ Fpath.to_string c
 
 let build ?on src =
   match on with

--- a/test/plugins/opam/current_opam_test.ml
+++ b/test/plugins/opam/current_opam_test.ml
@@ -9,9 +9,9 @@ let revdeps src =
   let> src = src in
   match Fpath.to_string src with
   | "src-123" ->
-    Current.Input.const [
+    Current.Primitive.const [
       Git.Commit.v ~repo:"example.org/foo" ~hash:"111";
       Git.Commit.v ~repo:"example.org/bar" ~hash:"222";
     ]
   | _ ->
-    Current.Input.const []
+    Current.Primitive.const []

--- a/test/test.ml
+++ b/test/test.ml
@@ -196,13 +196,7 @@ let test_pair _switch () =
   in
   Driver.test ~name:"pair" pipeline (fun _ -> raise Exit)
 
-module Test_primitive = struct
-  type job_id = string
-  type 'a t = ('a Current_term.Output.t * job_id option) Current_incr.t
-  let get x = x
-end
-
-module Term = Current_term.Make(Test_primitive)
+module Term = Current_term.Make(String)
 
 let test_all_labelled () =
   let test x = Current_incr.observe (Term.Executor.run (Term.all_labelled x)) in
@@ -231,10 +225,10 @@ let job x =
   let info = Term.component "job" in
   Term.primitive ~info (fun () -> Current_incr.const (Ok (), Some x)) @@ Term.return ()
 
-let test_job_id () =
+let test_metadata () =
   let pipeline =
     let j = Term.map ignore (job "1") in
-    Term.Analysis.job_id j
+    Term.Analysis.metadata j
   in
   let job_id = Current_incr.observe (Term.Executor.run pipeline) in
   Alcotest.(check (result (option string) reject)) "Got job ID" (Ok (Some "1")) job_id
@@ -259,7 +253,7 @@ let () =
       ];
       "terms", [
         Alcotest_lwt.test_case_sync "all_labelled" `Quick test_all_labelled;
-        Alcotest_lwt.test_case_sync "job_id"       `Quick test_job_id;
+        Alcotest_lwt.test_case_sync "metadata"     `Quick test_metadata;
       ];
       "cache", Test_cache.tests;
       "monitor", Test_monitor.tests;

--- a/test/test.ml
+++ b/test/test.ml
@@ -178,7 +178,7 @@ let test_pair _switch () =
   let show label x = (* Make it show up on the diagram so we can see the input state. *)
     Current.component "%s" label |>
     let> () = x in
-    Current.Input.const ()
+    Current.Primitive.const ()
   in
   let check name expected x =
     let+ s = Current.state (show name x) in
@@ -196,13 +196,13 @@ let test_pair _switch () =
   in
   Driver.test ~name:"pair" pipeline (fun _ -> raise Exit)
 
-module Test_input = struct
+module Test_primitive = struct
   type job_id = string
   type 'a t = ('a Current_term.Output.t * job_id option) Current_incr.t
   let get x = x
 end
 
-module Term = Current_term.Make(Test_input)
+module Term = Current_term.Make(Test_primitive)
 
 let test_all_labelled () =
   let test x = Current_incr.observe (Term.Executor.run (Term.all_labelled x)) in

--- a/test/test_monitor.ml
+++ b/test/test_monitor.ml
@@ -45,7 +45,7 @@ let monitor = Current.Monitor.create ~read ~watch ~pp
 let input () =
   Current.component "input" |>
   let> () = Current.return () in
-  Current.Monitor.input monitor
+  Current.Monitor.get monitor
 
 module Bool_var = Current.Var(struct type t = bool let pp = Fmt.bool let equal = (=) end)
 


### PR DESCRIPTION
The name `Input` was confusing. It's a source of events to the evaluation engine, but not an input to the pipeline.

Also, primitives now always return a simple `(value, metadata)` pair. This removes the need for the separate `PRIMITIVE` interface. Also, renamed `job_id` to `metadata`, as it could be used for other things too.