### PR TITLE
Add a basic access control system

### DIFF
--- a/current_web.opam
+++ b/current_web.opam
@@ -19,6 +19,10 @@ depends: [
   "current" {= version}
   "current_ansi" {= version}
   "ocaml" {>= "4.08.0"}
+  "base64"
+  "session"
+  "session-cohttp-lwt"
+  "mirage-crypto-rng"
   "fmt"
   "bos"
   "lwt"

--- a/examples/auth.ml
+++ b/examples/auth.ml
@@ -1,0 +1,62 @@
+(** Shows how to configure authentication and access control in the web interface.
+    Run this and visit "/login" for configuration instructions. *)
+
+let program_name = "auth"
+
+module Git = Current_git
+module Docker = Current_docker.Default
+
+let pull = false
+let timeout = Duration.of_min 50
+
+let () = Logging.init ()
+
+(* Run "docker build" on the latest commit in Git repository [repo]. *)
+let pipeline ~repo () =
+  let src = Git.Local.head_commit repo in
+  let image = Docker.build ~pull ~timeout (`Git src) in
+  Docker.run image ~args:["dune"; "exec"; "--"; "examples/docker_build_local.exe"; "--help"]
+
+(* Access control policy. *)
+let has_role user role =
+  match user with
+  | None -> role = `Viewer              (* Unauthenticated users can only look at things. *)
+  | Some user ->
+    match Current_web.User.id user, role with
+    | "github:talex5", _ -> true        (* This user has all roles *)
+    | _, (`Viewer | `Builder) -> true   (* Any GitHub user can cancel and rebuild *)
+    | _ -> false
+
+let main config mode repo auth =
+  let repo = Git.Local.v (Fpath.v repo) in
+  let engine = Current.Engine.create ~config (pipeline ~repo) in
+  let authn = Option.map Current_github.Auth.make_login_uri auth in
+  let site = Current_web.Site.v ?authn ~has_role ~name:program_name () in
+  let routes =
+    Routes.(s "login" /? nil @--> Current_github.Auth.login auth) ::
+    Current_web.routes engine in
+  Logging.run begin
+    Lwt.choose [
+      Current.Engine.thread engine;
+      Current_web.run ~mode ~site routes;
+    ]
+  end
+
+(* Command-line parsing *)
+
+open Cmdliner
+
+let repo =
+  Arg.value @@
+  Arg.pos 0 Arg.dir (Sys.getcwd ()) @@
+  Arg.info
+    ~doc:"The directory containing the .git subdirectory."
+    ~docv:"DIR"
+    []
+
+let cmd =
+  let doc = "Build the head commit of a local Git repository using Docker." in
+  Term.(const main $ Current.Config.cmdliner $ Current_web.cmdliner $ repo $ Current_github.Auth.cmdliner),
+  Term.info program_name ~doc
+
+let () = Term.(exit @@ eval cmd)

--- a/examples/build_matrix.ml
+++ b/examples/build_matrix.ml
@@ -40,7 +40,7 @@ let pipeline ~repo () =
 let main config mode repo =
   let repo = Git.Local.v (Fpath.v repo) in
   let engine = Current.Engine.create ~config (pipeline ~repo) in
-  let site = Current_web.Site.v ~name:program_name () in
+  let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name () in
   let routes = Current_web.routes engine in
   Logging.run begin
     Lwt.choose [

--- a/examples/docker_build_local.ml
+++ b/examples/docker_build_local.ml
@@ -18,7 +18,7 @@ let pipeline ~repo () =
 let main config mode repo =
   let repo = Git.Local.v (Fpath.v repo) in
   let engine = Current.Engine.create ~config (pipeline ~repo) in
-  let site = Current_web.Site.v ~name:program_name () in
+  let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name () in
   let routes = Current_web.routes engine in
   Logging.run begin
     Lwt.choose [

--- a/examples/docker_custom.ml
+++ b/examples/docker_custom.ml
@@ -87,7 +87,7 @@ let pipeline () =
 
 let main config mode =
   let engine = Current.Engine.create ~config pipeline in
-  let site = Current_web.Site.v ~name:program_name () in
+  let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name () in
   let routes = Current_web.routes engine in
   Logging.run begin
     Lwt.choose [

--- a/examples/docker_service.ml
+++ b/examples/docker_service.ml
@@ -30,7 +30,7 @@ let pipeline ~repo ~service () =
 let main config mode service repo =
   let repo = Git.Local.v (Fpath.v repo) in
   let engine = Current.Engine.create ~config (pipeline ~repo ~service) in
-  let site = Current_web.Site.v ~name:program_name () in
+  let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name () in
   let routes = Current_web.routes engine in
   Logging.run begin
     Lwt.choose [

--- a/examples/dune
+++ b/examples/dune
@@ -3,6 +3,7 @@
                docker_service
                docker_custom
                build_matrix
+               auth
                github
                github_app
                rpc_server

--- a/examples/github.ml
+++ b/examples/github.ml
@@ -45,7 +45,7 @@ let pipeline ~github ~repo () =
 
 let main config mode github repo =
   let engine = Current.Engine.create ~config (pipeline ~github ~repo) in
-  let site = Current_web.Site.v ~name:program_name () in
+  let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name () in
   let routes =
     Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook) ::
     Current_web.routes engine

--- a/examples/github_app.ml
+++ b/examples/github_app.ml
@@ -54,7 +54,7 @@ let pipeline ~app () =
 let main config mode app =
   Logging.run begin
     let engine = Current.Engine.create ~config (pipeline ~app) in
-    let site = Current_web.Site.v ~name:program_name () in
+    let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name () in
     let routes =
       Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook) ::
       Current_web.routes engine

--- a/examples/rpc_server.ml
+++ b/examples/rpc_server.ml
@@ -46,7 +46,7 @@ let main config mode capnp repo =
     output_string ch (Uri.to_string uri ^ "\n");
     close_out ch;
     Logs.app (fun f -> f "Wrote capability reference to %S" cap_file);
-    let site = Current_web.Site.v ~name:program_name () in
+    let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name () in
     let routes = Current_web.routes engine in
     Lwt.choose [
       Current.Engine.thread engine;

--- a/lib_web/context.ml
+++ b/lib_web/context.ml
@@ -1,16 +1,67 @@
+open Lwt.Infix
+
+let cookie_key = "__session"
+
 type t = {
   site : Site.t;
+  session : Site.Sess.t;
+  user : User.t option;
   request : Cohttp.Request.t;
 }
 
 let of_request ~site request =
-  Lwt.return { site; request }
+  let headers = Cohttp.Request.headers request in
+  Site.Sess.of_header_or_create site.Site.session_backend cookie_key "" headers >>= fun session ->
+  begin
+    match User.unmarshal session.value with
+    | Ok x -> Lwt.return x
+    | Error m ->
+      Log.err (fun f -> f "Invalid user in session table: %s" m);
+      Site.Sess.clear site.session_backend session >|= fun () ->
+      None
+  end >|= fun user ->
+  { site; session; user; request }
+
+let headers t =
+  Site.Sess.to_cookie_hdrs cookie_key t.session
+    ~path:"/"
+    ~secure:t.site.secure_cookies
+  |> Cohttp.Header.of_list
+
+(* Just use the hash of the session key as the CSRF token.
+   Perhaps we could use the key itself, but this seems slightly safer. *)
+let csrf t =
+  t.session.key
+  |> Cstruct.of_string
+  |> Mirage_crypto.Hash.SHA256.digest
+  |> Cstruct.to_string
+  |> Base64.(encode_exn ~alphabet:uri_safe_alphabet)
+
+let has_role t role =
+  let ok = t.site.has_role t.user role in
+  if not ok then
+    Log.info (fun f -> f "%a does not have required role %a"
+                 (Fmt.option ~none:(Fmt.unit "(anonymous)") User.pp) t.user Role.pp role);
+  ok
 
 let request t = t.request
 
 let uri t = Cohttp.Request.uri (request t)
 
 let html_to_string = Fmt.to_to_string (Tyxml.Html.pp ())
+
+let logout_form t user =
+  let link_path = "/logout" in
+  let link_label = Fmt.strf "Log out %s" (User.id user) in
+  let open Tyxml.Html in
+  [
+    li [
+      form ~a:[a_action link_path; a_method `Post] [
+        button [txt link_label];
+        input ~a:[a_name "csrf"; a_input_type `Hidden; a_value (csrf t)] ();
+      ]
+    ]
+  ]
 
 let template t contents =
   let site = t.site in
@@ -31,6 +82,16 @@ let template t contents =
               li [a ~a:[a_href "/query"] [txt "Query"]];
               li [a ~a:[a_href "/log-rules"] [txt "Log analysis"]];
             ];
+            ul ~a:[a_class ["right"]] (
+              match t.site.authn with
+              | None -> []
+              | Some login_uri ->
+                match t.user with
+                | None ->
+                  let uri = login_uri ~csrf:(csrf t) in
+                  [li [a ~a:[a_href (Uri.to_string uri)] [txt "Log in"]]]
+                | Some user -> logout_form t user
+            )
           ];
           div ~a:[a_id "main"] contents
         ]
@@ -39,11 +100,15 @@ let template t contents =
 
 let respond_ok t body =
   let body = template t body in
-  Utils.Server.respond_string ~status:`OK ~body ()
+  Utils.Server.respond_string ~headers:(headers t) ~status:`OK ~body ()
 
-let respond_redirect _t uri =
-  Utils.Server.respond_redirect ~uri ()
+let respond_redirect t uri =
+  Utils.Server.respond_redirect ~headers:(headers t) ~uri ()
 
 let respond_error t status msg =
   let body = template t [Tyxml.Html.txt msg] in
-  Utils.Server.respond_string ~status ~body ()
+  Utils.Server.respond_string ~headers:(headers t) ~status ~body ()
+
+let set_user t user =
+  Site.Sess.generate t.site.session_backend (User.marshal user) >>= fun session ->
+  respond_redirect { t with session } (Uri.of_string "/")

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -1,8 +1,12 @@
+module User = User
+module Role = Role
 module Site = Site
 module Context = Context
 
 let metrics ~engine = object
   inherit Resource.t
+
+  val! can_get = `Monitor
 
   method! private get _ctx =
     Current.Engine.(update_metrics engine);
@@ -43,6 +47,7 @@ let routes engine =
     s "metrics" /? nil @--> metrics ~engine;
     s "set" / s "confirm" /? nil @--> set_confirm ~engine;
     s "jobs" /? nil @--> Jobs.r;
+    s "logout" /? nil @--> Resource.logout;
   ] @ Job.routes ~engine
 
 let handle_request ~site routes _conn request body =

--- a/lib_web/current_web.mli
+++ b/lib_web/current_web.mli
@@ -1,30 +1,78 @@
+module User : sig
+  type t
+  (** Information about a site user. *)
+
+  val v : string -> (t, [> `Msg of string]) result
+  (** [v id] is a user with ID [id]. *)
+
+  val id : t -> string
+  (** [id t] is the user ID (e.g. "github:alice") *)
+end
+
+module Role : sig
+  type t = [
+    | `Viewer   (* Read-only access, suitable for the general public. *)
+    | `Builder  (* Can cancel and rebuild jobs. *)
+    | `Monitor  (* Can read the metrics. *)
+    | `Admin    (* Can manage log matcher rules. *)
+  ]
+
+  val pp : t Fmt.t
+end
+
 module Site : sig
   type t
   (** Site configuration settings. *)
 
