### PR TITLE
GitHub: remove unicorn from error string

### DIFF
--- a/lib_term/dot.ml
+++ b/lib_term/dot.ml
@@ -21,8 +21,13 @@ let fix_escaping s =
     Buffer.contents b
   )
 
+let limit_str len s =
+  if String.length s <= len then s
+  else String.sub s 0 (len - 3) ^ "..."
+
 let node f ?style ?shape ?bg ?url ?tooltip i label =
   let url = Option.map fix_escaping url in
+  let tooltip = Option.map (limit_str 4096) tooltip in (* (Graphviz max length is 16384) *)
   let attrs = [
     "label", Some label;
     "fillcolor", bg;

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -226,9 +226,11 @@ let exec_graphql ?variables t query =
           | _ ->
             Fmt.failwith "Unknown error type from GitHub GraphQL"
       end
-    | err -> Fmt.failwith "@[<v2>Error performing GraphQL query on GitHub: %s@,%s@]"
-               (Cohttp.Code.string_of_status err)
-               body
+    | err ->
+      Log.warn (fun f -> f "@[<v2>Error performing GraphQL query on GitHub: %s@,%s@]"
+                   (Cohttp.Code.string_of_status err)
+                   body);
+      Fmt.failwith "Error performing GraphQL query on GitHub: %s" (Cohttp.Code.string_of_status err)
 
 let query_default =
   "query($owner: String!, $name: String!) { \


### PR DESCRIPTION
When a GraphQL query returned a server error, we previously returned the body of the HTTP response as the error message. However, this includes a large picture of a unicorn, which is not suitable as an error string.