### PR TITLE
Add a context to maps

### DIFF
--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -71,11 +71,15 @@ module Make (Metadata : sig type t end) = struct
 
   let map f x =
     let id = Id.mint () in
-    node ~id (Map (Term x)) @@ Current_incr.map (Dyn.map ~id f) x.v
+    node ~id (Map (Term x)) @@
+    with_bind_context (Term x) @@ fun () ->
+    Current_incr.map (Dyn.map ~id f) x.v
 
   let map_error f x =
     let id = Id.mint () in
-    node ~id (Map (Term x)) @@ Current_incr.map (Dyn.map_error ~id f) x.v
+    node ~id (Map (Term x)) @@
+    with_bind_context (Term x) @@ fun () ->
+    Current_incr.map (Dyn.map_error ~id f) x.v
 
   let ignore_value x = map ignore x
 


### PR DESCRIPTION
Currently, maps – contrary to binds – do not carry a context information. This could be useful in several cases. For instance, see the following sketched code:
```OCaml
let x =
  let+ list_file = Current_docker.pread image "ls distro.txt" in
  let dockerfile = from "%s" distro @@ ... in
  ("example", Current_docker.build ~dockerfile image)
```
Other functions might also benefit from a similar change