### PR TITLE
List all dependencies in opam files

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Pipeline language for keeping things up-to-date"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
@@ -14,13 +14,8 @@ run steps in parallel where possible."""
 maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
-bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
 doc: "https://ocurrent.github.io/ocurrent/"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "current_incr" {= version}
@@ -37,3 +32,8 @@ depends: [
   "lwt-dllist"
   "alcotest-lwt" {>= "1.2.0" & with-test}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current.opam
+++ b/current.opam
@@ -30,7 +30,12 @@ depends: [
   "dune" {>= "2.0"}
   "re"
   "lwt-dllist"
+  "alcotest" {>= "1.2.0" & with-test}
   "alcotest-lwt" {>= "1.2.0" & with-test}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/current_docker.opam
+++ b/current_docker.opam
@@ -22,6 +22,12 @@ depends: [
   "ppx_deriving_yojson" {>= "3.5.1"}
   "yojson"
   "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "duration" {>= "0.1.3"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/current_docker.opam
+++ b/current_docker.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "OCurrent Docker plugin"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 This package provides a plugin for interacting with Docker.
@@ -9,13 +9,8 @@ multiple Docker Engine instances."""
 maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
-bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
 doc: "https://ocurrent.github.io/ocurrent/"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "current" {= version}
   "current_git" {= version}
