### PR TITLE
Web UI: improvements to query page

### DIFF
--- a/lib_cache/current_cache.mli
+++ b/lib_cache/current_cache.mli
@@ -64,11 +64,12 @@ module Db : sig
   (** Ensure that the database tables have been created.
       This is useful if you need to refer to them in your own SQL. *)
 
-  val query : ?op:string -> ?ok:bool -> ?rebuild:bool -> unit -> entry list
+  val query : ?op:string -> ?ok:bool -> ?rebuild:bool -> ?job_prefix:string -> unit -> entry list
   (** Search the database for matching records.
       @param op : if present, restrict to results from the named builder or publisher
       @param ok : if present, restrict results to passing (ok=true) or failing (ok=false) results.
-      @param rebuild : if present, restrict results to ones where the rebuild flag matches this. *)
+      @param rebuild : if present, restrict results to ones where the rebuild flag matches this.
+      @param job_prefix : if present, restrict results to ones where the job ID starts with this string. *)
 
   val ops : unit -> string list
   (** [ops ()] is the list of operation types that can be passed to [query]. *)

--- a/lib_cache/current_cache.mli
+++ b/lib_cache/current_cache.mli
@@ -70,6 +70,9 @@ module Db : sig
       @param ok : if present, restrict results to passing (ok=true) or failing (ok=false) results.
       @param rebuild : if present, restrict results to ones where the rebuild flag matches this. *)
 
+  val ops : unit -> string list
+  (** [ops ()] is the list of operation types that can be passed to [query]. *)
+
   val history : limit:int -> job_id:string -> string option * entry list
   (** [history ~limit ~job_id] returns the in-progress build (if any),
       and the [limit] most recent builds with the same key as [job_id]. *)

--- a/lib_cache/db.mli
+++ b/lib_cache/db.mli
@@ -42,6 +42,6 @@ val lookup_job_id : string -> (string * string) option
 (** These functions are described in the {!Current_cache} public API. *)
 
 val init : unit -> unit
-val query : ?op:string -> ?ok:bool -> ?rebuild:bool ->unit -> entry list
+val query : ?op:string -> ?ok:bool -> ?rebuild:bool -> ?job_prefix:string -> unit -> entry list
 val history : limit:int -> op:string -> string -> entry list
 val ops : unit -> string list

--- a/lib_cache/db.mli
+++ b/lib_cache/db.mli
@@ -26,8 +26,6 @@ val record :
     @param running When the job started running.
     @param finished When the job stopped running (i.e. now). *)
 
-val init : unit -> unit
-
 val lookup : op:string -> string -> entry option
 (** [lookup ~op key] returns the most recently stored result for [op] and [key], if any. *)
 
@@ -37,10 +35,13 @@ val drop_all : string -> unit
 val invalidate : op:string -> string -> unit
 (** [invalidate ~op key] removes any existing entry for [op, key]. *)
 
-val query : ?op:string -> ?ok:bool -> ?rebuild:bool ->unit -> entry list
-(** Search the database for matching records. *)
 
 val lookup_job_id : string -> (string * string) option
 (** [lookup_job_id x] is the (op, key) of job [x], if known. *)
 
+(** These functions are described in the {!Current_cache} public API. *)
+
+val init : unit -> unit
+val query : ?op:string -> ?ok:bool -> ?rebuild:bool ->unit -> entry list
 val history : limit:int -> op:string -> string -> entry list
+val ops : unit -> string list

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -42,7 +42,7 @@ let routes engine =
     s "index.html" /? nil @--> Main.r ~engine;
     s "css" / s "style.css" /? nil @--> Style.r;
     s "pipeline.svg" /? nil @--> Pipeline.r ~engine;
-    s "query" /? nil @--> Query.r;
+    s "query" /? nil @--> Query.r ~engine;
     s "log-rules" /? nil @--> Log_rules.r;
     s "metrics" /? nil @--> metrics ~engine;
     s "set" / s "confirm" /? nil @--> set_confirm ~engine;

--- a/lib_web/log_rules.ml
+++ b/lib_web/log_rules.ml
@@ -65,7 +65,7 @@ let test_pattern pattern =
   | results ->
     [
       p [txt (Fmt.strf "%d matches in last %d jobs:" (List.length results) n_jobs)];
-      table ~a:[a_class ["table"]]
+      table ~a:[a_class ["table"; "log-rules"]]
         ~thead:(thead [
             tr [
               th [txt "Job"];

--- a/lib_web/query.ml
+++ b/lib_web/query.ml
@@ -65,6 +65,12 @@ let bool_option ?(t="True") ?(f="False") name value =
       )
   )
 
+let string_option ~placeholder ~title name value =
+  let value = Option.value value ~default:"" in
+  input ~a:[a_name name; a_input_type `Text; a_value value; a_placeholder placeholder; a_title title] ()
+
+let date_tip = "Actually, any prefix of the job ID can be used here."
+
 let r = object
   inherit Resource.t
 
@@ -75,7 +81,8 @@ let r = object
     let ok = bool_param "ok" uri in
     let rebuild = bool_param "rebuild" uri in
     let op = string_param "op" uri in
-    let results = Db.query ?op ?ok ?rebuild () in
+    let date = string_param "date" uri in
+    let results = Db.query ?op ?ok ?rebuild ?job_prefix:date () in
     let ops = Db.ops () in
     Context.respond_ok ctx [
       form ~a:[a_action "/query"; a_method `Get] [
@@ -83,6 +90,7 @@ let r = object
             li [txt "Operation type:"; enum_option ~choices:ops "op" op];
             li [txt "Result:"; bool_option "ok" ok ~t:"Passed" ~f:"Failed"];
             li [txt "Needs rebuild:"; bool_option "rebuild" rebuild];
+            li [txt "Date:"; string_option "date" date ~placeholder:"YYYY-MM-DD" ~title:date_tip];
             li [input ~a:[a_input_type `Submit; a_value "Submit"] ()];
           ];
       ];

--- a/lib_web/query.mli
+++ b/lib_web/query.mli
@@ -1,1 +1,1 @@
-val r : Resource.t
+val r : engine:Current.Engine.t -> Resource.t

--- a/lib_web/style.ml
+++ b/lib_web/style.ml
@@ -115,6 +115,21 @@ let css = {|
       content: ", ";
       padding: 0 .2em;
   }
+
+  ul.query-form {
+    list-style-type: none;
+    padding-left: 0;
+    width: 100%;
+  }
+
+  ul.query-form li {
+    display: inline
+  }
+
+  ul.query-form li select {
+    margin-left: 0.5em;
+    margin-right: 2em;
+  }
 |} ^ Current_ansi.css
 
 let r = object

--- a/lib_web/style.ml
+++ b/lib_web/style.ml
@@ -90,8 +90,11 @@ let css = {|
   }
 
   table td input {
-    width: 100%;
     box-sizing: border-box;
+  }
+
+  table.log-rules td input {
+    width: 100%;
   }
 
   table.log-rules td.score {

--- a/lib_web/style.ml
+++ b/lib_web/style.ml
@@ -130,6 +130,11 @@ let css = {|
     margin-left: 0.5em;
     margin-right: 2em;
   }
+
+  ul.query-form li input {
+    margin-left: 0.5em;
+    margin-right: 2em;
+  }
 |} ^ Current_ansi.css
 
 let r = object


### PR DESCRIPTION
- Show how long jobs were queued, and how long they ran for in the results table.
- Allow filtering the results by the operation type, whether a rebuild was requested, and the date (job ID prefix).
- Active jobs can be selected and rebuilt in bulk.