### PR TITLE
Docker: add Raw module with low-level API

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -32,4 +32,7 @@
    lwt.unix
    prometheus
    result
-   uri))
+   uri
+   ppx_deriving_yojson.runtime
+   yojson)
+ (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -4,35 +4,17 @@ module S = S
 
 let pp_tag = Fmt.using (Astring.String.cuts ~sep:":") Fmt.(list ~sep:(unit ":@,") string)
 
-module Make (Host : S.HOST) = struct
+module Raw = struct
   module Image = Image
 
   module PC = Current_cache.Make(Pull)
 
-  let docker_context = Host.docker_context
-
-  let pull ?label ~schedule tag =
-    let label = Option.value label ~default:tag in
-    Current.component "pull %s" label |>
-    let> () = Current.return () in
+  let pull ~docker_context ~schedule tag =
     PC.get ~schedule Pull.No_context { Pull.Key.docker_context; tag }
 
   module BC = Current_cache.Make(Build)
 
-  let pp_sp_label = Fmt.(option (prefix sp string))
-
-  let option_map f = function
-    | None -> None
-    | Some x -> Some (f x)
-
-  let get_build_context = function
-    | `No_context -> Current.return `No_context
-    | `Git commit -> Current.map (fun x -> `Git x) commit
-
-  let build ?schedule ?timeout ?(squash=false) ?label ?dockerfile ?pool ?(build_args=[]) ~pull src =
-    Current.component "build%a" pp_sp_label label |>
-    let> commit = get_build_context src
-    and> dockerfile = Current.option_seq dockerfile in
+  let build ~docker_context ?schedule ?timeout ?(squash=false) ?dockerfile ?pool ?(build_args=[]) ~pull commit =
     let dockerfile =
       match dockerfile with
       | None -> `File (Fpath.v "Dockerfile")
@@ -44,37 +26,27 @@ module Make (Host : S.HOST) = struct
 
   module RC = Current_cache.Make(Run)
 
-  let run ?label ?pool ?(run_args=[]) image ~args  =
-    Current.component "run%a" pp_sp_label label |>
-    let> image = image in
+  let run ~docker_context ?pool ?(run_args=[]) image ~args  =
     RC.get { Run.pool } { Run.Key.image; args; docker_context; run_args }
 
   module PrC = Current_cache.Make(Pread)
 
-  let pread ?label ?pool ?(run_args=[]) image ~args  =
-    Current.component "pread%a" pp_sp_label label |>
-    let> image = image in
+  let pread ~docker_context ?pool ?(run_args=[]) image ~args =
     PrC.get { Pread.pool } { Pread.Key.image; args; docker_context; run_args }
 
   module TC = Current_cache.Output(Tag)
 
-  let tag ~tag image =
-    Current.component "docker-tag@,%a" pp_tag tag |>
-    let> image = image in
+  let tag ~docker_context ~tag image =
     TC.set Tag.No_context { Tag.Key.tag; docker_context } { Tag.Value.image }
 
   module Push_cache = Current_cache.Output(Push)
 
-  let push ?auth ~tag image =
-    Current.component "docker-push@,%a" pp_tag tag |>
-    let> image = image in
+  let push ~docker_context ?auth ~tag image =
     Push_cache.set auth { Push.Key.tag; docker_context } { Push.Value.image }
 
   module SC = Current_cache.Output(Service)
 
-  let service ~name ~image () =
-    Current.component "docker-service@,%s" name |>
-    let> image = image in
+  let service ~docker_context ~name ~image () =
     SC.set Service.No_context { Service.Key.name; docker_context } { Service.Value.image }
 
   module Cmd = struct
@@ -84,19 +56,18 @@ module Make (Host : S.HOST) = struct
 
     type t = Lwt_process.command
 
-    let docker args =
-      Cmd.docker ~docker_context args
+    let docker args ~docker_context = Cmd.docker ~docker_context args
 
     let rm_f id = docker ["container"; "rm"; "-f"; id]
     let kill id = docker ["container"; "kill"; id]
 
     (* Try to "docker kill $id". If it fails, just log a warning and continue. *)
-    let try_kill_container ~job id =
-      Current.Process.exec ~cancellable:false ~job (kill id) >|= function
+    let try_kill_container ~docker_context ~job id =
+      Current.Process.exec ~cancellable:false ~job (kill ~docker_context id) >|= function
       | Ok () -> ()
       | Error (`Msg m) -> Current.Job.log job "Warning: Failed to kill container %S: %s" id m
 
