### PR TITLE
docker: add an arch tag to the pull command

### DIFF
--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -107,11 +107,15 @@ module Make (Host : S.HOST) = struct
 
   let docker_context = Host.docker_context
 
-  let pull ?label ~schedule tag =
+  let pp_opt_arch f = function
+    | None -> ()
+    | Some arch -> Fmt.pf f "@,%s" arch
+
+  let pull ?label ?arch ~schedule tag =
     let label = Option.value label ~default:tag in
-    Current.component "pull %s" label |>
+    Current.component "pull %s%a" label pp_opt_arch arch |>
     let> () = Current.return () in
-    Raw.pull ~docker_context ~schedule tag
+    Raw.pull ~docker_context ~schedule ?arch tag
 
   let pp_sp_label = Fmt.(option (prefix sp string))
 

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -9,8 +9,8 @@ module Raw = struct
 
   module PC = Current_cache.Make(Pull)
 
-  let pull ~docker_context ~schedule tag =
-    PC.get ~schedule Pull.No_context { Pull.Key.docker_context; tag }
+  let pull ~docker_context ~schedule ?arch tag =
+    PC.get ~schedule Pull.No_context { Pull.Key.docker_context; tag; arch }
 
   module BC = Current_cache.Make(Build)
 

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -23,7 +23,8 @@ module Raw : sig
 
   val pull :
     docker_context:string option ->
-    schedule:Current_cache.Schedule.t -> string -> Image.t Current.Primitive.t
+    schedule:Current_cache.Schedule.t ->
+    ?arch:string -> string -> Image.t Current.Primitive.t
 
   val build :
     docker_context:string option ->

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -2,6 +2,8 @@ open Lwt.Infix
 
 type t = No_context
 
