### PR TITLE
use `Routes.empty` for empty routes.

### DIFF
--- a/current_web.opam
+++ b/current_web.opam
@@ -30,6 +30,6 @@ depends: [
   "prometheus-app"
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
-  "routes" {>= "0.7.0"}
+  "routes" {>= "0.8.0"}
   "dune" {>= "2.0"}
 ]

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -38,7 +38,7 @@ end
 
 let routes engine =
   Routes.[
-    nil @--> Main.r ~engine;
+    empty @--> Main.r ~engine;
     s "index.html" /? nil @--> Main.r ~engine;
     s "css" / s "style.css" /? nil @--> Style.r;
     s "pipeline.svg" /? nil @--> Pipeline.r ~engine;


### PR DESCRIPTION
Starting version 0.8.0, nil can only be used after another route pattern.
See: https://github.com/anuragsoni/routes/pull/111

https://github.com/ocaml/opam-repository/pull/16386 -> PR to add a version constraint of < 0.8.0 for the version of current_web on opam