### PR TITLE
GitHub: only refresh the repository that generated the event

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -4,11 +4,25 @@ open Current.Syntax
 (* Limit updates to one at a time for now. *)
 let pool = Current.Pool.create ~label:"github" 1
 
-(* Currently, this fires whenever we get an incoming web-hook.
-   Ideally, it would be more fine-grained. *)
-let webhook_cond = Lwt_condition.create ()
+(* When we get a webhook event, we fire the condition for that repository `owner/name`, if any. *)
+let webhook_cond = Hashtbl.create 10
 
-let input_webhook () = Lwt_condition.broadcast webhook_cond ()
+let await_event ~owner_name =
+  let cond =
+    match Hashtbl.find_opt webhook_cond owner_name with
+    | Some c -> c
+    | None ->
+      let c = Lwt_condition.create () in
+      Hashtbl.add webhook_cond owner_name c;
+      c
+  in
+  Lwt_condition.wait cond
+
+let input_webhook body =
+  let owner_name = Yojson.Safe.Util.(body |> member "repository" |> member "full_name" |> to_string) in
+  match Hashtbl.find_opt webhook_cond owner_name with
+  | Some cond -> Lwt_condition.broadcast cond ()
+  | None -> Log.info (fun f -> f "Got webhook event for %S, but we're not interested in that" owner_name)
 
 module Metrics = struct
   open Prometheus
@@ -273,14 +287,15 @@ let make_head_commit_monitor t repo =
       (fun ex -> Lwt_result.fail @@ `Msg (Fmt.strf "GitHub query for %a failed: %a" Repo_id.pp repo Fmt.exn ex))
   in
   let watch refresh =
+    let owner_name = Printf.sprintf "%s/%s" repo.owner repo.name in
     let rec aux x =
       x >>= fun () ->
-      let x = Lwt_condition.wait webhook_cond in
+      let x = await_event ~owner_name in
       refresh ();
       Lwt_unix.sleep 10.0 >>= fun () ->   (* Limit updates to 1 per 10 seconds *)
       aux x
     in
-    let x = Lwt_condition.wait webhook_cond in
+    let x = await_event ~owner_name in
     let thread =
       Lwt.catch
         (fun () -> aux x)
@@ -396,14 +411,15 @@ let make_ci_refs_monitor t repo =
       (fun ex -> Lwt_result.fail @@ `Msg (Fmt.strf "GitHub query for %a failed: %a" Repo_id.pp repo Fmt.exn ex))
   in
   let watch refresh =
+    let owner_name = Printf.sprintf "%s/%s" repo.owner repo.name in
     let rec aux x =
       x >>= fun () ->
-      let x = Lwt_condition.wait webhook_cond in
+      let x = await_event ~owner_name in
       refresh ();
       Lwt_unix.sleep 10.0 >>= fun () ->   (* Limit updates to 1 per 10 seconds *)
       aux x
     in
-    let x = Lwt_condition.wait webhook_cond in
+    let x = await_event ~owner_name in
     let thread =
       Lwt.catch
         (fun () -> aux x)

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -64,8 +64,8 @@ type token = {
 val get_token : t -> (string, [`Msg of string]) result Lwt.t
 (** [get_token t] returns the cached token for [t], or fetches a new one if it has expired. *)
 
-val input_webhook : unit -> unit
-(** Call this when we get a webhook event. *)
+val input_webhook : Yojson.Safe.t -> unit
+(** Call this when we get a "pull_request", "push" or "create" webhook event. *)
 
 val v : get_token:(unit -> token Lwt.t) -> string -> t
 (** [v ~get_token account] is a configuration that uses [get_token] when it needs to get or refresh the API token.

--- a/plugins/github/current_github.ml
+++ b/plugins/github/current_github.ml
@@ -23,6 +23,8 @@ let input_webhook req _body =
   begin match event with
     | Some "installation_repositories" -> Installation.input_installation_repositories_webhook ()
     | Some "installation" -> App.input_installation_webhook ()
-    | _ -> Api.input_webhook ()
+    | Some ("pull_request" | "push" | "create") -> Api.input_webhook ()
+    | Some x -> Log.warn (fun f -> f "Unknown GitHub event type %S" x)
+    | None -> Log.warn (fun f -> f "Missing GitHub event type in webhook!")
   end;
   Cohttp_lwt_unix.Server.respond_string ~status:`OK ~body:"OK" ()


### PR DESCRIPTION
Before, we refreshed all repositories whenever we got an event for any of them.