### PR TITLE
Github: add Installation.repositories ?include_archived option

### DIFF
--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -126,9 +126,10 @@ module Installation : sig
   val pp : t Fmt.t
   (** The GitHub account that installed the app. *)
 
-  val repositories : t Current.t -> Api.Repo.t list Current.t
+  val repositories : ?include_archived:bool -> t Current.t -> Api.Repo.t list Current.t
   (** [repositories t] evaluates to the list of repositories which the user
-      configured for this installation. *)
+      configured for this installation.
+      @param include_archived If [false] (the default) then filter out archived repositories. *)
 
   val compare : t -> t -> int
   (** Order by installation ID. *)

--- a/plugins/github/installation.mli
+++ b/plugins/github/installation.mli
@@ -5,7 +5,7 @@ val api : t -> Api.t
 val pp : t Fmt.t
 val compare : t -> t -> int
 
-val repositories : t Current.t -> Api.Repo.t list Current.t
+val repositories : ?include_archived:bool -> t Current.t -> Api.Repo.t list Current.t
 
 (* Private API *)
 


### PR DESCRIPTION
Filtering archived repositories is now the default. There's not much point doing CI on them as you can't write the status result back.