### PR TITLE
Staleness argument

### DIFF
--- a/current_github.opam
+++ b/current_github.opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "fmt"
   "lwt"
+  "ptime"
   "yojson"
   "cohttp-lwt-unix" {< "3.0.0"}
   "mirage-crypto"

--- a/current_github.opam
+++ b/current_github.opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "fmt"
   "lwt"
+  "duration"
   "ptime"
   "yojson"
   "cohttp-lwt-unix" {< "3.0.0"}

--- a/examples/github_app.ml
+++ b/examples/github_app.ml
@@ -43,7 +43,7 @@ let pipeline ~app () =
   Github.App.installations app |> Current.list_iter (module Github.Installation) @@ fun installation ->
   let repos = Github.Installation.repositories installation in
   repos |> Current.list_iter ~collapse_key:"repo" (module Github.Api.Repo) @@ fun repo ->
-  Github.Api.Repo.ci_refs repo
+  Github.Api.Repo.ci_refs ~staleness:(Duration.of_day 90) repo
   |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   Docker.build ~pool ~pull:false ~dockerfile (`Git src)

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -166,6 +166,10 @@ and ci_refs = {
   all_refs: commit Ref_map.t
 }
 
+let get_default_ref t = t.default_ref 
+
+let get_all_refs t = t.all_refs
+
 let v ~get_token account =
   let head_monitors = Repo_map.empty in
   let ci_refs_monitors = Repo_map.empty in

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -246,10 +246,10 @@ let query_default =
        prefix \
        name \
        target { \
-        ...on Commit { \
-          oid \
-          committedDate \ 
-        } \ 
+         ...on Commit { \
+           oid \
+           committedDate \
+         } \
        } \
      } \
    } \

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -38,14 +38,14 @@ val refs : t -> Repo_id.t -> refs Current.Primitive.t
 val default_ref : refs -> string
 val all_refs : refs -> Commit.t Ref_map.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
-val ci_refs : ?staleness:(Duration.t option) -> t -> Repo_id.t -> Commit.t list Current.t
+val ci_refs : ?staleness:Duration.t -> t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t
 
 module Repo : sig
   type nonrec t = t * Repo_id.t
 
   val id : t -> Repo_id.t
-  val ci_refs : t Current.t -> Commit.t list Current.t
+  val ci_refs : ?staleness:Duration.t -> t Current.t -> Commit.t list Current.t
   val head_commit : t Current.t -> Commit.t Current.t
   val pp : t Fmt.t
   val compare : t -> t -> int

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -13,6 +13,7 @@ module Commit : sig
   val repo_id : t -> Repo_id.t
   val owner_name : t -> string
   val hash : t -> string
+  val committed_date : t -> string 
   val pp : t Fmt.t
   val compare : t -> t -> int
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
@@ -34,7 +35,7 @@ val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yo
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
 val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
-val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
+val ci_refs : ?staleness:(int option) -> t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t
 
 module Repo : sig

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -13,7 +13,7 @@ module Commit : sig
   val repo_id : t -> Repo_id.t
   val owner_name : t -> string
   val hash : t -> string
-  val committed_date : t -> string 
+  val committed_date : t -> string
   val pp : t Fmt.t
   val compare : t -> t -> int
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
@@ -30,13 +30,13 @@ end
 module Ref_map : Map.S with type key = Ref.t
 
 type t
-type ci_refs 
+type refs
 val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
-val refs : t -> Repo_id.t -> ci_refs Current.Primitive.t
-val get_default_ref : ci_refs -> string 
-val get_all_refs : ci_refs -> Commit.t Ref_map.t
+val refs : t -> Repo_id.t -> refs Current.Primitive.t
+val default_ref : refs -> string
+val all_refs : refs -> Commit.t Ref_map.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
 val ci_refs : ?staleness:(Duration.t option) -> t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -35,6 +35,8 @@ val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
 val refs : t -> Repo_id.t -> ci_refs Current.Primitive.t
+val get_default_ref : ci_refs -> string 
+val get_all_refs : ci_refs -> Commit.t Ref_map.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
 val ci_refs : ?staleness:(Duration.t option) -> t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -35,7 +35,7 @@ val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yo
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
 val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
-val ci_refs : ?staleness:(int option) -> t -> Repo_id.t -> Commit.t list Current.t
+val ci_refs : ?staleness:(Duration.t option) -> t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t
 
 module Repo : sig

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -30,10 +30,11 @@ end
 module Ref_map : Map.S with type key = Ref.t
 
 type t
+type ci_refs 
 val of_oauth : string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
-val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
+val refs : t -> Repo_id.t -> ci_refs Current.Primitive.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
 val ci_refs : ?staleness:(Duration.t option) -> t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -22,6 +22,9 @@ module Api : sig
   type t
   (** Configuration for accessing GitHub. *)
 
+  type ci_refs 
+  (** Reference information for the repository *)
+
   module Status : sig
     type t
     (** GitHub commit context status type. *)
@@ -104,7 +107,7 @@ module Api : sig
       The optional [staleness] argument can be used to specify the duration beyond which the latest
       commit of a PR or branch is deemed too old and will be removed. It defaults to [None]. *)
 
-  val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
+  val refs : t -> Repo_id.t -> ci_refs Current.Primitive.t
   (** [refs t repo] is the primitive for all the references in [repo].
       This is the low-level API for getting the refs.
       It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly.

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -110,8 +110,15 @@ module Api : sig
   val refs : t -> Repo_id.t -> ci_refs Current.Primitive.t
   (** [refs t repo] is the primitive for all the references in [repo].
       This is the low-level API for getting the refs.
-      It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly.
+      It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly, 
+      [get_default_ref] and [get_all_refs] will expose useful information for you. 
       The result is cached (so calling it twice will return the same primitive). *)
+
+  val get_default_ref : ci_refs -> string 
+  (** [get_default_ref ci_refs] will return the full name of the repository's default branch ref *)
+
+  val get_all_refs : ci_refs -> Commit.t Ref_map.t
+  (** [get_all_refs ci_refs] will return a map of all the repository's refs *)
 
   module Anonymous : sig
     val head_of : Repo_id.t -> Ref.t -> Current_git.Commit_id.t Current.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -49,6 +49,9 @@ module Api : sig
     val hash : t -> string
     (** [hash t] is the Git commit hash of [t]. *)
 
+    val committed_date : t -> string 
+    (** [committed_date t] is the datetime when [t] was committed *)
+
     val pp : t Fmt.t
     val compare : t -> t -> int
 
@@ -96,8 +99,11 @@ module Api : sig
   (** [head_of t repo id] evaluates to the commit at the head of [id] in [repo].
       e.g. [head_of t repo (`Ref "refs/heads/master")] *)
 
