### PR TITLE
Allow jobs to latch previous output while rebuilding

### DIFF
--- a/lib/current.mli
+++ b/lib/current.mli
@@ -33,6 +33,13 @@ class type actions = object
       or [None] if it is not something that can be repeated. Returns the new job ID. *)
 end
 
+module Metadata : sig
+  type t = {
+    job_id : job_id option;
+    update : Current_term.Output.active option;
+  }
+end
+
 (** An OCurrent pipeline is made up of primitive operations.
     A primitive is roughly the content of a single box in the diagram.
 
@@ -40,7 +47,7 @@ end
     use {!Current_cache} (for processing or publishing jobs) or {!Monitor} (for
     inputs) instead. *)
 module Primitive : sig
-  type 'a t = ('a Current_term.Output.t * job_id option) Current_incr.t
+  type 'a t = ('a Current_term.Output.t * Metadata.t option) Current_incr.t
 
   val const : 'a -> 'a t
   (** [const x] is a primitive that always evaluates to [x] and never needs to be updated. *)
@@ -51,7 +58,7 @@ module Primitive : sig
 end
 
 include Current_term.S.TERM with
-  type metadata := job_id and
+  type metadata := Metadata.t and
   type 'a primitive := 'a Primitive.t
 
 (** A monitor is an input pipeline stage that can watch for external events. *)
@@ -89,7 +96,7 @@ type 'a term = 'a t
 (** Diagram generation, introspection, and statistics. *)
 module Analysis : Current_term.S.ANALYSIS with
   type 'a term := 'a t and
-  type metadata := job_id
+  type metadata := Metadata.t
 
 (** Variable pipeline inputs. *)
 module Var (T : Current_term.S.T) : sig

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -33,10 +33,19 @@ class type actions = object
       or [None] if it is not something that can be repeated. Returns the new job ID. *)
 end
 
