### PR TITLE
Current_git.clone: find default branch when gref is not specified

### DIFF
--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -7,7 +7,7 @@ let ( >>!= ) = Lwt_result.bind
 module Key = struct
   type t = {
     repo : string;  (* Remote repository from which to pull. *)
-    gref : string;
+    gref : string option;
   } [@@deriving to_yojson]
 
   let pp f t = Yojson.Safe.pretty_print f (to_yojson t)
@@ -31,10 +31,23 @@ let repo_lock repo =
 
 let id = "git-clone"
 
+let parse_ls_remote_output ~job output =
+  match List.find_opt (fun line -> String.sub line 0 4 = "ref:") output with
+  | Some ref_line ->
+    let split = Astring.String.fields ~empty:false ~is_sep:(function | ' ' | '\t' | '/' -> true | _ -> false) ref_line in
+    let branch,_ = List.fold_left (fun (_,b) c -> (b,c)) ("","") split in
+    Current.Job.log job "Default branch is '%s'" branch;
+    Ok branch
+  | None -> Error (`Msg "Failed to parse ls-remote output.")
+
 let build No_context job { Key.repo; gref } =
   Lwt_mutex.with_lock (repo_lock repo) @@ fun () ->
   Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
   let local_repo = Cmd.local_copy repo in
+  (match gref with
+    | Some v -> Lwt.return_ok v
+    | None -> Cmd.git_ls_remote ~job repo >|= (fun res -> Result.bind res (parse_ls_remote_output ~job)))
+  >>!= fun gref ->
   (* Ensure we have a local clone of the repository. *)
   begin
     if Cmd.dir_exists local_repo

--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -45,6 +45,12 @@ let git_reset_hard ~job ~repo hash =
 let git_remote_set_url ~job ~repo ~remote url =
   git ~cancellable:false ~job ~cwd:repo ["remote"; "set-url"; remote; url]
 
+let git_ls_remote ?(cancellable=false) ?(ref="HEAD") ~job url =
+  let cmd = ["git"; "ls-remote"; "--symref"; url; ref] in
+  Current.Process.check_output ~cancellable ~job ("", Array.of_list cmd) >|=
+  Stdlib.Result.map String.trim >|=
+  Stdlib.Result.map (String.split_on_char '\n')
+
 let git_rev_parse ?(cancellable=false) ~job ~repo x =
   let cmd = ["git"; "-C"; Fpath.to_string repo; "rev-parse"; x] in
   Current.Process.check_output ~cancellable ~job ("", Array.of_list cmd) >|= Stdlib.Result.map String.trim

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -58,8 +58,9 @@ let fetch cid =
 
 module Clone_cache = Current_cache.Make(Clone)
 
-let clone ~schedule ?(gref="master") repo =
-  Current.component "clone@ %s@ %s" repo gref |>
+let clone ~schedule ?gref repo =
+  let pp_ref f = Fmt.pf f "@ %s" in
+  Current.component "clone@ %s%a" repo (Fmt.option pp_ref) gref |>
   let> () = Current.return () in
   Clone_cache.get ~schedule Clone.No_context { Clone.Key.repo; gref }
 

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -40,7 +40,8 @@ module Commit : sig
 end
 
 val clone : schedule:Current_cache.Schedule.t -> ?gref:string -> string -> Commit.t Current.t
-(** [clone ~schedule ~gref uri] evaluates to the head commit of [uri]'s [gref] branch (default: "master"). *)
+(** [clone ~schedule ~gref uri] evaluates to the head commit of [uri]'s [gref] branch (default: make 
+    use of `git ls-remote` to get the remote's default branch). *)
 
 val fetch : Commit_id.t Current.t -> Commit.t Current.t
 


### PR DESCRIPTION
An attempt to fix https://github.com/ocurrent/ocurrent/issues/247
