### PR TITLE
Replace deprecated Fmt functions

### DIFF
--- a/examples/build_matrix.ml
+++ b/examples/build_matrix.ml
@@ -30,7 +30,7 @@ let pipeline ~repo () =
       `Contents (dockerfile ~base ~ocaml_version)
     in
     Docker.build ~label:ocaml_version ~pull:false ~dockerfile (`Git src) |>
-    Docker.tag ~tag:(Fmt.strf "example-%s" ocaml_version)
+    Docker.tag ~tag:(Fmt.str "example-%s" ocaml_version)
   in
   Current.all [
     build "4.10";

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -123,7 +123,7 @@ module Engine = struct
       flush_release_queue ();
       let r = Current_incr.observe outcome in
       if not (Current_term.Output.equal Unit.equal r !last_result.value) then
-        Log.info (fun f -> f "Result: %a" Current_term.(Output.pp Fmt.(unit "()")) r);
+        Log.info (fun f -> f "Result: %a" Current_term.(Output.pp Fmt.(any "()")) r);
       last_result := {
         value = r;
         jobs = Job.Map.map List.hd !active_jobs;

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -50,7 +50,7 @@ let log t fmt =
   let { Unix.tm_year; tm_mon; tm_mday; tm_hour; tm_min; tm_sec; _ } =
     !timestamp () |> Unix.gmtime in
   let fmt = "%04d-%02d-%02d %02d:%02d.%02d: @[" ^^ fmt ^^ "@]@." in
-  Fmt.kstrf (write t) fmt
+  Fmt.kstr (write t) fmt
     (tm_year + 1900) (tm_mon + 1) tm_mday
     tm_hour tm_min tm_sec
 

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -68,10 +68,10 @@ let log_path job_id =
     let path = Fpath.(jobs_dir / date / (file ^ ".log")) in
     begin match Bos.OS.File.exists path with
       | Ok true -> Ok path
-      | Ok false -> Error (`Msg (Fmt.strf "Job log %a does not exist" Fpath.pp path))
+      | Ok false -> Error (`Msg (Fmt.str "Job log %a does not exist" Fpath.pp path))
       | Error _ as e -> e
     end
-  | _ -> Error (`Msg (Fmt.strf "Invalid job ID %S" job_id))
+  | _ -> Error (`Msg (Fmt.str "Invalid job ID %S" job_id))
 
 let id_of_path path =
   match Fpath.split_base path with
@@ -106,7 +106,7 @@ let create ?(priority=`Low) ~switch ~label ~config () =
   let time = !timestamp () |> Unix.gmtime in
   let date =
     let { Unix.tm_year; tm_mon; tm_mday; _ } = time in
-    Fmt.strf "%04d-%02d-%02d" (tm_year + 1900) (tm_mon + 1) tm_mday
+    Fmt.str "%04d-%02d-%02d" (tm_year + 1900) (tm_mon + 1) tm_mday
   in
   let date_dir = Fpath.(jobs_dir / date) in
   match Bos.OS.Dir.create date_dir with
@@ -114,7 +114,7 @@ let create ?(priority=`Low) ~switch ~label ~config () =
   | Ok (_ : bool) ->
     let prefix =
       let { Unix.tm_hour; tm_min; tm_sec; _ } = time in
-      Fmt.strf "%02d%02d%02d-%s-" tm_hour tm_min tm_sec label
+      Fmt.str "%02d%02d%02d-%s-" tm_hour tm_min tm_sec label
     in
     let path, ch = open_temp_file ~dir:date_dir ~prefix ~suffix:".log" in
     Log.info (fun f -> f "Created new log file at@ %a" Fpath.pp path);
@@ -220,7 +220,7 @@ let start_with ?timeout ~pool ~level t =
           Lwt_unix.sleep (Duration.to_f duration) >|= fun () ->
           match t.cancel_hooks with
           | `Cancelled _ -> ()
-          | `Hooks _ -> cancel t (Fmt.strf "Timeout (%a)" pp_duration duration)
+          | `Hooks _ -> cancel t (Fmt.str "Timeout (%a)" pp_duration duration)
         )
     );
   r

--- a/lib/level.ml
+++ b/lib/level.ml
@@ -31,5 +31,5 @@ let of_string x =
   match List.find_opt (fun l -> to_string l = x) values with
   | Some x -> Ok x
   | None ->
-    Error (`Msg (Fmt.strf "Unknown level %S; expected one of %a" x
+    Error (`Msg (Fmt.str "Unknown level %S; expected one of %a" x
                    Fmt.(list ~sep:(unit ", ") pp) values))

--- a/lib/level.ml
+++ b/lib/level.ml
@@ -32,4 +32,4 @@ let of_string x =
   | Some x -> Ok x
   | None ->
     Error (`Msg (Fmt.str "Unknown level %S; expected one of %a" x
-                   Fmt.(list ~sep:(unit ", ") pp) values))
+                   Fmt.(list ~sep:(any ", ") pp) values))

--- a/lib/log_matcher.ml
+++ b/lib/log_matcher.ml
@@ -117,7 +117,7 @@ let analyse_string ?job log_text =
       try Re.Group.get group (int_of_string r)
       with ex ->
         Log.err (fun f -> f "Bad group %S in report %S: %a" r test.report Fmt.exn ex);
-        Fmt.strf "Bad group %S in report %S: %a" r test.report Fmt.exn ex
+        Fmt.str "Bad group %S in report %S: %a" r test.report Fmt.exn ex
     in
     let report = Re.replace ~all:true re_subst ~f:subst test.report in
     job |> Option.iter (fun job -> Job.log job "%s" report);

--- a/lib/process.ml
+++ b/lib/process.ml
@@ -3,7 +3,7 @@ open Lwt.Infix
 let () =
   Random.self_init ()
 
-let failf fmt = fmt |> Fmt.kstrf @@ fun msg -> Error (`Msg msg)
+let failf fmt = fmt |> Fmt.kstr @@ fun msg -> Error (`Msg msg)
 
 let pp_args =
   let sep = Fmt.(const string) " " in

--- a/lib/switch.ml
+++ b/lib/switch.ml
@@ -9,7 +9,7 @@ type t = {
   mutable state : [`On of string * callback Stack.t | `Turning_off of unit Lwt.t | `Off];
 }
 
-let pp_reason f x = Current_term.Output.pp (Fmt.unit "()") f (x :> unit Current_term.Output.t)
+let pp_reason f x = Current_term.Output.pp (Fmt.any "()") f (x :> unit Current_term.Output.t)
 
 let turn_off t =
   match t.state with

--- a/lib_ansi/current_ansi.ml
+++ b/lib_ansi/current_ansi.ml
@@ -48,7 +48,7 @@ let with_style s txt =
       let style = if bold then [ "bold" ] else [] in
       let style = cl "fg" fg @ style in
       let style = cl "bg" bg @ style in
-      Fmt.strf "<span class='%a'>%s</span>" pp_style style txt
+      Fmt.str "<span class='%a'>%s</span>" pp_style style txt
 
 let create () = { gfx_state = default_gfx_state; buf = "" }
 

--- a/lib_cache/db.ml
+++ b/lib_cache/db.ml
@@ -7,7 +7,7 @@ let or_fail label x =
 
 let format_timestamp time =
   let { Unix.tm_year; tm_mon; tm_mday; tm_hour; tm_min; tm_sec; _ } = time in
-  Fmt.strf "%04d-%02d-%02d %02d:%02d:%02d" (tm_year + 1900) (tm_mon + 1) tm_mday tm_hour tm_min tm_sec
+  Fmt.str "%04d-%02d-%02d %02d:%02d:%02d" (tm_year + 1900) (tm_mon + 1) tm_mday tm_hour tm_min tm_sec
 
 type t = {
   db : Sqlite3.db;
@@ -156,14 +156,14 @@ let query ?op ?ok ?rebuild ?job_prefix () =
         s ^ "*"
       ) in
   let tests = List.filter_map Fun.id [
-      Option.map (fun x -> Fmt.strf "ok=?", sqlite_bool x) ok;
-      Option.map (fun x -> Fmt.strf "op=?", Sqlite3.Data.TEXT x) op;
-      Option.map (fun x -> Fmt.strf "rebuild=?", sqlite_bool x) rebuild;
-      Option.map (fun x -> Fmt.strf "job_id GLOB ?", Sqlite3.Data.TEXT x) job_pattern;
+      Option.map (fun x -> Fmt.str "ok=?", sqlite_bool x) ok;
+      Option.map (fun x -> Fmt.str "op=?", Sqlite3.Data.TEXT x) op;
+      Option.map (fun x -> Fmt.str "rebuild=?", sqlite_bool x) rebuild;
+      Option.map (fun x -> Fmt.str "job_id GLOB ?", Sqlite3.Data.TEXT x) job_pattern;
   ] in
   let t = Lazy.force db in
   let query = Sqlite3.prepare t.db (
-      Fmt.strf "SELECT job_id, value, ok, outcome,
+      Fmt.str "SELECT job_id, value, ok, outcome,
                 strftime('%%s', ready),
                 strftime('%%s', running),
                 strftime('%%s', finished),

--- a/lib_cache/db.ml
+++ b/lib_cache/db.ml
@@ -143,7 +143,7 @@ let finalize stmt () =
 
 let pp_where_clause f = function
   | [] -> ()
-  | tests -> Fmt.pf f "WHERE %a" Fmt.(list ~sep:(unit " AND ") string) tests
+  | tests -> Fmt.pf f "WHERE %a" Fmt.(list ~sep:(any " AND ") string) tests
 
 let sqlite_bool = function
   | false -> Sqlite3.Data.INT 0L

--- a/lib_rpc/impl.ml
+++ b/lib_rpc/impl.ml
@@ -108,7 +108,7 @@ module Make (Current : S.CURRENT) = struct
               begin match lookup () with
                 | None -> Results.description_set results "Inactive job"
                 | Some job ->
-                  Results.description_set results (Fmt.strf "%t" job#pp);
+                  Results.description_set results (Fmt.str "%t" job#pp);
                   Results.can_cancel_set results can_cancel;
                   Results.can_rebuild_set results (job#rebuild <> None);
               end;

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -197,8 +197,8 @@ module Make (Metadata : sig type t end) = struct
     let** results = aux items in
     match results with
     | Ok () -> return ()
-    | Error (`Same (ls, e)) -> fail (Fmt.str "%a failed: %s" Fmt.(list ~sep:(unit ", ") string) ls e)
-    | Error (`Diff ls) -> fail (Fmt.str "%a failed" Fmt.(list ~sep:(unit ", ") string) ls)
+    | Error (`Same (ls, e)) -> fail (Fmt.str "%a failed: %s" Fmt.(list ~sep:(any ", ") string) ls e)
+    | Error (`Diff ls) -> fail (Fmt.str "%a failed" Fmt.(list ~sep:(any ", ") string) ls)
 
   (* A node with the constant value [v], but that depends on [old]. *)
   let replace old v =

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -86,7 +86,7 @@ module Make (Metadata : sig type t end) = struct
   let catch ?(hidden=false) t =
     node (Catch { source = Term t; hidden }) @@ Current_incr.map Dyn.catch t.v
 
-  let component fmt = Fmt.strf ("@[<v>" ^^ fmt ^^ "@]")
+  let component fmt = Fmt.str ("@[<v>" ^^ fmt ^^ "@]")
 
   let join x =
     Current_incr.of_cc begin
@@ -197,8 +197,8 @@ module Make (Metadata : sig type t end) = struct
     let** results = aux items in
     match results with
     | Ok () -> return ()
-    | Error (`Same (ls, e)) -> fail (Fmt.strf "%a failed: %s" Fmt.(list ~sep:(unit ", ") string) ls e)
-    | Error (`Diff ls) -> fail (Fmt.strf "%a failed" Fmt.(list ~sep:(unit ", ") string) ls)
+    | Error (`Same (ls, e)) -> fail (Fmt.str "%a failed: %s" Fmt.(list ~sep:(unit ", ") string) ls e)
+    | Error (`Diff ls) -> fail (Fmt.str "%a failed" Fmt.(list ~sep:(unit ", ") string) ls)
 
   (* A node with the constant value [v], but that depends on [old]. *)
   let replace old v =

--- a/lib_term/dot.ml
+++ b/lib_term/dot.ml
@@ -41,13 +41,13 @@ let node f ?style ?shape ?bg ?url ?tooltip i label =
       | k, Some v -> [k, v]
     )
   in
-  Fmt.pf f "n%d [%a]@," i Fmt.(list ~sep:(unit ",") pp_option) attrs
+  Fmt.pf f "n%d [%a]@," i Fmt.(list ~sep:(any ",") pp_option) attrs
 
 let pp_options f = function
   | [] -> ()
   | items ->
     Fmt.pf f " [%a]"
-      (Fmt.list ~sep:(Fmt.unit ",") pp_option) items
+      (Fmt.list ~sep:(Fmt.any ",") pp_option) items
 
 let edge f ?style ?color a b =
   let styles = [

--- a/lib_web/context.ml
+++ b/lib_web/context.ml
@@ -52,7 +52,7 @@ let html_to_string = Fmt.to_to_string (Tyxml.Html.pp ())
 
 let logout_form t user =
   let link_path = "/logout" in
-  let link_label = Fmt.strf "Log out %s" (User.id user) in
+  let link_label = Fmt.str "Log out %s" (User.id user) in
   let open Tyxml.Html in
   [
     li [

--- a/lib_web/context.ml
+++ b/lib_web/context.ml
@@ -41,7 +41,7 @@ let has_role t role =
   let ok = t.site.has_role t.user role in
   if not ok then
     Log.info (fun f -> f "%a does not have required role %a"
-                 (Fmt.option ~none:(Fmt.unit "(anonymous)") User.pp) t.user Role.pp role);
+                 (Fmt.option ~none:(Fmt.any "(anonymous)") User.pp) t.user Role.pp role);
   ok
 
 let request t = t.request

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -78,7 +78,7 @@ let run ?(mode=default_mode) site =
     (fun () -> Lwt.return @@ Error (`Msg "Web-server stopped!"))
     (function
       | Unix.Unix_error(Unix.EADDRINUSE, "bind", _) ->
-        let msg = Fmt.strf "Web-server failed.@ Another program is already using this port %a." pp_mode mode in
+        let msg = Fmt.str "Web-server failed.@ Another program is already using this port %a." pp_mode mode in
         Lwt.return @@ Error (`Msg msg)
       | ex -> Lwt.fail ex
     )

--- a/lib_web/job.ml
+++ b/lib_web/job.ml
@@ -20,7 +20,7 @@ let read ~start path =
 
 let render ctx ~actions ~job_id ~log:path =
   let ansi = Current_ansi.create () in
-  let action op = a_action (Fmt.strf "/job/%s/%s" job_id op) in
+  let action op = a_action (Fmt.str "/job/%s/%s" job_id op) in
   let csrf = Context.csrf ctx in
   let rebuild_button =
     if actions#rebuild = None then []
@@ -51,7 +51,7 @@ let render ctx ~actions ~job_id ~log:path =
   let job_item ~label id =
     let label = txt label in
     if id = job_id then b [label]
-    else a ~a:[a_href (Fmt.strf "/job/%s" id)] [label]
+    else a ~a:[a_href (Fmt.str "/job/%s" id)] [label]
   in
   let history =
     match Current_cache.Db.history ~limit:10 ~job_id with
@@ -180,7 +180,7 @@ let start ~job_id = object
       Context.respond_redirect ctx (Uri.of_string ("/job/" ^ id))
 end
 
-let id ~date ~log = Fmt.strf "%s/%s" date log
+let id ~date ~log = Fmt.str "%s/%s" date log
 
 let routes ~engine = Routes.[
     s "job" / str / str /? nil @--> (fun date log -> job ~engine ~job_id:(id ~date ~log));

--- a/lib_web/jobs.ml
+++ b/lib_web/jobs.ml
@@ -3,7 +3,7 @@ open Tyxml.Html
 module Job = Current.Job
 
 let render_row (id, job) =
-  let url = Fmt.strf "/job/%s" id in
+  let url = Fmt.str "/job/%s" id in
   let start_time =
     match Lwt.state (Job.start_time job) with
     | Lwt.Sleep -> "(ready to start)"

--- a/lib_web/log_rules.ml
+++ b/lib_web/log_rules.ml
@@ -51,7 +51,7 @@ let test_pattern pattern =
                 ~finally:(fun () -> close_in ch)
             in
             Re.exec_opt re log_data |> Option.map (fun g ->
-                let text = Fmt.strf "@[<v>%a@]" dump_groups (Re.Group.all g) in
+                let text = Fmt.str "@[<v>%a@]" dump_groups (Re.Group.all g) in
                 job_id, text
               )
           | Error _ -> None
@@ -61,10 +61,10 @@ let test_pattern pattern =
   >|= fun results ->
   let open Tyxml.Html in
   match results with
-  | [] -> [p [txt (Fmt.strf "New pattern doesn't match anything in last %d jobs" n_jobs)]]
+  | [] -> [p [txt (Fmt.str "New pattern doesn't match anything in last %d jobs" n_jobs)]]
   | results ->
     [
-      p [txt (Fmt.strf "%d matches in last %d jobs:" (List.length results) n_jobs)];
+      p [txt (Fmt.str "%d matches in last %d jobs:" (List.length results) n_jobs)];
       table ~a:[a_class ["table"; "log-rules"]]
         ~thead:(thead [
             tr [
@@ -73,7 +73,7 @@ let test_pattern pattern =
             ]
           ])
         (results |> List.map @@ fun (job_id, text) ->
-         let job = Fmt.strf "/job/%s" job_id in
+         let job = Fmt.str "/job/%s" job_id in
          tr [
            td [ a ~a:[a_href job] [txt job_id] ];
            td [pre [txt text]]

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -12,7 +12,7 @@ let settings ctx config =
     Current.Level.values
     |> List.map @@ fun level ->
     let s = Current.Level.to_string level in
-    let msg = Fmt.strf "Confirm if level >= %s" s in
+    let msg = Fmt.str "Confirm if level >= %s" s in
     let sel = if selected = Some level then [a_selected ()] else [] in
     option ~a:(a_value s :: sel) (txt msg)
   in

--- a/lib_web/pipeline.ml
+++ b/lib_web/pipeline.ml
@@ -13,7 +13,7 @@ let render_svg ctx a =
       let query = (k, [v]) :: List.remove_assoc k old_query in
       Some (Uri.make ~path:"/" ~query () |> Uri.to_string)
   and job_info { Current.Metadata.job_id; update } =
-    let url = job_id |> Option.map (fun id -> Fmt.strf "/job/%s" id) in
+    let url = job_id |> Option.map (fun id -> Fmt.str "/job/%s" id) in
     update, url
   in
   let dotfile = Fmt.to_to_string (Current.Analysis.pp_dot ~env ~collapse_link ~job_info) a in

--- a/lib_web/query.ml
+++ b/lib_web/query.ml
@@ -9,13 +9,13 @@ let pp_duration f x =
   Fmt.pf f "%.0fs" x
 
 let render_row ~jobs ~need_toggles { Db.job_id; build; value = _; rebuild; ready; running; finished; outcome } =
-  let job = Fmt.strf "/job/%s" job_id in
+  let job = Fmt.str "/job/%s" job_id in
   let times =
     match running with
     | None ->
-      Fmt.strf "%a queued" pp_duration (finished -. ready)
+      Fmt.str "%a queued" pp_duration (finished -. ready)
     | Some running ->
-      Fmt.strf "%a+%a"
+      Fmt.str "%a+%a"
         pp_duration (running -. ready)
         pp_duration (finished -. running)
   in

--- a/lib_web/query.ml
+++ b/lib_web/query.ml
@@ -162,7 +162,7 @@ let r ~engine = object
         let msg =
           Fmt.str "%d/%d jobs could not be restarted (because they are no longer active): %a"
             (List.length failed) (List.length jobs)
-            Fmt.(list ~sep:(unit ", ") string) failed in
+            Fmt.(list ~sep:(any ", ") string) failed in
         Context.respond_error ctx `Bad_request msg
 
   method! nav_link = Some "Query"

--- a/lib_web/utils.ml
+++ b/lib_web/utils.ml
@@ -2,4 +2,4 @@ module Server = Cohttp_lwt_unix.Server
 
 let string_of_timestamp time =
   let { Unix.tm_year; tm_mon; tm_mday; tm_hour; tm_min; tm_sec; _ } = time in
-  Fmt.strf "%04d-%02d-%02d %02d:%02d:%02d" (tm_year + 1900) (tm_mon + 1) tm_mday tm_hour tm_min tm_sec
+  Fmt.str "%04d-%02d-%02d %02d:%02d:%02d" (tm_year + 1900) (tm_mon + 1) tm_mday tm_hour tm_min tm_sec

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -48,7 +48,7 @@ end
 module Value = Image
 
 let errorf fmt =
-  fmt |> Fmt.kstrf @@ fun msg ->
+  fmt |> Fmt.kstr @@ fun msg ->
   Error (`Msg msg)
 
 let or_raise = function

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -133,7 +133,7 @@ module Make (Host : S.HOST) = struct
     let> () = Current.return () in
     Raw.peek ~docker_context ~schedule ~arch tag
 
-  let pp_sp_label = Fmt.(option (prefix sp string))
+  let pp_sp_label = Fmt.(option (sp ++ string))
 
   let get_build_context = function
     | `No_context -> Current.return `No_context

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -2,7 +2,7 @@ open Current.Syntax
 
 module S = S
 
-let pp_tag = Fmt.using (Astring.String.cuts ~sep:":") Fmt.(list ~sep:(unit ":@,") string)
+let pp_tag = Fmt.using (Astring.String.cuts ~sep:":") Fmt.(list ~sep:(any ":@,") string)
 
 module Raw = struct
   module Image = Image

--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -38,7 +38,7 @@ let build No_context job { Key.repo; gref } =
   (* Ensure we have a local clone of the repository. *)
   begin
     if Cmd.dir_exists local_repo
-    then Cmd.git_fetch ~cancellable:true ~job ~src:repo ~dst:local_repo (Fmt.strf "%s:refs/remotes/origin/%s" gref gref)
+    then Cmd.git_fetch ~cancellable:true ~job ~src:repo ~dst:local_repo (Fmt.str "%s:refs/remotes/origin/%s" gref gref)
     else Cmd.git_clone ~cancellable:true ~job ~src:repo local_repo
   end >>!= fun () ->
   Cmd.git_rev_parse ~cancellable:true ~job ~repo:local_repo ("origin/" ^ gref) >>!= fun hash ->

--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -17,7 +17,7 @@ let id_of_repo repo =
   let module Hash = Mirage_crypto.Hash.SHA256 in
   let base = Filename.basename repo in
   let digest = Hash.digest (Cstruct.of_string repo) in
-  Fmt.strf "%s-%a" base pp_hex digest
+  Fmt.str "%s-%a" base pp_hex digest
 
 (* .../var/git/myrepo-hhh *)
 let local_copy repo =

--- a/plugins/git/commit.ml
+++ b/plugins/git/commit.ml
@@ -27,7 +27,7 @@ let pp_short f t =
 
 let check_cached t =
   let hash = hash t in
-  let branch = Fmt.strf "fetch-%s" hash in
+  let branch = Fmt.str "fetch-%s" hash in
   Cmd.git ~cwd:t.repo ["branch"; "-f"; branch; hash]
 
 let marshal t = to_yojson t |> Yojson.Safe.to_string

--- a/plugins/git/commit_id.ml
+++ b/plugins/git/commit_id.ml
@@ -31,7 +31,7 @@ let is_local t =
 
 let equal = (=)
 let compare = compare
-let digest {repo; gref; hash} = Fmt.strf "%s %s %s" repo gref hash
+let digest {repo; gref; hash} = Fmt.str "%s %s %s" repo gref hash
 
 let repo t = t.repo
 let gref t = t.gref

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -114,7 +114,7 @@ module Local = struct
     let cmd = [| "git"; "-C"; Fpath.to_string t.repo; "rev-parse"; "--revs-only"; gref |] in
     Lwt_process.pread ("", cmd) >|= fun out ->
     match String.trim out with
-    | "" -> Error (`Msg (Fmt.strf "Unknown ref %S" gref))
+    | "" -> Error (`Msg (Fmt.str "Unknown ref %S" gref))
     | hash ->
       let id = { Commit_id.repo = Fpath.to_string t.repo; gref; hash } in
       Ok { Commit.repo = t.repo; id }
@@ -181,7 +181,7 @@ module Local = struct
       match String.cuts ~sep:" " (String.trim contents) with
       | [hash] -> Ok (`Commit {Commit_id.repo = Fpath.to_string repo; gref = "HEAD"; hash})
       | [_;r]  -> Ok (`Ref r)
-      | _      -> Error (`Msg (Fmt.strf "Can't parse HEAD %S" contents))
+      | _      -> Error (`Msg (Fmt.str "Can't parse HEAD %S" contents))
 
   let make_head repo =
     let dot_git = Fpath.(repo / ".git") in

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -50,7 +50,7 @@ end
 let graphql_endpoint = Uri.of_string "https://api.github.com/graphql"
 
 let status_endpoint ~owner_name ~commit =
-  Uri.of_string (Fmt.strf "https://api.github.com/repos/%s/statuses/%s"
+  Uri.of_string (Fmt.str "https://api.github.com/repos/%s/statuses/%s"
                    owner_name commit)
 
 let read_file path =
@@ -114,7 +114,7 @@ module Ref = struct
 
   let to_git = function
     | `Ref head -> head
-    | `PR id -> Fmt.strf "refs/pull/%d/head" id
+    | `PR id -> Fmt.str "refs/pull/%d/head" id
 end
 
 module Ref_map = Map.Make(Ref)
@@ -127,7 +127,7 @@ module Commit_id = struct
   } [@@deriving to_yojson]
 
   let to_git { owner_name; id; hash } =
-    let repo = Fmt.strf "https://github.com/%s.git" owner_name in
+    let repo = Fmt.str "https://github.com/%s.git" owner_name in
     let gref = Ref.to_git id in
     Current_git.Commit_id.v ~repo ~gref ~hash
 
@@ -286,7 +286,7 @@ let make_head_commit_monitor t repo =
   let read () =
     Lwt.catch
       (fun () -> default_ref t repo >|= fun c -> Ok (t, c))
-      (fun ex -> Lwt_result.fail @@ `Msg (Fmt.strf "GitHub query for %a failed: %a" Repo_id.pp repo Fmt.exn ex))
+      (fun ex -> Lwt_result.fail @@ `Msg (Fmt.str "GitHub query for %a failed: %a" Repo_id.pp repo Fmt.exn ex))
   in
   let watch refresh =
     let owner_name = Printf.sprintf "%s/%s" repo.owner repo.name in
@@ -410,7 +410,7 @@ let make_ci_refs_monitor t repo =
   let read () =
     Lwt.catch
       (fun () -> get_ci_refs t repo >|= Stdlib.Result.ok)
-      (fun ex -> Lwt_result.fail @@ `Msg (Fmt.strf "GitHub query for %a failed: %a" Repo_id.pp repo Fmt.exn ex))
+      (fun ex -> Lwt_result.fail @@ `Msg (Fmt.str "GitHub query for %a failed: %a" Repo_id.pp repo Fmt.exn ex))
   in
   let watch refresh =
     let owner_name = Printf.sprintf "%s/%s" repo.owner repo.name in
@@ -468,7 +468,7 @@ let head_of t repo id =
   | Ok refs ->
     match Ref_map.find_opt id refs with
     | Some x -> Ok x
-    | None -> Error (`Msg (Fmt.strf "No such ref %a/%a" Repo_id.pp repo Ref.pp id))
+    | None -> Error (`Msg (Fmt.str "No such ref %a/%a" Repo_id.pp repo Ref.pp id))
 
 module Commit = struct
   module Set_status = struct
@@ -633,7 +633,7 @@ module Anonymous = struct
         )
         (fun ex ->
            Log.warn (fun f -> f "GitHub query_head failed: %a" Fmt.exn ex);
-           Lwt_result.fail (`Msg (Fmt.strf "Failed to get head of %a:%a" Repo_id.pp repo Ref.pp gref))
+           Lwt_result.fail (`Msg (Fmt.str "Failed to get head of %a:%a" Repo_id.pp repo Ref.pp gref))
         )
     in
     let watch refresh =

--- a/plugins/github/app.ml
+++ b/plugins/github/app.ml
@@ -23,7 +23,7 @@ let list_installations_endpoint =
   Uri.of_string "https://api.github.com/app/installations"
 
 let access_tokens_endpoint id =
-  Uri.of_string (Fmt.strf "https://api.github.com/app/installations/%d/access_tokens" id)
+  Uri.of_string (Fmt.str "https://api.github.com/app/installations/%d/access_tokens" id)
 
 module Int_map = Map.Make(Int)
 
@@ -129,7 +129,7 @@ let get_installations app =
      in
      aux list_installations_endpoint
     ) (fun ex ->
-      Lwt_result.fail (`Msg (Fmt.strf "Failed to get GitHub installations: %a" Fmt.exn ex))
+      Lwt_result.fail (`Msg (Fmt.str "Failed to get GitHub installations: %a" Fmt.exn ex))
     )
 
 let installation t ~account iid =

--- a/plugins/github/current_github.ml
+++ b/plugins/github/current_github.ml
@@ -24,7 +24,7 @@ let webhook = object
     Log.info (fun f -> f "input_webhook: %a" Cohttp_lwt.Request.pp_hum req);
     let headers = Cohttp.Request.headers req in
     let event = Cohttp.Header.get headers "X-GitHub-Event" in
-    Log.info (fun f -> f "Got GitHub event %a" Fmt.(option ~none:(unit "NONE") (quote string)) event);
+    Log.info (fun f -> f "Got GitHub event %a" Fmt.(option ~none:(any "NONE") (quote string)) event);
     Prometheus.Counter.inc_one (Metrics.webhook_events_total (Option.value event ~default:"NONE"));
     Cohttp_lwt.Body.to_string body >|= Yojson.Safe.from_string >>= fun body ->
     begin match event with

--- a/plugins/github/repo_id.ml
+++ b/plugins/github/repo_id.ml
@@ -12,6 +12,6 @@ let cmdliner =
   let parse s =
     match Astring.String.cuts ~sep:"/" s with
     | [ owner; name] -> Ok { owner; name }
-    | _ -> Error (`Msg (Fmt.strf "%S not in the form 'owner/name'" s))
+    | _ -> Error (`Msg (Fmt.str "%S not in the form 'owner/name'" s))
   in
   Arg.conv ~docv:"REPO" (parse, pp)

--- a/plugins/slack/post.ml
+++ b/plugins/slack/post.ml
@@ -24,7 +24,7 @@ let publish t job _key message =
   match resp.Cohttp_lwt.Response.status with
   | `OK -> Lwt.return @@ Ok ()
   | err ->
-    let msg = Fmt.strf "Slack post failed: %s" (Cohttp.Code.string_of_status err) in
+    let msg = Fmt.str "Slack post failed: %s" (Cohttp.Code.string_of_status err) in
     Lwt.return @@ Error (`Msg msg)
 
 let pp f (key, value) = Fmt.pf f "Post %s: %s" key value

