### PR TITLE
Add with_context to help with diagram layout

### DIFF
--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -120,6 +120,9 @@ module Make (Metadata : sig type t end) = struct
   let collapse ~key ~value ~input t =
     node (Collapse { key; value; input = Term input; output = Term t }) t.v
 
+  let with_context ctx f =
+    with_bind_context (Term ctx) f
+
   let rec all = function
     | [] -> return ()
     | [x] -> x

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -131,6 +131,8 @@ module type TERM = sig
   val gate : on:unit t -> 'a t -> 'a t
   (** [gate ~on:ctrl x] is the same as [x], once [ctrl] succeeds. *)
 
+  (** {2 Diagram control} *)
+
   val collapse : key:string -> value:string -> input:_ t -> 'a t -> 'a t
   (** [collapse ~key ~value ~input t] is a term that behaves just like [t], but
       when shown in a diagram it can be expanded or collapsed. When collapsed,
@@ -141,6 +143,11 @@ module type TERM = sig
       not. For example
       [collapse ~key:"repo" ~value:"mirage/mirage-www" ~input:repo (process repo)]
       Note: [list_map ~collapse_key] provides an easy way to use this. *)
+
+  val with_context : _ t -> (unit -> 'a t) -> 'a t
+  (** [with_context ctx f] is the term [f ()], where [f] is evaluated in
+      context [ctx]. This means that [ctx] will be treated as an input to all
+      terms created by [f] in the diagrams. *)
 
   (** {2 Monadic operations} *)
 


### PR DESCRIPTION
This is useful if you want to group things together using a virtual dependency. For example, ocurrent-deployer wants to group all pipelines for a single repository together.