### PR TITLE
Update Dockerfile to latest opam-repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.08
 RUN sudo apt-get update && sudo apt-get install capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 8b9c3436650a5e217b4b8242ed0234fd9c0fa1e6 && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard be5f02dafef6810cde6c51e1372806037989a8c3 && opam update
 ADD --chown=opam *.opam /src/
 WORKDIR /src
 RUN opam pin add -yn current_web.dev "./" && \


### PR DESCRIPTION
Perhaps we should remove the `Dockerfile`, but it's useful for some of the examples.