### PR TITLE
Also latch failed results

### DIFF
--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -300,8 +300,7 @@ module Generic(Op : S.GENERIC) = struct
                     Log.info (fun f -> f "Result for %a has expired" pp_desired t);
                     let latched =
                       match t.op with
-                      | `Finished (Ok x) -> Some (Ok x)
-                      | `Finished (Error _) -> None
+                      | `Finished x -> Some x
                       | `Retry x -> x
                       | _ -> None
                     in


### PR DESCRIPTION
This PR tidies up the cache code a little by combining the separate `Finished` and `Error` states into a single state with a result type.

A side-effect of this is that when a failed result expires and we rebuild it, we now latch the old failed result during the rebuild, instead of switching to pending. This is how we handle success cases already and is probably more useful.