@@ -28,3 +23,8 @@ depends: [
   "yojson"
   "dune" {>= "2.0"}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_examples.opam
+++ b/current_examples.opam
@@ -25,6 +25,19 @@ depends: [
   "current_rpc" {= version}
   "capnp-rpc-unix" {>= "0.5"}
   "dune" {>= "2.0"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0"}
+  "dockerfile" {>= "7.0.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "routes" {>= "0.8.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/current_examples.opam
+++ b/current_examples.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Example pipelines for OCurrent"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 This package provides some example pipelines.
@@ -9,13 +9,8 @@ plugins."""
 maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
-bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
 doc: "https://ocurrent.github.io/ocurrent/"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "fmt"
@@ -31,3 +26,8 @@ depends: [
   "capnp-rpc-unix" {>= "0.5"}
   "dune" {>= "2.0"}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_git.opam
+++ b/current_git.opam
@@ -20,6 +20,11 @@ depends: [
   "ppx_deriving_yojson" {>= "3.5.1"}
   "yojson"
   "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/current_git.opam
+++ b/current_git.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Git plugin for OCurrent"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 This package provides primitives for interacting with Git.
@@ -8,13 +8,8 @@ It can pull from remote repositories, or monitor local ones for changes."""
 maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
-bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
 doc: "https://ocurrent.github.io/ocurrent/"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "current" {= version}
   "ocaml" {>= "4.08.0"}
@@ -26,3 +21,8 @@ depends: [
   "yojson"
   "dune" {>= "2.0"}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_github.opam
+++ b/current_github.opam
@@ -25,6 +25,19 @@ depends: [
   "x509" {>= "0.10.0"}
   "tls" {>= "0.11.0"}
   "dune" {>= "2.0"}
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.0.4"}
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "cstruct" {>= "5.2.0"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "4.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/current_github.opam
+++ b/current_github.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "GitHub plugin for OCurrent"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 This package provides primitives for interacting with GitHub.
@@ -11,11 +11,6 @@ maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
 bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
 depends: [
   "current" {= version}
   "current_git" {= version}
@@ -24,10 +19,15 @@ depends: [
   "fmt"
   "lwt"
   "yojson"
-  "cohttp-lwt-unix" { < "3.0.0"}
+  "cohttp-lwt-unix" {< "3.0.0"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "x509" {>= "0.10.0"}
   "tls" {>= "0.11.0"}
   "dune" {>= "2.0"}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_incr.opam
+++ b/current_incr.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Self-adjusting computations"
-description: """
+description: """\
 This is a small, self-contained library for self-adjusting (incremental) computations.
 It was written for OCurrent, but can be used separately too.
 
@@ -9,20 +9,19 @@ has no external dependencies.
 
 It is also similar to the react library, but the results do not depend on the
 behaviour of the garbage collector. In particular, functions stop being called
-as soon as they are no longer needed.
-"""
+as soon as they are no longer needed."""
 maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
-bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
 doc: "https://ocurrent.github.io/ocurrent/"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0"}
   "alcotest" {with-test}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_rpc.opam
+++ b/current_rpc.opam
@@ -11,9 +11,16 @@ homepage: "https://github.com/ocurrent/ocurrent"
 bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {>= "0.8.0"}
   "capnp-rpc-lwt" {>= "0.4"}
   "fpath"
   "dune" {>= "2.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "stdint" {>= "0.7.0"}
 ]
 conflicts: [
   "x509" {= "0.11.0"}

--- a/current_rpc.opam
+++ b/current_rpc.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Cap'n Proto RPC plugin for OCurrent"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 This package provides a Cap'n Proto RPC interface, allowing
@@ -9,11 +9,6 @@ maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
 bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
 depends: [
   "ocaml" {>= "4.08.0"}
   "capnp-rpc-lwt" {>= "0.4"}
@@ -23,3 +18,8 @@ depends: [
 conflicts: [
   "x509" {= "0.11.0"}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_slack.opam
+++ b/current_slack.opam
@@ -16,8 +16,12 @@ depends: [
   "yojson"
   "lwt"
   "tls" {>= "0.12.0"}
-  "cohttp-lwt-unix" {< "3.0.0"}
+  "cohttp" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt-unix" {>= "2.2.0" & < "3.0.0"}
   "dune" {>= "2.0"}
+  "logs" {>= "0.7.0"}
+  "uri" {>= "4.0.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/current_slack.opam
+++ b/current_slack.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Slack plugin for OCurrent"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 This package provides primitives for interacting with Slack.
@@ -9,11 +9,6 @@ maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
 bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
 depends: [
   "current" {= version}
   "ocaml" {>= "4.08.0"}
@@ -21,6 +16,11 @@ depends: [
   "yojson"
   "lwt"
   "tls" {>= "0.12.0"}
-  "cohttp-lwt-unix" { < "3.0.0"}
+  "cohttp-lwt-unix" {< "3.0.0"}
   "dune" {>= "2.0"}
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_web.opam
+++ b/current_web.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Test web UI for OCurrent"
-description: """
+description: """\
 OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
 
 This package provides a basic web UI for service administrators.
@@ -10,11 +10,6 @@ maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
 homepage: "https://github.com/ocurrent/ocurrent"
 bug-reports: "https://github.com/ocurrent/ocurrent/issues"
-dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]
 depends: [
   "current" {= version}
   "current_ansi" {= version}
@@ -35,3 +30,8 @@ depends: [
   "dune" {>= "2.0"}
   "conf-graphviz"
 ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"

--- a/current_web.opam
+++ b/current_web.opam
@@ -18,17 +18,34 @@ depends: [
   "base64"
   "session"
   "session-cohttp-lwt"
+  "mirage-crypto" {>= "0.8.7"}
   "mirage-crypto-rng"
   "fmt"
   "bos"
   "lwt"
   "cmdliner"
+  "prometheus" {>= "0.7"}
   "prometheus-app"
+  "cohttp" {>= "2.2.0" & < "3.0.0"}
+  "cohttp-lwt" {>= "2.2.0" & < "3.0.0"}
   "cohttp-lwt-unix" {>= "2.2.0" & < "3.0.0"}
   "tyxml"
   "routes" {>= "0.8.0"}
   "dune" {>= "2.0"}
   "conf-graphviz"
+  "astring" {>= "0.8.5"}
+  "conduit-lwt-unix" {>= "2.2.2"}
+  "cstruct" {>= "5.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_sexp_conv" {>= "v0.14.1"}
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "sexplib" {>= "v0.14.0"}
+  "sqlite3" {>= "5.0.2"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/lib_rpc/dune
+++ b/lib_rpc/dune
@@ -9,7 +9,6 @@
    fpath
    logs
    lwt
-   lwt.unix
    result
    stdint)
  (flags (:standard -w -53-55)))

--- a/test/dune
+++ b/test/dune
@@ -42,5 +42,6 @@
 
 (rule
  (alias runtest)
+ (package current)
  (action
   (diff dune.inc dune.gen)))


### PR DESCRIPTION
If we list a dependency in our dune file, ensure we have a corresponding dependency in the opam file.

Patch mostly generated by https://github.com/talex5/dune-opam-lint (experimental!).

I reordered the dependencies in a few places and updated version constraints to match similar packages, e.g. cohttp and cohttp-lwt. I also adding a missing `(package)` line to the tests, which was adding a `fmt` test dependency on `current_incr` (which doesn't matter at the moment, as it already depends on it via alcotest), and removed an unnecessary dependency on `lwt.unix`.

I split the reformatting of the opam files into a separate commit to make the diff easier to read.