### PR TITLE
Git: Make `Commit_id.pp_user_clone` public

### DIFF
--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -29,7 +29,7 @@ module Key = struct
 
   let source_to_json = function
     | `No_context -> `Null
-    | `Git commit -> `String (Current_git.Commit.id commit)
+    | `Git commit -> `String (Current_git.Commit.hash commit)
 
   let to_json { commit; dockerfile; docker_context; squash; build_args } =
     `Assoc [

--- a/plugins/git/commit.ml
+++ b/plugins/git/commit.ml
@@ -16,16 +16,17 @@ type t = {
 
 [@@@ocaml.warning "+3"]
 
-let id t = t.id.Commit_id.hash
-let compare a b = String.compare (id a) (id b)
-let equal a b = String.equal (id a) (id b)
-let pp = Fmt.using id Fmt.string
+let id t = t.id
+let hash t = t.id.Commit_id.hash
+let compare a b = String.compare (hash a) (hash b)
+let equal a b = String.equal (hash a) (hash b)
+let pp = Fmt.using hash Fmt.string
 
 let pp_short f t =
-  Fmt.string f @@ Astring.String.with_range ~len:6 (id t)
+  Fmt.string f @@ Astring.String.with_range ~len:6 (hash t)
 
 let check_cached t =
-  let hash = id t in
+  let hash = hash t in
   let branch = Fmt.strf "fetch-%s" hash in
   Cmd.git ~cwd:t.repo ["branch"; "-f"; branch; hash]
 

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -17,13 +17,18 @@ module Commit_id : sig
 
   val equal : t -> t -> bool
   val pp : t Fmt.t
+
+  val pp_user_clone : t Fmt.t
+  (** Display a Git command a user could run to get this commit. *)
+
   val digest : t -> string
 end
 
 module Commit : sig
   include Set.OrderedType
 
-  val id : t -> string
+  val id : t -> Commit_id.t
+  val hash : t -> string
   val equal : t -> t -> bool
   val pp : t Fmt.t
 


### PR DESCRIPTION
Also, `Commit.id` now returns a `Commit_id.t`. Use `Commit.hash` to get the hash.