-  val v : ?name:string -> unit -> t
-  (** [v ~name () is a site named [name] (used for the HTML title, etc). *)
+  val allow_all : (User.t option -> Role.t -> bool)
+  (** [allow_all] grants every role to every user. *)
+
+  val v :
+    ?name:string ->
+    ?authn:(csrf:string -> Uri.t) ->
+    ?secure_cookies:bool ->
+    has_role:(User.t option -> Role.t -> bool) ->
+    unit -> t
+  (** [v ~name ~authn ~has_role ()] is a site named [name] (used for the HTML title, etc)
+      that uses [authn] to authenticate users and [has_role] to control what they can do.
+      @param authn A link to a login page.
+      @param secure_cookies Set secure cookie attribute (turn on if public site uses https). *)
 end
 
 module Context : sig
   type t
   (** The context of a single web request. *)
 
+  val of_request : site:Site.t -> Cohttp.Request.t -> t Lwt.t
+
   val request : t -> Cohttp.Request.t
 
-  val respond_ok : Context.t -> [< Html_types.div_content_fun ] Tyxml.Html.elt list -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val csrf : t -> string
+  (** [csrf t] is the user's CSRF token to include in POST forms. *)
+
+  val set_user : t -> User.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  (** [set_user t user] records a successful login by [user] and redirects the
+      user back to the page they came from. *)
+
+  val respond_ok : t -> [< Html_types.div_content_fun ] Tyxml.Html.elt list -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   (** [respond_ok ctx content] returns a successful page with [content] inserted into the site template. *)
 
-  val respond_redirect : Context.t -> Uri.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val respond_redirect : t -> Uri.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   (** [respond_redirect ctx uri] redirects the user to [uri]. *)
 
-  val respond_error : Context.t -> Cohttp.Code.status_code -> string -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  val respond_error : t -> Cohttp.Code.status_code -> string -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   (** [respond_error ctx code msg] returns an error message to the user, inside the site template. *)
 end
 
 module Resource : sig
   (* A single HTTP resource in the web UI. *)
   class virtual t : object
+    val can_get : Role.t
+    (** The role the client needs in order to make a GET request. *)
+
+    val can_post : Role.t
+    (** The role the client needs in order to make a POST request. *)
+
     method private get : Context.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
     (** Concrete resources should override this method to handle GET requests.
         The default method returns a [`Bad_request] error. *)
@@ -34,11 +82,13 @@ module Resource : sig
         The default method returns a [`Bad_request] error. *)
 
     method get_raw : Site.t -> Cohttp.Request.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-    (** Handle an HTTP GET request. *)
+    (** Handle an HTTP GET request. The default method checks that the caller
+        has the {!can_get} role and then calls [get]. *)
 
     method post_raw : Site.t -> Cohttp.Request.t -> Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
     (** Handle an HTTP POST request.
-        The default method reads the body, checks the CSRF token, and then calls [post]. *)
+        The default method checks that the caller has the {!can_post} role,
+        reads the body, checks the CSRF token, and then calls [post]. *)
   end
 end
 

--- a/lib_web/dune
+++ b/lib_web/dune
@@ -20,6 +20,7 @@
    lwt
    lwt.unix
    mirage-crypto
+   mirage-crypto-rng
    mirage-crypto-rng.unix
    ppx_sexp_conv.runtime-lib
    prometheus

--- a/lib_web/dune
+++ b/lib_web/dune
@@ -2,12 +2,14 @@
  (public_name current_web)
  (libraries
    astring
+   base64
    bos
    cmdliner
    cohttp
    cohttp-lwt
    cohttp-lwt-unix
    conduit-lwt-unix
+   cstruct
    current
    current.cache
    current.term
@@ -17,14 +19,21 @@
    logs
    lwt
    lwt.unix
+   mirage-crypto
+   mirage-crypto-rng.unix
    ppx_sexp_conv.runtime-lib
    prometheus
    prometheus-app
    re
    result
    routes
+   session
+   session-cohttp-lwt
    sexplib
    sqlite3
    tyxml
    tyxml.functor
-   uri))
+   ppx_deriving_yojson.runtime
+   yojson
+   uri)
+ (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/lib_web/jobs.ml
+++ b/lib_web/jobs.ml
@@ -18,6 +18,8 @@ let render_row (id, job) =
 let r = object
   inherit Resource.t
 
+  val! can_get = `Viewer
+
   method! private get ctx =
     let jobs = Current.Job.jobs () in
     Context.respond_ok ctx (

--- a/lib_web/log_rules.ml
+++ b/lib_web/log_rules.ml
@@ -100,6 +100,7 @@ let render ?msg ?test ?(pattern="") ?(report="") ?(score="") ctx =
     | None -> Lwt.return []
     | Some p -> test_pattern p
   end >>= fun test_results ->
+  let csrf = Context.csrf ctx in
   Context.respond_ok ctx (message @ [
       form ~a:[a_action "/log-rules"; a_method `Post] [
         table ~a:[a_class ["table"; "log-rules"]]
@@ -122,7 +123,7 @@ let render ?msg ?test ?(pattern="") ?(report="") ?(score="") ctx =
         input ~a:[a_input_type `Submit; a_name "test"; a_value "Test pattern"] ();
         input ~a:[a_input_type `Submit; a_name "add"; a_value "Add rule"] ();
         input ~a:[a_input_type `Submit; a_name "remove"; a_value "Remove rule"] ();
-        input ~a:[a_name "csrf"; a_input_type `Hidden; a_value Utils.csrf_token] ();
+        input ~a:[a_name "csrf"; a_input_type `Hidden; a_value csrf] ();
       ]
     ] @ [pattern_hints] @ test_results)
 
@@ -171,6 +172,8 @@ let handle_post ctx data =
 
 let r = object
   inherit Resource.t
+
+  val! can_get = `Viewer
 
   method! private get ctx = render ctx
 

--- a/lib_web/pipeline.ml
+++ b/lib_web/pipeline.ml
@@ -29,6 +29,8 @@ let render_svg ctx a =
 let r ~engine = object
   inherit Resource.t
 
+  val! can_get = `Viewer
+
   method! private get ctx =
     render_svg ctx (Current.Engine.pipeline engine) >>= function
     | Ok body ->

--- a/lib_web/query.ml
+++ b/lib_web/query.ml
@@ -39,6 +39,8 @@ let bool_option name value =
 let r = object
   inherit Resource.t
 
+  val! can_get = `Viewer
+
   method! private get ctx =
     let uri = Context.uri ctx in
     let ok = bool_param "ok" uri in

--- a/lib_web/resource.ml
+++ b/lib_web/resource.ml
@@ -1,6 +1,23 @@
 open Lwt.Infix
 
+let () = Mirage_crypto_rng_unix.initialize ()
+
+let forbidden (ctx : Context.t) =
+  match ctx.site.authn, ctx.user with
+  | None, _          (* Site doesn't allow logins! *)
+  | _, Some _ ->     (* User is already logged in. *)
+    Context.respond_error ctx `Forbidden "Permission denied"
+  | Some login_uri, None ->
+    let uri = login_uri ~csrf:(Context.csrf ctx) in
+    Context.respond_ok ctx Tyxml.Html.[
+        txt "Permission denied - you need to ";
+        a ~a:[a_href (Uri.to_string uri)] [ txt "log in" ]
+    ]
+
 class virtual t = object (self)
+  val can_get : Role.t = `Admin
+  val can_post : Role.t = `Admin
+
   method private get ctx =
     Context.respond_error ctx `Bad_request "Bad method"
 
@@ -9,14 +26,41 @@ class virtual t = object (self)
 
   method get_raw site request =
     Context.of_request ~site request >>= fun ctx ->
-    self#get ctx
+    if Context.has_role ctx can_get then self#get ctx
+    else forbidden ctx
 
   method post_raw site request body =
     Context.of_request ~site request >>= fun ctx ->
-    Cohttp_lwt.Body.to_string body >>= fun body ->
-    let data = Uri.query_of_encoded body in
-    match List.assoc_opt "csrf" data |> Option.value ~default:[] with
-    | [got] when got = Utils.csrf_token ->
-      self#post ctx body
-    | _ -> Context.respond_error ctx `Bad_request "Bad CSRF token"
+    if Context.has_role ctx can_post then (
+      Cohttp_lwt.Body.to_string body >>= fun body ->
+      let data = Uri.query_of_encoded body in
+      match List.assoc_opt "csrf" data |> Option.value ~default:[] with
+      | [got] when got = Context.csrf ctx ->
+        self#post ctx body
+      | _ -> Context.respond_error ctx `Bad_request "Bad CSRF token"
+    ) else (
+      forbidden ctx
+    )
+end
+
+let render_logged_out ctx =
+  Context.respond_ok ctx Tyxml.Html.[ txt "You are now logged out" ]
+
+let logout = object
+  method get_raw site request =
+    Context.of_request ~site request >>= fun ctx ->
+    Context.respond_error ctx `Bad_request "Use a POST to log out"
+
+  method post_raw site request body =
+    Context.of_request ~site request >>= fun ctx ->
+    if ctx.user = None then render_logged_out ctx
+    else (
+      Cohttp_lwt.Body.to_string body >>= fun body ->
+      let data = Uri.query_of_encoded body in
+      match List.assoc_opt "csrf" data |> Option.value ~default:[] with
+      | [got] when got = Context.csrf ctx ->
+        Site.Sess.clear site.session_backend ctx.session >>= fun () ->
+        render_logged_out { ctx with user = None }
+      | _ -> Context.respond_error ctx `Bad_request "Bad CSRF token"
+    )
 end

--- a/lib_web/role.ml
+++ b/lib_web/role.ml
@@ -1,0 +1,1 @@
+type t = [ `Viewer | `Builder | `Monitor | `Admin ] [@@deriving show]

--- a/lib_web/site.ml
+++ b/lib_web/site.ml
@@ -1,5 +1,5 @@
 module Sess = struct
-  module Backend = Session.Lift.IO(Lwt)(Session.Memory)
+  module Backend = Session.Lift.IO(Lwt)(Sqlite_session)
   include Session_cohttp_lwt.Make(Backend)
 end
 
@@ -14,4 +14,5 @@ type t = {
 let allow_all _ _ = true
 
 let v ?(name="OCurrent") ?authn ?(secure_cookies=false) ~has_role () =
-  { name; authn; has_role; secure_cookies; session_backend = Session.Memory.create () }
+  let db = Lazy.force Current.Db.v in
+  { name; authn; has_role; secure_cookies; session_backend = Sqlite_session.create db }

--- a/lib_web/site.ml
+++ b/lib_web/site.ml
@@ -1,5 +1,17 @@
+module Sess = struct
+  module Backend = Session.Lift.IO(Lwt)(Session.Memory)
+  include Session_cohttp_lwt.Make(Backend)
+end
+
 type t = {
   name : string;
+  authn : (csrf:string -> Uri.t) option;
+  has_role : User.t option -> Role.t -> bool;
+  secure_cookies : bool;
+  session_backend : Sess.backend;
 }
 
-let v ?(name="OCurrent") () = { name }
+let allow_all _ _ = true
+
+let v ?(name="OCurrent") ?authn ?(secure_cookies=false) ~has_role () =
+  { name; authn; has_role; secure_cookies; session_backend = Session.Memory.create () }

--- a/lib_web/sqlite_session.ml
+++ b/lib_web/sqlite_session.ml
@@ -1,0 +1,93 @@
+module Db = Current.Db
+
+type key = string
+type value = string
+type period = int64
+
+let default_period = Int64.of_int (60 * 60 * 24 * 7)
+
+type t = {
+  get : Sqlite3.stmt;
+  set : Sqlite3.stmt;
+  clear : Sqlite3.stmt;
+  expire : Sqlite3.stmt;
+  mutable next_expire_due : Int64.t;
+}
+
+let gensym () =
+  Base64.encode_exn (Cstruct.to_string (Mirage_crypto_rng.generate 30))
+
+let or_fail label x =
+  match x with
+  | Sqlite3.Rc.OK -> ()
+  | err -> Fmt.failwith "Sqlite3 %s error: %s" label (Sqlite3.Rc.to_string err)
+
+let now () =
+  Int64.of_float (Unix.time ())
+
+let clear t key =
+  Db.exec t.clear Sqlite3.Data.[ TEXT key ]
+
+let expire_old t =
+  Db.exec t.expire Sqlite3.Data.[ INT (now ()) ]
+
+let get t key =
+  match Db.query_some t.get Sqlite3.Data.[ TEXT key ] with
+  | None -> Error Session.S.Not_found
+  | Some Sqlite3.Data.[ value; INT expires ] ->
+    let period = Int64.(sub expires (now ())) in
+    if Int64.compare period 0L < 0 then (
+      clear t key;
+      Error Session.S.Not_found
+    ) else (
+      match value with
+      | NULL       -> Error Session.S.Not_set
+      | TEXT value -> Ok (value, period)
+      | _ -> Fmt.failwith "Invalid value in row!"
+    )
+  | Some row -> Fmt.failwith "get: invalid row: %a" Db.dump_row row
+
+let _set ?expiry ?value t key =
+  let expiry =
+    match expiry with
+    | None        -> Int64.(add (now ()) default_period)
+    | Some expiry -> Int64.(add (now ()) expiry)
+  in
+  let value =
+    match value with
+    | None -> Sqlite3.Data.NULL
+    | Some value -> Sqlite3.Data.TEXT value
+  in
+  Db.exec t.set Sqlite3.Data.[ TEXT key; value; INT expiry ]
+
+let set ?expiry t key value =
+  _set ?expiry ~value t key
+
+let generate ?expiry ?value t =
+  let now = now () in
+  if t.next_expire_due <= now then (
+    expire_old t;
+    t.next_expire_due <- now;
+  );
+  let key = gensym () in
+  _set ?expiry ?value t key;
+  key
+
+let create db =
+  Sqlite3.exec db "CREATE TABLE IF NOT EXISTS web_sessions ( \
+                   key       TEXT NOT NULL, \
+                   value     TEXT, \
+                   expires   INTEGER NOT NULL, \
+                   PRIMARY KEY (key))" |> or_fail "create session table";
+  let get = Sqlite3.prepare db "SELECT value, expires FROM web_sessions WHERE key = ?" in
+  let set = Sqlite3.prepare db "INSERT OR REPLACE INTO web_sessions \
+                                (key, value, expires) \
+                                VALUES (?, ?, ?)" in
+  let expire = Sqlite3.prepare db "DELETE FROM web_sessions WHERE expires < ?" in
+  let clear = Sqlite3.prepare db "DELETE FROM web_sessions WHERE key = ?" in
+  let next_expire_due = Int64.add default_period (now ()) in
+  let t = { get; set; clear; expire; next_expire_due } in
+  expire_old t;
+  t
+
+let default_period _ = default_period

--- a/lib_web/sqlite_session.mli
+++ b/lib_web/sqlite_session.mli
@@ -1,0 +1,8 @@
+(** An ocaml-session backend for sqlite *)
+
+include Session.S.Now with
+  type key = string and
+  type value = string and
+  type period = Int64.t
+
+val create : Current.Db.t -> t

--- a/lib_web/style.ml
+++ b/lib_web/style.ml
@@ -10,9 +10,11 @@ let css = {|
     display: block;
     background: black;
     color: #ddd;
+    overflow: hidden;
   }
 
   nav ul {
+    float: left;
     list-style-type: none;
     margin: 0;
     padding: 0;
@@ -23,6 +25,29 @@ let css = {|
   }
 
   nav li:hover {
+    background: yellow;
+  }
+
+  nav ul.right {
+    float: right;
+  }
+
+  nav ul.right form {
+    padding: 0;
+    background: none!important;
+  }
+
+  nav ul.right button {
+    background: black;
+    border: none;
+    color: #ddd;
+    text-decoration: none;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+  }
+
+  nav ul.right button:hover {
+    color: black;
     background: yellow;
   }
 
@@ -94,6 +119,8 @@ let css = {|
 
 let r = object
   inherit Resource.t
+
+  val! can_get = `Viewer
 
   method! private get _ctx =
     let headers = Cohttp.Header.init_with "Content-Type" "text/css" in

--- a/lib_web/user.ml
+++ b/lib_web/user.ml
@@ -1,0 +1,16 @@
+type t = {
+  id : string;
+} [@@deriving yojson]
+
+let v id = Ok { id }
+
+let id t = t.id
+
+let marshal t =
+  to_yojson t |> Yojson.Safe.to_string
+
+let unmarshal = function
+  | "" -> Ok None
+  | s -> Yojson.Safe.from_string s |> of_yojson |> Result.map Option.some
+
+let pp f t = Fmt.(quote string) f t.id

--- a/lib_web/utils.ml
+++ b/lib_web/utils.ml
@@ -1,10 +1,5 @@
 module Server = Cohttp_lwt_unix.Server
 
-(* Very primitive CSRF protection. *)
-let csrf_token =
-  Random.self_init ();
-  Random.int64 Int64.max_int |> Int64.to_string
-
 let string_of_timestamp time =
   let { Unix.tm_year; tm_mon; tm_mday; tm_hour; tm_min; tm_sec; _ } = time in
   Fmt.strf "%04d-%02d-%02d %02d:%02d:%02d" (tm_year + 1900) (tm_mon + 1) tm_mday tm_hour tm_min tm_sec

--- a/plugins/github/auth.ml
+++ b/plugins/github/auth.ml
@@ -1,0 +1,138 @@
+open Lwt.Infix
+
+module Server = Cohttp_lwt_unix.Server
+
+type t = {
+  client_id : string;
+  client_secret: string;
+  scopes : string list;
+} [@@deriving yojson]
+
+let v ?(scopes=["user:email"]) ~client_id ~client_secret () =
+  { client_id; client_secret; scopes }
+
+module Endpoint = struct
+  let authorize =
+    let uri = Uri.of_string "https://github.com/login/oauth/authorize" in
+    fun ~scopes ~state t ->
+      let scopes = String.concat " " scopes in
+      Uri.with_query' uri [
+        "scope", scopes;
+        "client_id", t.client_id;
+        "state", state;
+      ]
+
+  let access_token =
+    let uri = Uri.of_string "https://github.com/login/oauth/access_token" in
+    fun t ~state code ->
+      Uri.with_query' uri [
+        "client_id", t.client_id;
+        "client_secret", t.client_secret;
+        "code", code;
+        "state", state;
+      ]
+
+  let user = Uri.of_string "https://api.github.com/user"
+end
+
+let make_login_uri t ~csrf =
+  Endpoint.authorize ~scopes:t.scopes ~state:csrf t
+
+let get_access_token t ~state code =
+  let headers = Cohttp.Header.init_with "Accept" "application/json" in
+  Cohttp_lwt_unix.Client.post ~headers (Endpoint.access_token t ~state code) >>= fun (resp, body) ->
+  Cohttp_lwt.Body.to_string body >|= fun body ->
+  match Cohttp.Response.status resp with
+  | `OK ->
+    let json = Yojson.Safe.from_string body in
+    Ok (Yojson.Safe.Util.(json |> member "access_token" |> to_string))
+  | err -> Error (err, body)
+
+let get_user token =
+  let headers = Cohttp.Header.init_with "Authorization" ("token " ^ token) in
+  Cohttp_lwt_unix.Client.get ~headers Endpoint.user >>= fun (resp, body) ->
+  Cohttp_lwt.Body.to_string body >|= fun body ->
+  match Cohttp.Response.status resp with
+  | `OK ->
+    let json = Yojson.Safe.from_string body in
+    let github_user = Yojson.Safe.Util.(json |> member "login" |> to_string) in
+    Ok ("github:" ^ github_user)
+  | err ->
+    Error (err, body)
+
+let example_config () =
+  v ~client_id:"..." ~client_secret:"..." ()
+  |> to_yojson
+  |> Yojson.Safe.pretty_to_string
+
+let configuration_howto ctx =
+  Current_web.Context.respond_ok ctx Tyxml.Html.[
+      p [ txt "GitHub single-sign-on has not been configured." ];
+      p [
+        txt "Start the service with ";
+        code [txt "--github-oauth path.json"];
+        txt ", where the file contains:";
+      ];
+      pre [ txt (example_config ()) ]
+    ]
+
+let login t : Current_web.Resource.t = object
+  method get_raw site request =
+    Current_web.Context.of_request ~site request >>= fun ctx ->
+    match t with
+    | None -> configuration_howto ctx
+    | Some t ->
+      let uri = Cohttp.Request.uri request in
+      match Uri.get_query_param uri "code", Uri.get_query_param uri "state" with
+      | None, _ -> Server.respond_error ~status:`Bad_request ~body:"Missing code" ()
+      | _, None -> Server.respond_error ~status:`Bad_request ~body:"Missing state" ()
+      | Some code, Some state ->
+        if state <> Current_web.Context.csrf ctx then (
+          Server.respond_error ~status:`Bad_request ~body:"Bad CSRF token" ()
+        ) else (
+          get_access_token t ~state code >>= function
+          | Error (status, msg) ->
+            Log.warn (fun f -> f "Failed to get OAuth token from GitHub: %s: %s" (Cohttp.Code.string_of_status status) msg);
+            Server.respond_error ~status:`Internal_server_error ~body:"Failed to get token" ()
+          | Ok token ->
+            get_user token >>= function
+            | Error (status, msg) ->
+              Log.warn (fun f -> f "Failed to get user details from GitHub: %s: %s" (Cohttp.Code.string_of_status status) msg);
+              Server.respond_error ~status:`Internal_server_error ~body:"Failed to get user details" ()
+            | Ok user ->
+              Log.info (fun f -> f "Successful login for %S" user);
+              match Current_web.User.v user with
+              | Error (`Msg m) ->
+                Log.warn (fun f -> f "Failed to create user: %s" m);
+                Server.respond_error ~status:`Bad_request ~body:"Bad user" ()
+              | Ok user ->
+                Current_web.Context.set_user ctx user
+        )
+
+  method post_raw _ _ _ =
+    Server.respond_error ~status:`Bad_request ~body:"Bad method" ()
+end
+
+open Cmdliner
+
+let oauth_config =
+  Arg.value @@
+  Arg.opt Arg.(some file) None @@
+  Arg.info
+    ~doc:"The JSON file containing the GitHub OAuth configuration"
+    ~docv:"PATH"
+    ["github-oauth"]
+
+let make_config path =
+  match Yojson.Safe.from_file path with
+  | exception ex -> Fmt.failwith "Invalid JSON in %s:@,%a" path Fmt.exn ex
+  | json ->
+    json
+    |> of_yojson
+    |> function
+    | Ok x -> x
+    | Error msg ->
+      Fmt.failwith "Invalid GitHub OAuth configuration: %s@.Expected: %s" msg (example_config ())
+
+let cmdliner =
+  Term.(const (Option.map make_config) $ oauth_config)

--- a/plugins/github/current_github.ml
+++ b/plugins/github/current_github.ml
@@ -4,6 +4,7 @@ module Repo_id = Repo_id
 module Api = Api
 module App = App
 module Installation = Installation
+module Auth = Auth
 
 module Metrics = struct
   open Prometheus

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -144,3 +144,23 @@ module App : sig
   val installations : t -> Installation.t list Current.t
   (** [installations t] evaluates to the list of installations for this app. *)
 end
+
+(** Use GitHub to authenticate users. *)
+module Auth : sig
+  type t
+  (** Configuration for GitHub OAuth single-sign-on. *)
+
+  val v : ?scopes:string list -> client_id:string -> client_secret:string -> unit -> t
+  (** Create a configuration using the details provided by GitHub. *)
+
+  val make_login_uri : t -> csrf:string -> Uri.t
+  (** Use this as your [~authn] in {!Current_web.Site.v}. *)
+
+  val login : t option -> Current_web.Resource.t
+  (** The callback page for logins. Add a route to this from the URL you
+      configured when you set up your GitHub OAuth app.
+      If [t = None] then the page will tell you how to configure it. *)
+
+  val cmdliner : t option Cmdliner.Term.t
+  (** Get the configuration from the command-line. *)
+end

--- a/plugins/github/dune
+++ b/plugins/github/dune
@@ -24,5 +24,7 @@
    rresult
    uri
    x509
+   tyxml
+   tyxml.functor
    yojson)
  (preprocess (pps ppx_deriving_yojson)))


### PR DESCRIPTION
- `Site` now takes `authn` and `has_role` arguments.
- `authn` (if given) is used to create a "Login" link in the navbar.
- `has_role` is used to decide who can access which resource.
- The GitHub plugin now provides an authentication backend that authenticates users with GitHub.