--- a/test/driver.ml
+++ b/test/driver.ml
@@ -91,7 +91,7 @@ let test ?config ?final_stats ~name v actions =
     end;
     current_watches := step_result;
     let { Current.Engine.value = x; _} = step_result in
-    Logs.info (fun f -> f "--> %a" (Current_term.Output.pp (Fmt.unit "()")) x);
+    Logs.info (fun f -> f "--> %a" (Current_term.Output.pp (Fmt.any "()")) x);
     begin
       if Lwt.state next <> Lwt.Sleep then Fmt.failwith "Already ready, and nothing changed yet!";
       try actions !step with

--- a/test/driver.ml
+++ b/test/driver.ml
@@ -43,7 +43,7 @@ let pp_job f j = j#pp f
 
 let find_by_descr msg =
   let jobs = (!current_watches).Current.Engine.jobs |> Current.Job.Map.bindings in
-  match List.find_opt (fun (_, job) -> Fmt.strf "%t" job#pp = msg) jobs with
+  match List.find_opt (fun (_, job) -> Fmt.str "%t" job#pp = msg) jobs with
   | None ->
     Fmt.failwith "@[<v2>No job with description %S. We have:@,%a@]" msg
       Fmt.(Dump.list pp_job) (List.map snd jobs)
@@ -80,7 +80,7 @@ let test ?config ?final_stats ~name v actions =
     if !step = 0 then raise Exit;
     begin
       Logs.info (fun f -> f "Analysis: @[%a@]" Current.Analysis.pp test_pipeline);
-      let path = Fmt.strf "%s.%d.dot" name !step in
+      let path = Fmt.str "%s.%d.dot" name !step in
       let ch = open_out path in
       let f = Format.formatter_of_out_channel ch in
       let collapse_link ~k:_ ~v:_ = None in

--- a/test/plugins/docker/current_docker_test.ml
+++ b/test/plugins/docker/current_docker_test.ml
@@ -29,7 +29,7 @@ end
 let build_on platform ~src =
   Current.component "build-%s" platform |>
   let> c = src in
-  Current.Primitive.const @@ Fmt.strf "%s-image-%s" platform (Fpath.to_string c)
+  Current.Primitive.const @@ Fmt.str "%s-image-%s" platform (Fpath.to_string c)
 
 let build c =
   Current.component "build" |>
@@ -163,7 +163,7 @@ let reset () =
 
 let assert_finished () =
   !containers |> Containers.iter (fun key s ->
-      let ex = Failure (Fmt.strf "Container %a still running!" Key.pp key) in
+      let ex = Failure (Fmt.str "Container %a still running!" Key.pp key) in
       try Lwt.wakeup_exn s ex; raise ex
       with Invalid_argument _ -> () (* Already resolved - good! *)
     )

--- a/test/plugins/git/current_git_test.ml
+++ b/test/plugins/git/current_git_test.ml
@@ -22,7 +22,7 @@ module Commit = struct
 
   let equal = (=)
   let compare = compare
-  let digest { repo; hash } = Fmt.strf "%s#%s" repo hash
+  let digest { repo; hash } = Fmt.str "%s#%s" repo hash
 end
 
 let complete_clone {Commit.repo; hash} =

--- a/test/test.ml
+++ b/test/test.ml
@@ -77,7 +77,7 @@ let v3 commit =
   let test (_p, x) = test x in
   let tests = Current.all @@ List.map test binaries in
   let gated_deploy (p, x) =
-    let tag = Fmt.strf "foo/%s" p in
+    let tag = Fmt.str "foo/%s" p in
     x |> Current.gate ~on:tests |> push ~tag
   in
   Current.all @@ List.map gated_deploy binaries

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -42,7 +42,7 @@ let disk_cache () =
   Current_cache.Db.query ~op:"test-build" ~rebuild:false ()
   |> List.map (fun { Current_cache.Db.job_id = _; outcome; ready; running; finished; build; value = _; rebuild = _ } ->
       let running = Option.map truncate running in
-      Fmt.strf "%a %.0f/%a/%.0f +%Ld" Fmt.(result ~ok:string ~error:pp_error) outcome
+      Fmt.str "%a %.0f/%a/%.0f +%Ld" Fmt.(result ~ok:string ~error:pp_error) outcome
         ready Fmt.(option ~none:(unit "-") int) running finished build
     )
   |> List.sort compare
@@ -119,7 +119,7 @@ let expires _switch () =
       let+ x = get ~schedule:ten_s builds "a"
       and+ y = get ~schedule:five_s builds "a"
       in
-      Fmt.strf "%s,%s" x y
+      Fmt.str "%s,%s" x y
     )
     |> Current.map (fun x -> result := x)
   in

--- a/test/test_cache.ml
+++ b/test/test_cache.ml
@@ -43,7 +43,7 @@ let disk_cache () =
   |> List.map (fun { Current_cache.Db.job_id = _; outcome; ready; running; finished; build; value = _; rebuild = _ } ->
       let running = Option.map truncate running in
       Fmt.str "%a %.0f/%a/%.0f +%Ld" Fmt.(result ~ok:string ~error:pp_error) outcome
-        ready Fmt.(option ~none:(unit "-") int) running finished build
+        ready Fmt.(option ~none:(any "-") int) running finished build
     )
   |> List.sort compare
 


### PR DESCRIPTION
This PR is trivial as Fmt already aliases the deprecated functions to their replacement. They were only renamed.