-    let with_container ~kill_on_cancel ~job t fn =
+    let with_container ~docker_context ~kill_on_cancel ~job t fn =
       Current.Process.check_output ~cancellable:false ~job t >>!= fun id ->
       let id = String.trim id in
       let did_rm = ref false in
@@ -105,18 +76,18 @@ module Make (Host : S.HOST) = struct
            begin
              if kill_on_cancel then (
                Current.Job.on_cancel job (fun _ ->
-                   if !did_rm = false then try_kill_container ~job id
+                   if !did_rm = false then try_kill_container ~docker_context ~job id
                    else Lwt.return_unit
                  )
              ) else (
                Lwt.return_unit
              )
            end >>= fun () ->
-           fn id)
+           fn id )
         (fun ex -> Lwt.return (Fmt.error_msg "with_container: uncaught exception: %a" Fmt.exn ex))
       >>= fun result ->
       did_rm := true;
-      Current.Process.exec ~cancellable:false ~job (rm_f id) >|= function
+      Current.Process.exec ~cancellable:false ~job (rm_f ~docker_context id) >|= function
       | Ok () -> result         (* (the common case, where removing the container succeeds) *)
       | Error (`Msg rm_error) as rm_e ->
         match result with
@@ -129,6 +100,59 @@ module Make (Host : S.HOST) = struct
 
     let pp = Cmd.pp
   end
+end
+
+module Make (Host : S.HOST) = struct
+  module Image = Image
+
+  let docker_context = Host.docker_context
+
+  let pull ?label ~schedule tag =
+    let label = Option.value label ~default:tag in
+    Current.component "pull %s" label |>
+    let> () = Current.return () in
+    Raw.pull ~docker_context ~schedule tag
+
+  let pp_sp_label = Fmt.(option (prefix sp string))
+
+  let option_map f = function
+    | None -> None
+    | Some x -> Some (f x)
+
+  let get_build_context = function
+    | `No_context -> Current.return `No_context
+    | `Git commit -> Current.map (fun x -> `Git x) commit
+
+  let build ?schedule ?timeout ?squash ?label ?dockerfile ?pool ?build_args ~pull src =
+    Current.component "build%a" pp_sp_label label |>
+    let> commit = get_build_context src
+    and> dockerfile = Current.option_seq dockerfile in
+    Raw.build ~docker_context ?schedule ?timeout ?squash ?dockerfile ?pool ?build_args ~pull commit
+
+  let run ?label ?pool ?run_args image ~args  =
+    Current.component "run%a" pp_sp_label label |>
+    let> image = image in
+    Raw.run ~docker_context ?pool ?run_args image ~args
+
+  let pread ?label ?pool ?run_args image ~args  =
+    Current.component "pread%a" pp_sp_label label |>
+    let> image = image in
+    Raw.pread ~docker_context ?pool ?run_args image ~args
+
+  let tag ~tag image =
+    Current.component "docker-tag@,%a" pp_tag tag |>
+    let> image = image in
+    Raw.tag ~docker_context ~tag image
+
+  let push ?auth ~tag image =
+    Current.component "docker-push@,%a" pp_tag tag |>
+    let> image = image in
+    Raw.push ~docker_context ?auth ~tag image
+
+  let service ~name ~image () =
+    Current.component "docker-service@,%s" name |>
+    let> image = image in
+    Raw.service ~docker_context ~name ~image ()
 end
 
 module Default = Make(struct

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -11,3 +11,79 @@ module Make(Host : S.HOST) : S.DOCKER
 val push_manifest : ?auth:(string * string) -> tag:string -> S.repo_id Current.t list -> unit Current.t
 (** [push_manifest images ~tag] pushes a manifest containing [images] as [tag].
     @param auth If give, do a "docker login" using this username/password pair before pushing. *)
+
+(** Low-level API. This is useful for building custom components.
+    The functions are similar to the ones in {!S.DOCKER} except that each one
+    takes the context explicitly as an argument, there are no labels, input
+    values are no longer wrapped with [Current.t], and the output is a
+    {!Current.Primitive.t} type. You can wrap these with [let>] to create
+    your own components. *)
+module Raw : sig
+  module Image = Image
+
+  val pull :
+    docker_context:string option ->
+    schedule:Current_cache.Schedule.t -> string -> Image.t Current.Primitive.t
+
+  val build :
+    docker_context:string option ->
+    ?schedule:Current_cache.Schedule.t ->
+    ?timeout:Duration.t ->
+    ?squash:bool ->
+    ?dockerfile:[`File of Fpath.t | `Contents of Dockerfile.t] ->
+    ?pool:Current.Pool.t ->
+    ?build_args:string list ->
+    pull:bool ->
+    [ `Git of Current_git.Commit.t | `No_context ] ->
+    Image.t Current.Primitive.t
+
+  val run :
+    docker_context:string option ->
+    ?pool:Current.Pool.t ->
+    ?run_args:string list ->
+    Image.t -> args:string list ->
+    unit Current.Primitive.t
+
+  val pread :
+    docker_context:string option ->
+    ?pool:Current.Pool.t ->
+    ?run_args:string list ->
+    Image.t -> args:string list ->
+    string Current.Primitive.t
+
+  val tag :
+    docker_context:string option ->
+    tag:string -> Image.t -> unit Current.Primitive.t
+
+  val push :
+    docker_context:string option ->
+    ?auth:(string * string) -> tag:string -> Image.t -> S.repo_id Current.Primitive.t
+
+  val service :
+    docker_context:string option ->
+    name:string -> image:Image.t -> unit -> unit Current.Primitive.t
+
+  (** Building Docker commands. *)
+  module Cmd : sig
+    type t = Lwt_process.command
+
+    val docker : string list -> docker_context:string option -> t
+    (** [docker ~docker_context args] is a command to run docker, with the "--context" argument added (if necessary).
+        e.g. [docker ~docker_context ["run"; image]] *)
+
+    val with_container :
+      docker_context:string option ->
+      kill_on_cancel:bool ->
+      job:Current.Job.t ->
+      t ->
+      (string -> 'a Current.or_error Lwt.t) ->
+      'a Current.or_error Lwt.t
+    (** [with_container ~kill_on_cancel ~job t fn] runs [t] to create a new
+        container (the output is the container ID), then calls [fn id].
+        When [fn] returns, it removes the container (killing it first if necessary).
+        If [fn] raises an exception, it catches it and turns it into an error return.
+        @param kill_on_cancel "docker kill" the container if the the job is cancelled. *)
+
+    val pp : t Fmt.t
+  end
+end

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -14,6 +14,8 @@ module type DOCKER = sig
     val pp : t Fmt.t
   end
 
+  val docker_context : string option
+
   val pull : ?label:string -> schedule:Current_cache.Schedule.t -> string -> Image.t Current.t
   (** [pull ~schedule tag] ensures that the latest version of [tag] is cached locally, downloading it if not.
       @param schedule Controls how often we check for updates. If the schedule
@@ -65,29 +67,6 @@ module type DOCKER = sig
 
   val service : name:string -> image:Image.t Current.t -> unit -> unit Current.t
   (** [service ~name ~image ()] keeps a Docker SwarmKit service up-to-date. *)
-
-  module Cmd : sig
-    (** Building Docker commands. This is useful for creating custom pipeline stages. *)
-
-    type t = Lwt_process.command
-
-    val docker : string list -> t
-    (** [docker args] is a command to run docker, with the "--context" argument added (if necessary).
-        e.g. [docker ["run"; image]] *)
-
-    val with_container :
-      kill_on_cancel:bool ->
-      job:Current.Job.t -> t ->
-      (string -> 'a Current.or_error Lwt.t) ->
-      'a Current.or_error Lwt.t
-    (** [with_container ~kill_on_cancel ~job t fn] runs [t] to create a new container
-        (the output is the container ID), then calls [fn id].
-        When [fn] returns, it removes the container (killing it first if necessary).
-        If [fn] raises an exception, it catches it and turns it into an error return.
-        @param kill_on_cancel "docker kill" the container if the the job is cancelled. *)
-
-    val pp : t Fmt.t
-  end
 end
 
 module type HOST = sig


### PR DESCRIPTION
This is useful if you need to create your own custom components (for example, because you want to use a `Current.t` input to generate one of the fixed arguments such as `~run_args`).

Used the new API to update the example to work with different docker contexts.