### PR TITLE
Add ?pool argument to Git.with_checkout

### DIFF
--- a/lib/current.mli
+++ b/lib/current.mli
@@ -178,7 +178,8 @@ module Switch : sig
   (** Prints the state of the switch (for debugging). *)
 end
 
-(** Resource pools, to control how many jobs can use a resource at a time. *)
+(** Resource pools, to control how many jobs can use a resource at a time.
+    To use a pool within a job, call {!Job.use_pool}. *)
 module Pool : sig
   type t
 
@@ -265,6 +266,11 @@ module Job : sig
 
   val register_actions : job_id -> actions -> unit
   (** [register_actions job_id actions] is used to register handlers for e.g. rebuilding jobs. *)
+
+  val use_pool : switch:Switch.t -> t -> Pool.t -> unit Lwt.t
+  (** [use_pool ~switch t pool] gets one resource from [pool].
+      The resource is returned to the pool when the switch is turned off.
+      The operation will be aborted if the job is cancelled. *)
 
   (**/**)
 

--- a/lib/switch.ml
+++ b/lib/switch.ml
@@ -14,7 +14,7 @@ let pp_reason f x = Current_term.Output.pp (Fmt.unit "()") f (x :> unit Current_
 let turn_off t =
   match t.state with
   | `Off ->
-    Log.info (fun f -> f "Switch.turn_off: already off");
+    Log.debug (fun f -> f "Switch.turn_off: already off");
     Lwt.return_unit
   | `Turning_off thread ->
     thread

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -45,12 +45,14 @@ val clone : schedule:Current_cache.Schedule.t -> ?gref:string -> string -> Commi
 val fetch : Commit_id.t Current.t -> Commit.t Current.t
 
 val with_checkout :
+  ?pool:Current.Pool.t ->
   job:Current.Job.t ->
   Commit.t ->
   (Fpath.t -> 'a Current.or_error Lwt.t) ->
   'a Current.or_error Lwt.t
 (** [with_checkout ~job c fn] clones [c] to a temporary directory and runs [fn tmpdir].
-    When it returns, the directory is deleted. *)
+    When it returns, the directory is deleted.
+    @param pool Used to prevent too many clones from happening at once. *)
 
 module Local : sig
   type t


### PR DESCRIPTION
Git checkout operations can use a lot of CPU and IO, so allow users to supply a pool to limit the number of concurrent operations.