### PR TITLE
Add simple job priorities

### DIFF
--- a/lib/pool.mli
+++ b/lib/pool.mli
@@ -1,9 +1,15 @@
 type t
 
+type priority = [ `High | `Low ]
+
 val create : label:string -> int -> t
 
-val get : on_cancel:((string -> unit Lwt.t) -> unit Lwt.t) -> switch:Switch.t -> t -> unit Lwt.t
-(** [get ~on_cancel ~switch t] waits for a resource and then returns.
+val get :
+  priority:priority ->
+  on_cancel:((string -> unit Lwt.t) -> unit Lwt.t) ->
+  switch:Switch.t ->
+  t -> unit Lwt.t
+(** [get ~priority ~on_cancel ~switch t] waits for a resource and then returns.
     The resource will be returned to the pool when [switch] is turned off. *)
 
 val pp : t Fmt.t

--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -213,7 +213,8 @@ module Generic(Op : S.GENERIC) = struct
     output.current <- None;
     let ctx = output.ctx in
     let switch = Current.Switch.create ~label:Op.id () in
-    let job = Job.create ~switch ~label:Op.id ~config () in
+    let priority = if latched = None then `High else `Low in
+    let job = Job.create ~priority ~switch ~label:Op.id ~config () in
     let job_id = Job.id job in
     output.job_id <- Some job_id;
     let op = { value = output.desired; job; autocancelled = false } in


### PR DESCRIPTION
Pools now have high and low priority queues. The cache puts jobs on the low priority queue if they have a latched result available.