### PR TITLE
Allow pushing manifests to insecure Docker registries

### DIFF
--- a/plugins/docker/push_manifest.ml
+++ b/plugins/docker/push_manifest.ml
@@ -34,10 +34,10 @@ module Outcome = struct
 end
 
 let create_cmd ~config ~tag {Value.manifests} =
-  Cmd.docker ~config ~docker_context:None (["manifest"; "create"; tag] @ manifests)
+  Cmd.docker ~config ~docker_context:None (["manifest"; "create"; "--insecure"; tag] @ manifests)
 
 let push_cmd ~config tag =
-  Cmd.docker ~config ~docker_context:None ["manifest"; "push"; tag]
+  Cmd.docker ~config ~docker_context:None ["manifest"; "push"; "--insecure"; tag]
 
 let or_fail = function
   | Ok x -> x


### PR DESCRIPTION
At the moment, this simply adds `--insecure` to the docker manifest calls. I expect it'd be better to propagate this from higher up, but I wasn't sure exactly where to pass the instruction (bolt it into the `config`, add `?insecure`, etc.?) so it can start as a draft PR!