### PR TITLE
GitHub: Add Api.Anonymous.head_of

### DIFF
--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -47,6 +47,10 @@ module Repo : sig
   val compare : t -> t -> int
 end
 
+module Anonymous : sig
+  val head_of : Repo_id.t -> Ref.t -> Current_git.Commit_id.t Current.t
+end
+
 (* Private API *)
 
 val read_file : string -> string

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -92,7 +92,7 @@ module Api : sig
   val head_commit : t -> Repo_id.t -> Commit.t Current.t
   (** [head_commit t repo] evaluates to the commit at the head of the default branch in [repo]. *)
 
-  val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
+  val head_of : t -> Repo_id.t -> Ref.t -> Commit.t Current.t
   (** [head_of t repo id] evaluates to the commit at the head of [id] in [repo].
       e.g. [head_of t repo (`Ref "refs/heads/master")] *)
 
@@ -104,6 +104,13 @@ module Api : sig
       This is the low-level API for getting the refs.
       It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly.
       The result is cached (so calling it twice will return the same primitive). *)
+
+  module Anonymous : sig
+    val head_of : Repo_id.t -> Ref.t -> Current_git.Commit_id.t Current.t
+    (** [head_of repo ref] is the head commit of [repo]/[ref]. No API token is used to access this,
+        so it only works for public repositories. You are responsible for adding a web-hook so
+        that [input_webhook] gets called whenever the commit changes. *)
+  end
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub configuration. *)


### PR DESCRIPTION
This allows monitoring the head of a public GitHub repository without needing an OAuth token. It's useful for the `ocaml-ci-local` command, allowing users to test the pipeline easily.