### PR TITLE
Update Dockerfile to latest opam-repository.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-10-ocaml-4.08
 RUN sudo apt-get update && sudo apt-get install capnproto graphviz m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard be5f02dafef6810cde6c51e1372806037989a8c3 && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 01a0c2282a5aee43b5fbc0dade2d7a60888dafa9 && opam update
 ADD --chown=opam *.opam /src/
 WORKDIR /src
 RUN opam pin add -yn current_web.dev "./" && \


### PR DESCRIPTION
This is required because we depend on astring 0.8.5 (since 8df8b8530,
Dec 9 2020) and our previous pinned opam-repository doesn't include that
version of astring.  This implies that examples/docker_build_local has
been broken since then o_O.