### PR TITLE
Add `Current_docker.Raw.peek`

### DIFF
--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -26,6 +26,11 @@ module Raw : sig
     schedule:Current_cache.Schedule.t ->
     ?arch:string -> string -> Image.t Current.Primitive.t
 
+  val peek :
+    docker_context:string option ->
+    schedule:Current_cache.Schedule.t ->
+    arch:string -> string -> S.repo_id Current.Primitive.t
+
   val build :
     docker_context:string option ->
     ?schedule:Current_cache.Schedule.t ->

--- a/plugins/docker/peek.ml
+++ b/plugins/docker/peek.ml
@@ -1,0 +1,35 @@
+open Lwt.Infix
+
+type t = No_context
+
+let ( >>!= ) = Lwt_result.bind
+
+module Key = struct
+  type t = {
+    docker_context : string option;
+    arch: string;
+    tag : string;
+  } [@@deriving to_yojson]
+
+  let cmd { docker_context; tag; _ } = Cmd.docker ~docker_context ["manifest"; "inspect"; "--"; tag]
+
+  let digest t = Yojson.Safe.to_string (to_yojson t)
+end
+
+module Value = Current.String
+
+let id = "docker-peek"
+
+let build No_context job key =
+  Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
+  let { Key.docker_context = _; tag; arch } = key in
+  Current.Process.check_output ~cancellable:true ~job (Key.cmd key) >>!= fun manifest ->
+  match Pull.get_digest_from_manifest manifest arch with
+  | Error _ as e -> Lwt.return e
+  | Ok hash ->
+    Current.Job.log job "Got %S" hash;
+    Lwt_result.return (tag ^ "@" ^ hash)
+
+let pp f key = Cmd.pp f (Key.cmd key)
+
+let auto_cancel = true

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -27,6 +27,16 @@ module type DOCKER = sig
       @param schedule Controls how often we check for updates. If the schedule
                       has no [valid_for] limit then we will only ever pull once. *)
 
+  val peek :
+    ?label:string ->
+    arch:string ->
+    schedule:Current_cache.Schedule.t ->
+    string -> repo_id Current.t
+  (** [peek ~schedule ~arch tag] gets the latest version of [tag] without actually pulling it.
+      @param arch Select a specific architecture from a multi-arch manifest.
+      @param schedule Controls how often we check for updates. If the schedule
+                      has no [valid_for] limit then we will only ever check once. *)
+
   val build :
     ?schedule:Current_cache.Schedule.t ->
     ?timeout:Duration.t ->


### PR DESCRIPTION
This can be used to check the latest version of an image without pulling it. This is useful if you just want to pass the hash to a builder node, for example.