### PR TITLE
Provide Analysis.quick_stat for faster stats

### DIFF
--- a/lib/current.ml
+++ b/lib/current.ml
@@ -173,8 +173,9 @@ module Engine = struct
 
   let thread t = t.thread
 
-  let update_metrics t =
-    let { Current_term.S.ok; ready; running; failed; blocked } = Analysis.stats (pipeline t) in
+  let update_metrics _t =
+    (*  { Current_term.S.ok; ready; running; failed; blocked } = Analysis.stats (pipeline t) in *)
+    let { Current_term.S.ok; ready; running; failed; blocked } = Analysis.quick_stat () in
     Prometheus.Gauge.set (Metrics.pipeline_stage_total "ok") (float_of_int ok);
     Prometheus.Gauge.set (Metrics.pipeline_stage_total "ready") (float_of_int ready);
     Prometheus.Gauge.set (Metrics.pipeline_stage_total "running") (float_of_int running);

--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -303,7 +303,7 @@ module Make (Meta : sig type t end) = struct
     Fmt.pf f "}@]@."
 
   (* This is similar to [pp_dot], except that for each call to [node] we call [count] instead. *)
-  let stats x =
+  let stat x =
     let seen : Out_node.t Id.Map.t ref = ref Id.Map.empty in
     let next = ref 0 in
     let ok = ref 0 in

--- a/lib_term/analysis.mli
+++ b/lib_term/analysis.mli
@@ -3,7 +3,7 @@
 module Make (Metadata : sig type t end) : sig
   type 'a t
 
-  val stats : _ t -> S.stats
+  val stat : _ t -> S.stats
 
   val pp : _ t Fmt.t
   val pp_dot :

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -50,8 +50,16 @@ module type ANALYSIS = sig
                       displayed using a gradient from the update status colour
                       to the current output colour. *)
 
-  val stats : _ term -> stats
-  (** [stats t] count how many stages are in each state. *)
+  (** {2 Stats} *)
+
+  val stat : _ term -> stats
+  (** [stat t] count how many stages are in each state.
+      This can be slow for large pipelines. Consider using {!quick_stat} instead. *)
+
+  val quick_stat : unit -> stats
+  (** [quick_stat ()] returns the current values of the counters. This is O(1).
+      It only counts some operations (binds, primitives and of_output). *)
+
 end
 
 module type TERM = sig

--- a/test/driver.ml
+++ b/test/driver.ml
@@ -97,7 +97,8 @@ let test ?config ?final_stats ~name v actions =
       try actions !step with
       | Exit ->
         final_stats |> Option.iter (fun expected ->
-            Alcotest.check stats "Check final stats" expected @@ Current.Analysis.stats test_pipeline
+            Alcotest.check stats "Check final stats" expected @@ Current.Analysis.quick_stat ();
+            (* Alcotest.check stats "Check final stats" expected @@ Current.Analysis.stats test_pipeline *)
           );
         SVar.set selected (Error (`Msg "test-over"));
         step := -1

--- a/test/test.ml
+++ b/test/test.ml
@@ -89,7 +89,7 @@ let test_v3 _switch () =
       failed = 1;
       ready = 0;
       running = 1;
-      blocked = 6;
+      blocked = 3;
     }
   in
   Driver.test ~name:"v3" (with_commit v3) ~final_stats @@ function
@@ -131,14 +131,32 @@ let v5 commit =
   |> Current.list_iter (module Git.Commit) (fun s -> s |> fetch |> build |> test)
 
 let test_v5 _switch () =
-  Driver.test ~name:"v5" (with_commit v5) @@ function
+  let final_stats =
+    { Current_term.S.
+      ok = 7;
+      failed = 0;
+      ready = 0;
+      running = 2;
+      blocked = 4;
+    }
+  in
+  Driver.test ~name:"v5" ~final_stats (with_commit v5) @@ function
   | 1 -> Git.complete_clone test_commit
   | 2 -> Docker.complete "image-src-123" ~cmd:["make"; "test"] @@ Ok ()
   | _ -> raise Exit
 
 let test_v5_nil _switch () =
+  let final_stats =
+    { Current_term.S.
+      ok = 7;
+      failed = 0;
+      ready = 0;
+      running = 0;
+      blocked = 3;
+    }
+  in
   let test_commit = Git.Commit.v ~repo:"my/project" ~hash:"456" in
-  Driver.test ~name:"v5n" (with_commit v5) @@ function
+  Driver.test ~name:"v5n" ~final_stats (with_commit v5) @@ function
   | 1 -> Git.complete_clone test_commit
   | 2 -> Docker.complete "image-src-456" ~cmd:["make"; "test"] @@ Ok ()
   | _ -> raise Exit
@@ -150,16 +168,34 @@ let test_option ~case commit =
   |> Current.ignore_value
 
 let test_option_some _switch () =
+  let final_stats =
+    { Current_term.S.
+      ok = 6;
+      failed = 0;
+      ready = 0;
+      running = 0;
+      blocked = 0;
+    }
+  in
   test_option ~case:(Some "ocamlformat")
   |> with_commit
-  |> (fun c -> Driver.test ~name:"option-some" c @@ function
+  |> (fun c -> Driver.test ~final_stats ~name:"option-some" c @@ function
   | 1 -> Git.complete_clone test_commit
   | _ -> raise Exit)
 
 let test_option_none _switch () =
+  let final_stats =
+    { Current_term.S.
+      ok = 5;
+      failed = 0;
+      ready = 0;
+      running = 0;
+      blocked = 1;
+    }
+  in
   test_option ~case:None
   |> with_commit
-  |> (fun c -> Driver.test ~name:"option-none" c @@ function
+  |> (fun c -> Driver.test ~final_stats ~name:"option-none" c @@ function
     | 1 -> Git.complete_clone test_commit
     | _ -> raise Exit)
 
@@ -195,6 +231,14 @@ let test_pair _switch () =
     ]
   in
   Driver.test ~name:"pair" pipeline (fun _ -> raise Exit)
+    ~final_stats:
+    { Current_term.S.
+      ok = 2;
+      failed = 0;
+      ready = 0;
+      running = 0;
+      blocked = 3;
+    }
 
 (* This is just to check the diagram. *)
 let test_context _switch () =


### PR DESCRIPTION
`Analysis.stat` walks the graph and performs simplification so that the counts match the visible boxes. However, this gets pretty slow with large pipelines (about 3s for 10,000 boxes and 52s for 50,000 boxes on my machine).

Instead, just keep counters for primitives and bind operations. This makes getting the stats O(1). Use this for the Prometheus metrics.