### PR TITLE
Revert "Disable ocaml-tls when posting to Slack"

### DIFF
--- a/current_slack.opam
+++ b/current_slack.opam
@@ -20,7 +20,7 @@ depends: [
   "fmt"
   "yojson"
   "lwt"
-  "lwt_ssl"
+  "tls" {>= "0.12.0"}
   "cohttp-lwt-unix"
   "dune" {>= "2.0"}
 ]

--- a/plugins/slack/dune
+++ b/plugins/slack/dune
@@ -5,9 +5,6 @@
    cohttp
    cohttp-lwt
    cohttp-lwt-unix
-   conduit
-   conduit-lwt
-   conduit-lwt-unix
    current
    current.cache
    current.term

--- a/plugins/slack/post.ml
+++ b/plugins/slack/post.ml
@@ -8,24 +8,6 @@ module Key = Current.String
 module Value = Current.String
 module Outcome = Current.Unit
 
-(* Slack only allows EC crypto, which ocaml-tls doesn't support yet, so force the use of OpenSSL. *)
-module Net = struct
-  include Cohttp_lwt_unix.Net
-
-  let force_openssl = function
-    | `TLS x | `TLS_native x | `OpenSSL x -> `OpenSSL x
-    | _ -> failwith "force_openssl: unexpected Slack connection type!"
-
-  let connect_uri ~ctx uri =
-    Resolver_lwt.resolve_uri ~uri ctx.resolver
-    >>= fun endp ->
-    Conduit_lwt_unix.endp_to_client ~ctx:ctx.ctx endp
-    >>= fun client ->
-    Conduit_lwt_unix.connect ~ctx:ctx.ctx (force_openssl client)
-end
-
-module Client = Cohttp_lwt.Make_client(Cohttp_lwt_unix.IO)(Net)
-
 let publish t job _key message =
   Current.Job.start job ~level:Current.Level.Above_average >>= fun () ->
   let headers = Cohttp.Header.of_list [
@@ -38,7 +20,7 @@ let publish t job _key message =
     |> Yojson.to_string
     |> Cohttp_lwt.Body.of_string
   in
-  Client.post ~headers ~body t >>= fun (resp, _body) ->
+  Cohttp_lwt_unix.Client.post ~headers ~body t >>= fun (resp, _body) ->
   match resp.Cohttp_lwt.Response.status with
   | `OK -> Lwt.return @@ Ok ()
   | err ->


### PR DESCRIPTION
This reverts commit 1197cf46e04626c7480575d3b03cf7165feb549e and instead requires tls >= 0.12.0 to get the required support.