### PR TITLE
Switch from "capnpc" to "capnp compile"

### DIFF
--- a/lib_rpc/dune
+++ b/lib_rpc/dune
@@ -17,4 +17,4 @@
 (rule
  (targets schema.ml schema.mli)
  (deps schema.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))


### PR DESCRIPTION
`capnpc` seems to be the old name, and isn't present on Windows.