### PR TITLE
Add missing ?cwd to Current.Process.exec

### DIFF
--- a/lib/current.mli
+++ b/lib/current.mli
@@ -320,12 +320,13 @@ end
 (** Helper functions for spawning sub-processes. *)
 module Process : sig
   val exec :
-    ?stdin:string ->
+    ?cwd:Fpath.t -> ?stdin:string ->
     ?pp_error_command:(Format.formatter -> unit) ->
     cancellable:bool ->
     job:Job.t -> Lwt_process.command ->
     unit or_error Lwt.t
   (** [exec ~job cmd] uses [Lwt_process] to run [cmd], with output to [job]'s log.
+      @param cwd Sets the current working directory for this command.
       @param cancellable Should the process be terminated if the job is cancelled?
       @param stdin Data to write to stdin before closing it.
       @param pp_error_command Format the command for an error message.

--- a/lib/process.ml
+++ b/lib/process.ml
@@ -101,11 +101,12 @@ let add_shutdown_hooks ~cancellable ~job ~cmd proc =
       )
   )
 
-let exec ?(stdin="") ?pp_error_command ~cancellable ~job cmd =
+let exec ?cwd ?(stdin="") ?pp_error_command ~cancellable ~job cmd =
+  let cwd = Option.map Fpath.to_string cwd in
   let pp_error_command = Option.value pp_error_command ~default:(pp_command cmd) in
   Log.info (fun f -> f "Exec: @[%a@]" pp_cmd cmd);
   Job.log job "Exec: @[%a@]" pp_cmd cmd;
-  let proc = Lwt_process.open_process ~stderr:(`FD_copy Unix.stdout) cmd in
+  let proc = Lwt_process.open_process ?cwd ~stderr:(`FD_copy Unix.stdout) cmd in
   let copy_thread = copy_to_log ~job proc#stdout in
   add_shutdown_hooks ~cancellable ~job ~cmd proc >>= fun () ->
   send_to proc#stdin stdin >>= fun stdin_result ->

--- a/lib/process.mli
+++ b/lib/process.mli
@@ -1,5 +1,5 @@
 val exec :
-  ?stdin:string ->
+  ?cwd:Fpath.t -> ?stdin:string ->
   ?pp_error_command:(Format.formatter -> unit) ->
   cancellable:bool -> job:Job.t -> Lwt_process.command ->
   unit Current_term.S.or_error Lwt.t


### PR DESCRIPTION
`Current.Process.check_output` had it but not `Current.Process.exec`