### PR TITLE
Add `Current_cache.Generic` to control latching behaviour

### DIFF
--- a/lib_cache/s.ml
+++ b/lib_cache/s.ml
@@ -29,9 +29,8 @@ module type OPERATION = sig
   (** The [id, Key.t] pair uniquely identifies the operation. *)
 end
 
+(** A builder generates an output value from an input key. *)
 module type BUILDER = sig
-  (** A builder generates an output value from an input key. *)
-
   include OPERATION
 
   module Value : WITH_MARSHAL
@@ -52,9 +51,8 @@ module type BUILDER = sig
       [false] to cancel only when the user explicitly requests it. *)
 end
 
+(** A publisher sets a key to a value. *)
 module type PUBLISHER = sig
-  (** A publisher sets a key to a value. *)
-
   include OPERATION
 
   module Value : WITH_DIGEST
@@ -79,4 +77,44 @@ module type PUBLISHER = sig
       then we decide to output a different value instead.
       If [true], the old operation will be cancelled immediately.
       If [false], the old operation will run to completion first. *)
+end
+
+(** The most general API.
+    {!BUILDER} and {!PUBLISHER} are just special cases of this. *)
+module type GENERIC = sig
+
+  include OPERATION
+
+  module Value : WITH_DIGEST
+  (** A second input value, which is not part of the key
+      (so there can be only one value for any key at one time).
+      For outputs, this is used to hold the value to which the output should be set.
+      For builds, non-essential inputs can be placed here instead of in the key
+      so that the old outcome can be latched for minor changes. For example, when
+      testing a Git commit the commit to test would be the key, but the latest
+      version of the test platform might be the value. *)
+
+  module Outcome : WITH_MARSHAL
+  (** The output of the pipeline stage. *)
+
+  val run :
+    t -> Current.Job.t -> Key.t -> Value.t ->
+    Outcome.t Current.or_error Lwt.t
+  (** [run t j k v] performs the operation.
+      Call [Job.start j] once any required resources have been acquired.
+      Log messages can be written to [j]. *)
+
+  val pp : (Key.t * Value.t) Fmt.t
+  (** Describe the operation. e.g. ["docker push $tag"]. *)
+
+  val auto_cancel : bool
+  (** This affects what happens if we're in the process of outputting a value and
+      then we decide to output a different value instead.
+      If [true], the old operation will be cancelled immediately.
+      If [false], the old operation will run to completion first. *)
+
+  val latched : bool
+  (** This controls what happens to the reported outcome while changing to a new value.
+      If [true], we continue to report the previous outcome until the new job is complete.
+      If [false], the output is set to active during the update. *)
 end

--- a/test/plugins/docker/current_docker_test.ml
+++ b/test/plugins/docker/current_docker_test.ml
@@ -158,8 +158,8 @@ let reset () =
   containers := Containers.empty;
   Hashtbl.clear image_pulls;
   Hashtbl.clear image_monitors;
-  Run_cache.reset ();
-  Push_cache.reset ()
+  Run_cache.reset ~db:true;
+  Push_cache.reset ~db:true
 
 let assert_finished () =
   !containers |> Containers.iter (fun key s ->

--- a/test/plugins/git/current_git_test.ml
+++ b/test/plugins/git/current_git_test.ml
@@ -63,4 +63,4 @@ let fetch c =
 
 let reset () =
   state := RepoMap.empty;
-  C.reset ()
+  C.reset ~db:true


### PR DESCRIPTION
This provides the full API. `BUILDER` and `PUBLISHER` are now special cases of `GENERIC`.