+let ( >>!= ) = Lwt_result.bind
+
 module Key = struct
   type t = {
     docker_context : string option;
@@ -21,11 +23,11 @@ let id = "docker-pull"
 let get_digest_from_manifest manifest arch =
   let open Yojson.Basic.Util in
   try Yojson.Basic.from_string manifest |>
-  member "manifests" |> to_list |>
-  List.find (fun j -> member "platform" j |> fun j ->
-    (member "architecture" j |> to_string = arch) &&
-    (member "os" j |> to_string = "linux")) |>
-  member "digest" |> fun digest -> Ok (to_string digest)
+      member "manifests" |> to_list |>
+      List.find (fun j -> member "platform" j |> fun j ->
+                          (member "architecture" j |> to_string = arch) &&
+                          (member "os" j |> to_string = "linux")) |>
+      member "digest" |> fun digest -> Ok (to_string digest)
   with _ -> Error (`Msg (Fmt.strf "failed to parse docker manifest to find arch: %S" manifest))
 
 let build No_context job key =
@@ -33,30 +35,23 @@ let build No_context job key =
   let { Key.docker_context; tag; arch } = key in
   match arch with
   | None -> begin
-    Current.Process.exec ~cancellable:true ~job (Key.cmd key) >>= function
-    | Error _ as e -> Lwt.return e
-    | Ok () ->
+      Current.Process.exec ~cancellable:true ~job (Key.cmd key) >>!= fun () ->
       let cmd = Cmd.docker ~docker_context ["image"; "inspect"; tag; "-f"; "{{index .RepoDigests 0}}"] in
-      Current.Process.check_output ~cancellable:false ~job cmd >|= function
-      | Error _ as e -> e
-      | Ok id ->
-        let id = String.trim id in
-        Current.Job.log job "Pulled %S -> %S" tag id;
-        Ok (Image.of_hash id)
-  end
+      Current.Process.check_output ~cancellable:false ~job cmd >>!= fun id ->
+      let id = String.trim id in
+      Current.Job.log job "Pulled %S -> %S" tag id;
+      Lwt_result.return (Image.of_hash id)
+    end
   | Some arch -> begin
-     let cmd = Cmd.docker ~docker_context ["manifest"; "inspect"; tag ] in
-     Current.Process.check_output ~cancellable:true ~job cmd >>= function
-     | Error _ as e -> Lwt.return e
-     | Ok manifest ->
-         match get_digest_from_manifest manifest arch with
-         | Error _ as e -> Lwt.return e
-         | Ok hash ->
-            let full_tag = tag ^ "@" ^ hash in
-            Current.Process.exec ~cancellable:true ~job (Key.cmd {key with Key.tag=full_tag}) >|= function
-            | Error _ as e -> e
-            | Ok () -> Ok (Image.of_hash full_tag)
-  end
+      let cmd = Cmd.docker ~docker_context ["manifest"; "inspect"; tag ] in
+      Current.Process.check_output ~cancellable:true ~job cmd >>!= fun manifest ->
+      match get_digest_from_manifest manifest arch with
+      | Error _ as e -> Lwt.return e
+      | Ok hash ->
+        let full_tag = tag ^ "@" ^ hash in
+        Current.Process.exec ~cancellable:true ~job (Key.cmd {key with Key.tag=full_tag}) >>!= fun () ->
+        Lwt_result.return (Image.of_hash full_tag)
+    end
 
 let pp f key = Cmd.pp f (Key.cmd key)
 

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -5,10 +5,11 @@ type t = No_context
 module Key = struct
   type t = {
     docker_context : string option;
+    arch: string option;
     tag : string;
   } [@@deriving to_yojson]
 
-  let cmd { docker_context; tag } = Cmd.docker ~docker_context ["pull"; tag]
+  let cmd { docker_context; tag; _ } = Cmd.docker ~docker_context ["pull"; tag]
 
   let digest t = Yojson.Safe.to_string (to_yojson t)
 end
@@ -17,19 +18,45 @@ module Value = Image
 
 let id = "docker-pull"
 
+let get_digest_from_manifest manifest arch =
+  let open Yojson.Basic.Util in
+  try Yojson.Basic.from_string manifest |>
+  member "manifests" |> to_list |>
+  List.find (fun j -> member "platform" j |> fun j ->
+    (member "architecture" j |> to_string = arch) &&
+    (member "os" j |> to_string = "linux")) |>
+  member "digest" |> fun digest -> Ok (to_string digest)
+  with _ -> Error (`Msg (Fmt.strf "failed to parse docker manifest to find arch: %S" manifest))
+
 let build No_context job key =
   Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
-  Current.Process.exec ~cancellable:true ~job (Key.cmd key) >>= function
-  | Error _ as e -> Lwt.return e
-  | Ok () ->
-    let { Key.docker_context; tag } = key in
-    let cmd = Cmd.docker ~docker_context ["image"; "inspect"; tag; "-f"; "{{index .RepoDigests 0}}"] in
-    Current.Process.check_output ~cancellable:false ~job cmd >|= function
-    | Error _ as e -> e
-    | Ok id ->
-      let id = String.trim id in
-      Current.Job.log job "Pulled %S -> %S" tag id;
-      Ok (Image.of_hash id)
+  let { Key.docker_context; tag; arch } = key in
+  match arch with
+  | None -> begin
+    Current.Process.exec ~cancellable:true ~job (Key.cmd key) >>= function
+    | Error _ as e -> Lwt.return e
+    | Ok () ->
+      let cmd = Cmd.docker ~docker_context ["image"; "inspect"; tag; "-f"; "{{index .RepoDigests 0}}"] in
+      Current.Process.check_output ~cancellable:false ~job cmd >|= function
+      | Error _ as e -> e
+      | Ok id ->
+        let id = String.trim id in
+        Current.Job.log job "Pulled %S -> %S" tag id;
+        Ok (Image.of_hash id)
+  end
+  | Some arch -> begin
+     let cmd = Cmd.docker ~docker_context ["manifest"; "inspect"; tag ] in
+     Current.Process.check_output ~cancellable:true ~job cmd >>= function
+     | Error _ as e -> Lwt.return e
+     | Ok manifest ->
+         match get_digest_from_manifest manifest arch with
+         | Error _ as e -> Lwt.return e
+         | Ok hash ->
+            let full_tag = tag ^ "@" ^ hash in
+            Current.Process.exec ~cancellable:true ~job (Key.cmd {key with Key.tag=full_tag}) >|= function
+            | Error _ as e -> e
+            | Ok () -> Ok (Image.of_hash full_tag)
+  end
 
 let pp f key = Cmd.pp f (Key.cmd key)
 

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -17,8 +17,13 @@ module type DOCKER = sig
 
   val docker_context : string option
 
-  val pull : ?label:string -> schedule:Current_cache.Schedule.t -> string -> Image.t Current.t
+  val pull :
+    ?label:string ->
+    ?arch:string ->
+    schedule:Current_cache.Schedule.t ->
+    string -> Image.t Current.t
   (** [pull ~schedule tag] ensures that the latest version of [tag] is cached locally, downloading it if not.
+      @param arch Select a specific architecture from a multi-arch manifest.
       @param schedule Controls how often we check for updates. If the schedule
                       has no [valid_for] limit then we will only ever pull once. *)
 


### PR DESCRIPTION
This parses the output of `docker manifest inspect` and picks the appropriate hash from the multiarch manifest, and then pulls that specific tag by its hash.

If not specified, docker pull operates as normal and resolves to the default architecture of the build host.