### PR TITLE
Git: fix clone instructions for GitHub PRs

### DIFF
--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -72,15 +72,28 @@ let strip_heads gref =
   else
     gref
 
+let pp_user_clone f id =
+  let short_hash = Astring.String.with_range ~len:8 id.Commit_id.hash in
+  if Astring.String.is_prefix ~affix:"refs/pull/" id.Commit_id.gref then (
+    (* GitHub doesn't recognise pull requests in clones, but it does in fetches. *)
+    Fmt.pf f "git clone --recursive %S && cd %S && git fetch origin %S && git reset --hard %s"
+      id.Commit_id.repo
+      (Filename.basename id.Commit_id.repo |> Filename.remove_extension)
+      (strip_heads id.Commit_id.gref)
+      short_hash
+  ) else (
+    Fmt.pf f "git clone --recursive %S -b %S && cd %S && git reset --hard %s"
+      id.Commit_id.repo
+      (strip_heads id.Commit_id.gref)
+      (Filename.basename id.Commit_id.repo |> Filename.remove_extension)
+      short_hash
+  )
+
 let with_checkout ~job commit fn =
   let { Commit.repo; id } = commit in
   let short_hash = Astring.String.with_range ~len:8 id.Commit_id.hash in
-  Current.Job.log job "@[<v2>Checking out commit %s. To reproduce:@,git clone --recursive %S -b %S && cd %S && git reset --hard %s@]"
-    short_hash
-    id.Commit_id.repo
-    (strip_heads id.Commit_id.gref)
-    (Filename.basename id.Commit_id.repo |> Filename.remove_extension)
-    short_hash;
+  Current.Job.log job "@[<v2>Checking out commit %s. To reproduce:@,%a@]"
+    short_hash pp_user_clone id;
   Current.Process.with_tmpdir ~prefix:"git-checkout" @@ fun tmpdir ->
   Cmd.cp_r ~cancellable:true ~job ~src:(Fpath.(repo / ".git")) ~dst:tmpdir >>!= fun () ->
   Cmd.git_reset_hard ~job ~repo:tmpdir id.Commit_id.hash >>= function


### PR DESCRIPTION
GitHub only provides the `refs/pull/NNN/head` branches when fetching, not when cloning. Detect this case and show an alternative command that the user can run to reproduce the operation.

Reported by @samoht.