### PR TITLE
current_web depends on conf-graphviz

### DIFF
--- a/current_web.opam
+++ b/current_web.opam
@@ -33,4 +33,5 @@ depends: [
   "tyxml"
   "routes" {>= "0.8.0"}
   "dune" {>= "2.0"}
+  "conf-graphviz"
 ]


### PR DESCRIPTION
I wondered why I wasn't getting pipeline diagrams. I switched browser. I still wasn't pipeline diagrams. I realised why. i felt silly.

Hopefully this is the correct to address any further silly people...