-  val ci_refs : t -> Repo_id.t -> Commit.t list Current.t
-  (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo], excluding gh-pages. *)
+  val ci_refs : ?staleness:(int option) -> t -> Repo_id.t -> Commit.t list Current.t
+  (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo], excluding gh-pages.
+      The optional [staleness] argument can be used to specify the number of days beyond which the latest
+      commit of a PR or branch is deemed too old and will be removed. It defaults to [None] and supplying 
+      a number less than [0] behaves like [None]. *)
 
   val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
   (** [refs t repo] is the primitive for all the references in [repo].

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -99,11 +99,10 @@ module Api : sig
   (** [head_of t repo id] evaluates to the commit at the head of [id] in [repo].
       e.g. [head_of t repo (`Ref "refs/heads/master")] *)
 
-  val ci_refs : ?staleness:(int option) -> t -> Repo_id.t -> Commit.t list Current.t
+  val ci_refs : ?staleness:(Duration.t option) -> t -> Repo_id.t -> Commit.t list Current.t
   (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo], excluding gh-pages.
-      The optional [staleness] argument can be used to specify the number of days beyond which the latest
-      commit of a PR or branch is deemed too old and will be removed. It defaults to [None] and supplying 
-      a number less than [0] behaves like [None]. *)
+      The optional [staleness] argument can be used to specify the duration beyond which the latest
+      commit of a PR or branch is deemed too old and will be removed. It defaults to [None]. *)
 
   val refs : t -> Repo_id.t -> Commit.t Ref_map.t Current.Primitive.t
   (** [refs t repo] is the primitive for all the references in [repo].

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -22,7 +22,7 @@ module Api : sig
   type t
   (** Configuration for accessing GitHub. *)
 
-  type ci_refs 
+  type refs
   (** Reference information for the repository *)
 
   module Status : sig
@@ -52,7 +52,7 @@ module Api : sig
     val hash : t -> string
     (** [hash t] is the Git commit hash of [t]. *)
 
-    val committed_date : t -> string 
+    val committed_date : t -> string
     (** [committed_date t] is the datetime when [t] was committed *)
 
     val pp : t Fmt.t
@@ -107,18 +107,18 @@ module Api : sig
       The optional [staleness] argument can be used to specify the duration beyond which the latest
       commit of a PR or branch is deemed too old and will be removed. It defaults to [None]. *)
 
-  val refs : t -> Repo_id.t -> ci_refs Current.Primitive.t
+  val refs : t -> Repo_id.t -> refs Current.Primitive.t
   (** [refs t repo] is the primitive for all the references in [repo].
       This is the low-level API for getting the refs.
-      It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly, 
-      [get_default_ref] and [get_all_refs] will expose useful information for you. 
+      It is used internally by [ci_refs] and [head_of] but in some cases you may want to use it directly,
+      [default_ref] and [all_refs] will expose useful information for you.
       The result is cached (so calling it twice will return the same primitive). *)
 
-  val get_default_ref : ci_refs -> string 
-  (** [get_default_ref ci_refs] will return the full name of the repository's default branch ref *)
+  val default_ref : refs -> string
+  (** [get_default_ref refs] will return the full name of the repository's default branch ref *)
 
-  val get_all_refs : ci_refs -> Commit.t Ref_map.t
-  (** [get_all_refs ci_refs] will return a map of all the repository's refs *)
+  val all_refs : refs -> Commit.t Ref_map.t
+  (** [get_all_refs refs] will return a map of all the repository's refs *)
 
   module Anonymous : sig
     val head_of : Repo_id.t -> Ref.t -> Current_git.Commit_id.t Current.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -69,8 +69,10 @@ module Api : sig
     val pp : t Fmt.t
     val compare : t -> t -> int
 
-    val ci_refs : t Current.t -> Commit.t list Current.t
-    (** [ci_refs t] evaluates to the list of branches and open PRs in [t], excluding gh-pages. *)
+    val ci_refs : ?staleness:Duration.t -> t Current.t -> Commit.t list Current.t
+    (** [ci_refs t] evaluates to the list of branches and open PRs in [t], excluding gh-pages.
+        @param staleness If given, commits older than this are excluded.
+                         Note: the main branch commit is always included, even if stale. *)
 
     val head_commit : t Current.t -> Commit.t Current.t
     (** [head_commit t] evaluates to the commit at the head of the default branch in [t]. *)
@@ -102,10 +104,10 @@ module Api : sig
   (** [head_of t repo id] evaluates to the commit at the head of [id] in [repo].
       e.g. [head_of t repo (`Ref "refs/heads/master")] *)
 
-  val ci_refs : ?staleness:(Duration.t option) -> t -> Repo_id.t -> Commit.t list Current.t
+  val ci_refs : ?staleness:Duration.t -> t -> Repo_id.t -> Commit.t list Current.t
   (** [ci_refs t repo] evaluates to the list of branches and open PRs in [repo], excluding gh-pages.
-      The optional [staleness] argument can be used to specify the duration beyond which the latest
-      commit of a PR or branch is deemed too old and will be removed. It defaults to [None]. *)
+      @param staleness If given, commits older than this are excluded.
+                       Note: the main branch commit is always included, even if stale. *)
 
   val refs : t -> Repo_id.t -> refs Current.Primitive.t
   (** [refs t repo] is the primitive for all the references in [repo].

--- a/plugins/github/dune
+++ b/plugins/github/dune
@@ -13,6 +13,7 @@
    current.term
    current_git
    current_web
+   ptime
    fmt
    logs
    lwt

--- a/plugins/github/dune
+++ b/plugins/github/dune
@@ -13,6 +13,7 @@
    current.term
    current_git
    current_web
+   duration
    ptime
    fmt
    logs


### PR DESCRIPTION
This PR adds an optional `staleness` argument to `ci_refs` (defaulting to `None`) which allows a user to specify how old, as a number of days, is too old for the last commit of a PR/branch to be considered for using. It was tested locally with a modified `example/github.ml` pipeline. 

It does add `ptime` as a dependency, if this isn't desirable it's possible to write one using just functions on strings? 