+(** Metadata associated with primitive terms. *)
 module Metadata : sig
   type t = {
     job_id : job_id option;
+    (** The job ID, for jobs with logs. This is used when generating the
+        diagrams to create links to the job pages, and can also be useful for
+        indexing. *)
+
     update : Current_term.Output.active option;
+    (** If the job is updating in the background (while still outputting the
+        previous value), this gives the status of the update. In the diagrams,
+        this will appear as a gradient from the update colour on the left to
+        the output state's colour on the right. *)
   }
 end
 

--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -460,7 +460,8 @@ module Output(Op : S.PUBLISHER) = struct
             in
             Error (`Active a)
         in
-        Current_incr.write (v, o.job_id)
+        let metadata = { Current.Metadata.job_id = o.job_id; update = None } in
+        Current_incr.write (v, Some metadata)
     end
 
   let reset () =

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -6,5 +6,9 @@ module Make (Metadata : sig type t end) : sig
   val stats : _ t -> S.stats
 
   val pp : _ t Fmt.t
-  val pp_dot : env:(string * string) list -> url:(Metadata.t S.link -> string option) -> _ t Fmt.t
+  val pp_dot :
+    env:(string * string) list ->
+    collapse_link:(k:string -> v:string -> string option) ->
+    job_info:(Metadata.t -> Output.active option * string option) ->
+    _ t Fmt.t
 end with type 'a t := 'a Node.Make(Metadata).t

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -9,12 +9,6 @@ type stats = {
 }
 (** Counters showing how many pipeline stages are in each state. *)
 
-type 'j link = [
-  | `Collapse of string * string        (* [Collapse (k, v) is a link to the same page
-                                           with "?k=v" added to the environment. *)
-  | `Job of 'j                          (* [Job id] link to the job with ID [id]. *)
-]
-
 module type T = sig
   type t
   val equal : t -> t -> bool
@@ -41,10 +35,20 @@ module type ANALYSIS = sig
   val pp : _ term Fmt.t
   (** [pp] formats a [t] as a simple string. *)
 
-  val pp_dot : env:(string * string) list -> url:(metadata link -> string option) -> _ term Fmt.t
-  (** [pp_dot ~env ~url] formats a [t] as a graphviz dot graph.
+  val pp_dot :
+    env:(string * string) list ->
+    collapse_link:(k:string -> v:string -> string option) ->
+    job_info:(metadata -> Output.active option * string option) ->
+    _ term Fmt.t
+  (** [pp_dot ~env ~collapse_link ~job_info] formats a [t] as a graphviz dot graph.
       @param env A list of key-value pairs from the URL to control rendering.
-      @param url Generates URLs for links. *)
+      @param collapse_link Should return a link to the same page with "?k=v"
+                           added to the environment.
+      @param job_info Get update statuses and URLs for links to jobs.
+                      The update status is used if the job is rebuilding while
+                      showing the output of a previous run. The box is
+                      displayed using a gradient from the update status colour
+                      to the current output colour. *)
 
   val stats : _ term -> stats
   (** [stats t] count how many stages are in each state. *)

--- a/lib_web/pipeline.ml
+++ b/lib_web/pipeline.ml
@@ -9,13 +9,14 @@ let render_svg ctx a =
       | (k, v :: _) -> Some (k, v)
     ) in
   let old_query = Uri.query uri in
-  let url = function
-    | `Collapse (k, v) ->
+  let collapse_link ~k ~v =
       let query = (k, [v]) :: List.remove_assoc k old_query in
       Some (Uri.make ~path:"/" ~query () |> Uri.to_string)
-    | `Job id -> Some (Fmt.strf "/job/%s" id)
+  and job_info { Current.Metadata.job_id; update } =
+    let url = job_id |> Option.map (fun id -> Fmt.strf "/job/%s" id) in
+    update, url
   in
-  let dotfile = Fmt.to_to_string (Current.Analysis.pp_dot ~env ~url) a in
+  let dotfile = Fmt.to_to_string (Current.Analysis.pp_dot ~env ~collapse_link ~job_info) a in
   let proc = Lwt_process.open_process_full dot_to_svg in
   Lwt_io.write proc#stdin dotfile >>= fun () ->
   Lwt_io.close proc#stdin >>= fun () ->

--- a/test/driver.ml
+++ b/test/driver.ml
@@ -83,9 +83,10 @@ let test ?config ?final_stats ~name v actions =
       let path = Fmt.strf "%s.%d.dot" name !step in
       let ch = open_out path in
       let f = Format.formatter_of_out_channel ch in
-      let url _ = None in
+      let collapse_link ~k:_ ~v:_ = None in
+      let job_info { Current.Metadata.job_id = _; update } = update, None in
       let env = [] in
-      Fmt.pf f "%a@!" (Current.Analysis.pp_dot ~env ~url) test_pipeline;
+      Fmt.pf f "%a@!" (Current.Analysis.pp_dot ~env ~collapse_link ~job_info) test_pipeline;
       close_out ch
     end;
     current_watches := step_result;

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -1,5 +1,9 @@
 (rule
- (targets option-none.1.dot
+ (targets latch.1.dot
+          latch.2.dot
+          latch.3.dot
+          latch.4.dot
+          option-none.1.dot
           option-none.2.dot
           option-some.1.dot
           option-some.2.dot
@@ -28,6 +32,26 @@
           v5n.2.dot
           v5n.3.dot)
  (action (run ./test.exe)))
+
+(rule
+ (alias runtest)
+ (package current)
+ (action (diff expected/latch.1.dot latch.1.dot)))
+
+(rule
+ (alias runtest)
+ (package current)
+ (action (diff expected/latch.2.dot latch.2.dot)))
+
+(rule
+ (alias runtest)
+ (package current)
+ (action (diff expected/latch.3.dot latch.3.dot)))
+
+(rule
+ (alias runtest)
+ (package current)
+ (action (diff expected/latch.4.dot latch.4.dot)))
 
 (rule
  (alias runtest)

--- a/test/expected/latch.1.dot
+++ b/test/expected/latch.1.dot
@@ -1,0 +1,16 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#ffa500",style="filled"]
+  n7 [label="docker pull alpine",fillcolor="#ffa500:#ffa500",style="filled"]
+  n1 [label="test",fillcolor="#d3d3d3",style="filled"]
+  n7 -> n1
+  n5 -> n1
+  n2 -> n7
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
+  }

--- a/test/expected/latch.2.dot
+++ b/test/expected/latch.2.dot
@@ -1,0 +1,16 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="docker pull alpine",fillcolor="#90ee90",style="filled"]
+  n1 [label="test",fillcolor="#90ee90",style="filled"]
+  n7 -> n1
+  n5 -> n1
+  n2 -> n7
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
+  }

--- a/test/expected/latch.3.dot
+++ b/test/expected/latch.3.dot
@@ -1,0 +1,16 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="docker pull alpine",fillcolor="#ffa500:#90ee90",style="filled"]
+  n1 [label="test",fillcolor="#90ee90",style="filled"]
+  n7 -> n1
+  n5 -> n1
+  n2 -> n7
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
+  }

--- a/test/expected/latch.4.dot
+++ b/test/expected/latch.4.dot
@@ -1,0 +1,16 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n3 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n2 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="head",fillcolor="#90ee90",style="filled"]
+  n5 [label="fetch",fillcolor="#90ee90",style="filled"]
+  n7 [label="docker pull alpine",fillcolor="#90ee90",style="filled"]
+  n1 [label="test",fillcolor="#90ee90",style="filled"]
+  n7 -> n1
+  n5 -> n1
+  n2 -> n7
+  n6 -> n5
+  n2 -> n6
+  n3 -> n2
+  }

--- a/test/plugins/docker/current_docker_test.mli
+++ b/test/plugins/docker/current_docker_test.mli
@@ -2,7 +2,7 @@
 
 type source = Fpath.t
 
-module Image : sig type t end
+module Image : sig type t = string end
 
 val build : ?on:string -> source Current.t -> Image.t Current.t
 (** [build ~on:platform src] builds a Docker image from source. *)
@@ -15,6 +15,15 @@ val complete : string -> cmd:string list -> (unit, [`Msg of string]) result -> u
 
 val push : Image.t Current.t -> tag:string -> unit Current.t
 (** [push x ~tag] publishes [x] on Docker Hub as [tag]. *)
+
+val pull : string -> Image.t Current.t
+(** [pull tag] pulls [tag] from Docker Hub. *)
+
+val complete_pull : string -> Image.t Current.or_error -> unit
+(** [complete_pull tag image] marks the pull for [tag] as complete. *)
+
+val update_pull : string -> unit
+(** [update_pull tag] checks for updates to [tag] in the background. *)
 
 val reset : unit -> unit
 (** Reset state for tests. *)

--- a/test/plugins/docker/dune
+++ b/test/plugins/docker/dune
@@ -3,6 +3,8 @@
  (libraries
    current
    current.cache
+   current.term
+   current_incr
    fmt
    fpath
    logs


### PR DESCRIPTION
A primitive can now report a status for the job separately from the output status. This allows a job to check for updates in the background while continuing to provide the old value as its output.

This is used by `Monitor` jobs (which have always updated in the background, but previously didn't show any visual indication of this activity in the diagrams), and by `Current_cache` jobs (which now latch the old value during scheduled rebuilds).