### PR TITLE
Allow user-defined pools

### DIFF
--- a/lib/pool.ml
+++ b/lib/pool.ml
@@ -32,66 +32,84 @@ end
 
 type priority = [ `High | `Low ]
 
-type t = {
-  label : string;
-  mutable used : int;
-  capacity : int;
-  queue_low : [`Use | `Cancel] Lwt.u Lwt_dllist.t;
-  queue_high : [`Use | `Cancel] Lwt.u Lwt_dllist.t;
+type 'a t = {
+  name : string;
+  get : priority:priority -> switch:Switch.t -> 'a Lwt.t * (unit -> unit Lwt.t);
 }
 
-let create ~label capacity =
-  Prometheus.Gauge.set (Metrics.capacity label) (float_of_int capacity);
-  { label; used = 0; capacity;
-    queue_low = Lwt_dllist.create ();
-    queue_high = Lwt_dllist.create ()
+module Local = struct
+  type t = {
+    label : string;
+    mutable used : int;
+    capacity : int;
+    queue_low : [`Use | `Cancel] Lwt.u Lwt_dllist.t;
+    queue_high : [`Use | `Cancel] Lwt.u Lwt_dllist.t;
   }
 
-let check t =
-  if t.used < t.capacity then (
-    let next =
-      match Lwt_dllist.take_opt_l t.queue_high with
-      | None -> Lwt_dllist.take_opt_l t.queue_low
-      | Some _ as x -> x
-    in
-    next |> Option.iter @@ fun waiter ->
-    t.used <- t.used + 1;
-    Lwt.wakeup_later waiter `Use
-  )
+  let check t =
+    if t.used < t.capacity then (
+      let next =
+        match Lwt_dllist.take_opt_l t.queue_high with
+        | None -> Lwt_dllist.take_opt_l t.queue_low
+        | Some _ as x -> x
+      in
+      next |> Option.iter @@ fun waiter ->
+      t.used <- t.used + 1;
+      Lwt.wakeup_later waiter `Use
+    )
 
-let get ~priority ~on_cancel ~switch t =
-  let ready, set_ready = Lwt.wait () in
-  let queue =
-    match priority with
-    | `High -> t.queue_high
-    | `Low -> t.queue_low
-  in
-  let node = Lwt_dllist.add_r set_ready queue in
-  on_cancel (fun _ ->
-      Lwt_dllist.remove node;
-      if Lwt.is_sleeping ready then Lwt.wakeup_later set_ready `Cancel;
-      Lwt.return_unit
-    ) >>= fun () ->
-  check t;
-  let start_wait = Unix.gettimeofday () in
-  Prometheus.Gauge.inc_one (Metrics.qlen t.label);
-  ready >|= fun ready ->
-  Prometheus.Gauge.dec_one (Metrics.qlen t.label);
-  match ready with
-  | `Cancel -> Fmt.failwith "Cancelled waiting for resource from pool %S" t.label
-  | `Use ->
-    let stop_wait = Unix.gettimeofday () in
-    Prometheus.Summary.observe (Metrics.wait_time t.label) (stop_wait -. start_wait);
-    Prometheus.Gauge.inc_one (Metrics.resources_in_use t.label);
-    Switch.add_hook_or_fail switch (fun _reason ->
-        assert (t.used > 0);
-        Prometheus.Gauge.dec_one (Metrics.resources_in_use t.label);
-        t.used <- t.used - 1;
-        let release_time = Unix.gettimeofday () in
-        Prometheus.Summary.observe (Metrics.use_time t.label) (release_time -. stop_wait);
-        check t;
+  let get t ~priority ~switch =
+    let ready, set_ready = Lwt.wait () in
+    let queue =
+      match priority with
+      | `High -> t.queue_high
+      | `Low -> t.queue_low
+    in
+    let node = Lwt_dllist.add_r set_ready queue in
+    let cancel () =
+        Lwt_dllist.remove node;
+        if Lwt.is_sleeping ready then Lwt.wakeup_later set_ready `Cancel;
         Lwt.return_unit
-      )
+    in
+    check t;
+    let start_wait = Unix.gettimeofday () in
+    Prometheus.Gauge.inc_one (Metrics.qlen t.label);
+    let th =
+      Switch.add_hook_or_exec switch cancel >>= fun () ->
+      ready >|= fun ready ->
+      Prometheus.Gauge.dec_one (Metrics.qlen t.label);
+      match ready with
+      | `Cancel -> Fmt.failwith "Cancelled waiting for resource from pool %S" t.label
+      | `Use ->
+        let stop_wait = Unix.gettimeofday () in
+        Prometheus.Summary.observe (Metrics.wait_time t.label) (stop_wait -. start_wait);
+        Prometheus.Gauge.inc_one (Metrics.resources_in_use t.label);
+        Switch.add_hook_or_fail switch (fun _reason ->
+            assert (t.used > 0);
+            Prometheus.Gauge.dec_one (Metrics.resources_in_use t.label);
+            t.used <- t.used - 1;
+            let release_time = Unix.gettimeofday () in
+            Prometheus.Summary.observe (Metrics.use_time t.label) (release_time -. stop_wait);
+            check t;
+            Lwt.return_unit
+          )
+    in
+    th, cancel
+
+  let create ~label capacity =
+    Prometheus.Gauge.set (Metrics.capacity label) (float_of_int capacity);
+    let t = { label; used = 0; capacity;
+      queue_low = Lwt_dllist.create ();
+      queue_high = Lwt_dllist.create ()
+    } in
+    { name = label; get = get t }
+end
+
+let create = Local.create
+
+let of_fn ~label get = { name = label; get }
+
+let get t = t.get
 
 let pp f t =
-  Fmt.string f t.label
+  Fmt.string f t.name

--- a/lib/pool.mli
+++ b/lib/pool.mli
@@ -1,15 +1,21 @@
-type t
+type 'a t
 
 type priority = [ `High | `Low ]
 
-val create : label:string -> int -> t
+val create : label:string -> int -> unit t
+
+val of_fn :
+  label : string ->
+  (priority:priority -> switch:Switch.t -> 'a Lwt.t * (unit -> unit Lwt.t)) ->
+  'a t
 
 val get :
+  'a t ->
   priority:priority ->
-  on_cancel:((string -> unit Lwt.t) -> unit Lwt.t) ->
   switch:Switch.t ->
-  t -> unit Lwt.t
-(** [get ~priority ~on_cancel ~switch t] waits for a resource and then returns.
+  'a Lwt.t * (unit -> unit Lwt.t)
+(** [get ~priority ~switch t] waits for a resource and then returns.
+    It also returns a function that can be used to cancel the request.
     The resource will be returned to the pool when [switch] is turned off. *)
 
-val pp : t Fmt.t
+val pp : _ t Fmt.t

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 type t = {
   pull : bool;
-  pool : Current.Pool.t option;
+  pool : unit Current.Pool.t option;
   timeout : Duration.t option;
 }
 

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -31,7 +31,7 @@ module Raw : sig
     ?timeout:Duration.t ->
     ?squash:bool ->
     ?dockerfile:[`File of Fpath.t | `Contents of Dockerfile.t] ->
-    ?pool:Current.Pool.t ->
+    ?pool:unit Current.Pool.t ->
     ?build_args:string list ->
     pull:bool ->
     [ `Git of Current_git.Commit.t | `No_context ] ->
@@ -39,14 +39,14 @@ module Raw : sig
 
   val run :
     docker_context:string option ->
-    ?pool:Current.Pool.t ->
+    ?pool:unit Current.Pool.t ->
     ?run_args:string list ->
     Image.t -> args:string list ->
     unit Current.Primitive.t
 
   val pread :
     docker_context:string option ->
-    ?pool:Current.Pool.t ->
+    ?pool:unit Current.Pool.t ->
     ?run_args:string list ->
     Image.t -> args:string list ->
     string Current.Primitive.t

--- a/plugins/docker/pread.ml
+++ b/plugins/docker/pread.ml
@@ -1,7 +1,7 @@
 open Lwt.Infix
 
 type t = {
-  pool : Current.Pool.t option;
+  pool : unit Current.Pool.t option;
 }
 
 let id = "docker-pread"

--- a/plugins/docker/run.ml
+++ b/plugins/docker/run.ml
@@ -1,7 +1,7 @@
 open Lwt.Infix
 
 type t = {
-  pool : Current.Pool.t option;
+  pool : unit Current.Pool.t option;
 }
 
 let id = "docker-run"

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -27,7 +27,7 @@ module type DOCKER = sig
     ?squash:bool ->
     ?label:string ->
     ?dockerfile:[`File of Fpath.t | `Contents of Dockerfile.t] Current.t ->
-    ?pool:Current.Pool.t ->
+    ?pool:unit Current.Pool.t ->
     ?build_args:string list ->
     pull:bool ->
     source ->
@@ -41,7 +41,7 @@ module type DOCKER = sig
 
   val run :
     ?label:string ->
-    ?pool:Current.Pool.t ->
+    ?pool:unit Current.Pool.t ->
     ?run_args:string list ->
     Image.t Current.t -> args:string list ->
     unit Current.t
@@ -51,7 +51,7 @@ module type DOCKER = sig
 
   val pread :
     ?label:string ->
-    ?pool:Current.Pool.t ->
+    ?pool:unit Current.Pool.t ->
     ?run_args:string list ->
     Image.t Current.t -> args:string list ->
     string Current.t

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -45,7 +45,7 @@ val clone : schedule:Current_cache.Schedule.t -> ?gref:string -> string -> Commi
 val fetch : Commit_id.t Current.t -> Commit.t Current.t
 
 val with_checkout :
-  ?pool:Current.Pool.t ->
+  ?pool:unit Current.Pool.t ->
   job:Current.Job.t ->
   Commit.t ->
   (Fpath.t -> 'a Current.or_error Lwt.t) ->


### PR DESCRIPTION
This allows waiting for resources from an external service before marking a job as started.