### PR TITLE
Extend, rather than replace, the context in with_context

### DIFF
--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -120,8 +120,13 @@ module Make (Metadata : sig type t end) = struct
   let collapse ~key ~value ~input t =
     node (Collapse { key; value; input = Term input; output = Term t }) t.v
 
-  let with_context ctx f =
-    with_bind_context (Term ctx) f
+  let with_context (ctx : _ t) f =
+    let ctx =
+      match !bind_context with
+      | None -> Term ctx
+      | Some (Term prev) -> Term (pair prev ctx)
+    in
+    with_bind_context ctx f
 
   let rec all = function
     | [] -> return ()

--- a/test/dune.inc
+++ b/test/dune.inc
@@ -1,5 +1,6 @@
 (rule
- (targets latch.1.dot
+ (targets context.1.dot
+          latch.1.dot
           latch.2.dot
           latch.3.dot
           latch.4.dot
@@ -32,6 +33,11 @@
           v5n.2.dot
           v5n.3.dot)
  (action (run ./test.exe)))
+
+(rule
+ (alias runtest)
+ (package current)
+ (action (diff expected/context.1.dot context.1.dot)))
 
 (rule
  (alias runtest)

--- a/test/expected/context.1.dot
+++ b/test/expected/context.1.dot
@@ -1,0 +1,13 @@
+digraph pipeline {
+  node [shape="box"]
+  rankdir=LR
+  n5 [label="current-test",fillcolor="#90ee90",style="filled"]
+  n4 [label="choose pipeline",fillcolor="#90ee90",style="filled"]
+  n6 [label="a",fillcolor="#90ee90",style="filled"]
+  n7 [label="b",fillcolor="#90ee90",style="filled"]
+  n1 [label="c",fillcolor="#90ee90",style="filled"]
+  n7 -> n1
+  n6 -> n1
+  n4 -> n1
+  n5 -> n4
+  }

--- a/test/test.ml
+++ b/test/test.ml
@@ -196,6 +196,23 @@ let test_pair _switch () =
   in
   Driver.test ~name:"pair" pipeline (fun _ -> raise Exit)
 
+(* This is just to check the diagram. *)
+let test_context _switch () =
+  let label l =
+    Current.component "%s" l |>
+    let> () = Current.return () in
+    Current.Primitive.const ()
+  in
+  let a = label "a" in
+  let b = label "b" in
+  let pipeline () =
+    Current.with_context a @@ fun () ->
+    Current.with_context b @@ fun () ->
+    label "c"
+  in
+  Driver.test ~name:"context" pipeline @@ function
+  | _ -> raise Exit
+
 let test_with base src =
   Current.component "test" |>
   let> _base = base
@@ -279,6 +296,7 @@ let () =
         Driver.test_case_gc "state"       test_state;
         Driver.test_case_gc "pair"        test_pair;
         Driver.test_case_gc "latch"       test_latch;
+        Driver.test_case_gc "context"     test_context;
       ];
       "terms", [
         Alcotest_lwt.test_case_sync "all_labelled" `Quick test_all_labelled;


### PR DESCRIPTION
This required some changes to the way the diagrams are generated.