### PR TITLE
Implement labelling of clusters on the Graphviz diagram.

### DIFF
--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -34,8 +34,8 @@ module Make (Meta : sig type t end) = struct
         | Primitive {x; info; meta = _ } -> Fmt.pf f "%a@;>>=@;%s" aux x info
         | Pair (x, y) -> Fmt.pf f "@[<v>@[%a@]@,||@,@[%a@]@]" aux x aux y
         | Gate_on { ctrl; value } -> Fmt.pf f "%a@;>>@;gate (@[%a@])" aux value aux ctrl
-        | List_map { items; output } -> Fmt.pf f "%a@;>>@;list_map (@[%a@])" aux items aux (Current_incr.observe output)
-        | Option_map { item; output } -> Fmt.pf f "%a@;>>@;option_map (@[%a@])" aux item aux (Current_incr.observe output)
+        | List_map { items; output; label = _ } -> Fmt.pf f "%a@;>>@;list_map (@[%a@])" aux items aux (Current_incr.observe output)
+        | Option_map { item; output; label = _ } -> Fmt.pf f "%a@;>>@;option_map (@[%a@])" aux item aux (Current_incr.observe output)
         | State x -> Fmt.pf f "state(@[%a@])" aux x.source
         | Catch x -> Fmt.pf f "catch(@[%a@])" aux x.source
         | Map x -> aux f x
@@ -268,15 +268,15 @@ module Make (Meta : sig type t end) = struct
               | _ ->
                 aux x
             end
-          | List_map { items; output } ->
+          | List_map { items; output; label } ->
             ignore (aux items);
-            Dot.begin_cluster f i;
+            Dot.begin_cluster f ?label i;
             let outputs = aux (Current_incr.observe output) in
             Dot.end_cluster f;
             outputs
-          | Option_map { item; output } ->
+          | Option_map { item; output; label } ->
             ignore (aux item);
-            Dot.begin_cluster f i;
+            Dot.begin_cluster f ?label i;
             Dot.pp_option f ("style", "dotted");
             let outputs = aux (Current_incr.observe output) in
             Dot.end_cluster f;
@@ -400,10 +400,10 @@ module Make (Meta : sig type t end) = struct
               | _ ->
                 aux x
             end
-          | List_map { items; output } ->
+          | List_map { items; output; label = _ } ->
             ignore (aux items);
             aux (Current_incr.observe output)
-          | Option_map { item; output } ->
+          | Option_map { item; output; label = _ } ->
             ignore (aux item);
             aux (Current_incr.observe output)
           | Collapse x ->

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -209,7 +209,7 @@ module Make (Metadata : sig type t end) = struct
       bind = Some (Term old)
     }
 
-  let option_map (type a b) (f : a t -> b t) (input : a option t) : b option t =
+  let option_map (type a b) ?label (f : a t -> b t) (input : a option t) : b option t =
     let results =
       input.v |> Current_incr.map @@ function
       | Error _ as r ->
@@ -226,7 +226,7 @@ module Make (Metadata : sig type t end) = struct
         { output with v = Current_incr.map (Result.map Option.some) output.v }
     in
     let output = Current_incr.map (fun x -> Term x) results in
-    node (Option_map { item = Term input; output }) (join results)
+    node (Option_map { item = Term input; output; label }) (join results)
 
   let rec list_seq : 'a t list -> 'a list t = function
     | [] -> return []
@@ -236,7 +236,7 @@ module Make (Metadata : sig type t end) = struct
       y :: ys
 
 
-  let list_map (type a) (module M : S.ORDERED with type t = a) ?collapse_key (f : a t -> 'b t) (input : a list t) =
+  let list_map (type a) (module M : S.ORDERED with type t = a) ?collapse_key ?label (f : a t -> 'b t) (input : a list t) =
     let module Map = Map.Make(M) in
     let module Sep = Current_incr.Separate(Map) in
     (* Stage 1 : convert input list to a set.
@@ -281,10 +281,10 @@ module Make (Metadata : sig type t end) = struct
       end
     in
     let output = Current_incr.map (fun x -> Term x) results in
-    node (List_map { items = Term input; output }) (join results)
+    node (List_map { items = Term input; output; label }) (join results)
 
-  let list_iter (type a) (module M : S.ORDERED with type t = a) ?collapse_key f (xs : a list t) =
-    let+ (_ : unit list) = list_map (module M) ?collapse_key f xs in
+  let list_iter (type a) (module M : S.ORDERED with type t = a) ?collapse_key ?label f (xs : a list t) =
+    let+ (_ : unit list) = list_map (module M) ?collapse_key ?label f xs in
     ()
 
   let option_seq : 'a t option -> 'a option t = function

--- a/lib_term/dot.mli
+++ b/lib_term/dot.mli
@@ -4,5 +4,5 @@ val node : Format.formatter -> ?style:string -> ?shape:string -> ?bg:string -> ?
 val edge : Format.formatter -> ?style:string -> ?color:string -> int -> int -> unit
 val pp_option : (string * string) Fmt.t
 
-val begin_cluster : Format.formatter -> int -> unit
+val begin_cluster : Format.formatter -> ?label:string -> int -> unit
 val end_cluster : Format.formatter -> unit

--- a/lib_term/node.ml
+++ b/lib_term/node.ml
@@ -19,7 +19,7 @@ module Make (Metadata : sig type t end) = struct
     | Primitive of {x : generic; info : string; meta : Metadata.t option Current_incr.t }
     | Pair of generic * generic
     | Gate_on of { ctrl : generic; value : generic }
-    | List_map of { items : generic; output : generic Current_incr.t }
-    | Option_map of { item : generic; output : generic Current_incr.t }
+    | List_map of { items : generic; output : generic Current_incr.t; label: string option }
+    | Option_map of { item : generic; output : generic Current_incr.t; label: string option }
     | Collapse of { key : string; value : string; input : generic; output : generic }
 end

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -109,21 +109,21 @@ module type TERM = sig
   (** [pair a b] is the pair containing the results of evaluating [a] and [b]
       (in parallel). *)
 
-  val list_map : (module ORDERED with type t = 'a) -> ?collapse_key:string -> ('a t -> 'b t) -> 'a list t -> 'b list t
+  val list_map : (module ORDERED with type t = 'a) -> ?collapse_key:string -> ?label:string -> ('a t -> 'b t) -> 'a list t -> 'b list t
   (** [list_map (module T) f xs] adds [f] to the end of each input term
       and collects all the results into a single list.
       @param T Used to display labels for each item, and to avoid recreating pipelines
                unnecessarily.
       @param collapse_key If given, each element is wrapped with [collapse]. *)
 
-  val list_iter : (module ORDERED with type t = 'a) -> ?collapse_key:string -> ('a t -> unit t) -> 'a list t -> unit t
+  val list_iter : (module ORDERED with type t = 'a) -> ?collapse_key:string -> ?label:string -> ('a t -> unit t) -> 'a list t -> unit t
   (** Like [list_map] but for the simpler case when the result is unit. *)
 
   val list_seq : 'a t list -> 'a list t
   (** [list_seq x] evaluates to a list containing the results of evaluating
       each element in [x], once all elements of [x] have successfully completed. *)
 
-  val option_map : ('a t -> 'b t) -> 'a option t -> 'b option t
+  val option_map : ?label:string -> ('a t -> 'b t) -> 'a option t -> 'b option t
   (** [option_map f x] is a term that evaluates to [Some (f y)] if [x]
       evaluates to [Some y], or to [None] otherwise. *)
 

--- a/test/expected/option-none.1.dot
+++ b/test/expected/option-none.1.dot
@@ -6,7 +6,7 @@ digraph pipeline {
   n9 [label="head",fillcolor="#90ee90",style="filled"]
   n8 [label="fetch",fillcolor="#ffa500",style="filled"]
   n7 [label="analyse",fillcolor="#d3d3d3",style="filled"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   style="dotted"n13 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
   n7 -> n13

--- a/test/expected/option-none.2.dot
+++ b/test/expected/option-none.2.dot
@@ -6,7 +6,7 @@ digraph pipeline {
   n9 [label="head",fillcolor="#90ee90",style="filled"]
   n8 [label="fetch",fillcolor="#90ee90",style="filled"]
   n7 [label="analyse",fillcolor="#90ee90",style="filled"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   style="dotted"n13 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
   n7 -> n13

--- a/test/expected/option-some.1.dot
+++ b/test/expected/option-some.1.dot
@@ -6,7 +6,7 @@ digraph pipeline {
   n9 [label="head",fillcolor="#90ee90",style="filled"]
   n8 [label="fetch",fillcolor="#ffa500",style="filled"]
   n7 [label="analyse",fillcolor="#d3d3d3",style="filled"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   style="dotted"n13 [label="lint",fillcolor="#d3d3d3",style="filled"]
   }
   n7 -> n13

--- a/test/expected/option-some.2.dot
+++ b/test/expected/option-some.2.dot
@@ -6,7 +6,7 @@ digraph pipeline {
   n9 [label="head",fillcolor="#90ee90",style="filled"]
   n8 [label="fetch",fillcolor="#90ee90",style="filled"]
   n7 [label="analyse",fillcolor="#90ee90",style="filled"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   style="dotted"n12 [label="lint",fillcolor="#90ee90",style="filled"]
   }
   n7 -> n12

--- a/test/expected/v5.1.dot
+++ b/test/expected/v5.1.dot
@@ -9,7 +9,7 @@ digraph pipeline {
   n6 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   n10 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
   n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
   n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
   n13 [label="build",fillcolor="#d3d3d3",style="filled"]

--- a/test/expected/v5.2.dot
+++ b/test/expected/v5.2.dot
@@ -9,7 +9,7 @@ digraph pipeline {
   n6 [label="docker run make test",fillcolor="#ffa500",style="filled"]
   n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
   n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
   n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
   n13 [label="build",fillcolor="#d3d3d3",style="filled"]

--- a/test/expected/v5.3.dot
+++ b/test/expected/v5.3.dot
@@ -9,7 +9,7 @@ digraph pipeline {
   n6 [label="docker run make test",fillcolor="#90ee90",style="filled"]
   n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
   n5 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   n19 [label="example.org/bar#222",fillcolor="#90ee90",style="filled"]
   n18 [label="fetch",fillcolor="#ffa500",style="filled"]
   n17 [label="build",fillcolor="#d3d3d3",style="filled"]

--- a/test/expected/v5n.1.dot
+++ b/test/expected/v5n.1.dot
@@ -9,7 +9,7 @@ digraph pipeline {
   n6 [label="docker run make test",fillcolor="#d3d3d3",style="filled"]
   n10 [label="get-revdeps",fillcolor="#d3d3d3",style="filled"]
   n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
   n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
   n13 [label="build",fillcolor="#d3d3d3",style="filled"]

--- a/test/expected/v5n.2.dot
+++ b/test/expected/v5n.2.dot
@@ -9,7 +9,7 @@ digraph pipeline {
   n6 [label="docker run make test",fillcolor="#ffa500",style="filled"]
   n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
   n5 [label="",fillcolor="#d3d3d3",style="filled",shape="circle"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   n15 [label="(each item)",fillcolor="#d3d3d3",style="filled"]
   n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
   n13 [label="build",fillcolor="#d3d3d3",style="filled"]

--- a/test/expected/v5n.3.dot
+++ b/test/expected/v5n.3.dot
@@ -9,7 +9,7 @@ digraph pipeline {
   n6 [label="docker run make test",fillcolor="#90ee90",style="filled"]
   n10 [label="get-revdeps",fillcolor="#90ee90",style="filled"]
   n5 [label="",fillcolor="#90ee90",style="filled",shape="circle"]
-  subgraph cluster_4 {
+  subgraph cluster_4 {label=""
   n15 [label="(empty list)",fillcolor="#d3d3d3",style="filled"]
   n14 [label="fetch",fillcolor="#d3d3d3",style="filled"]
   n13 [label="build",fillcolor="#d3d3d3",style="filled"]


### PR DESCRIPTION
Add an optional label argument to list_iter, list_map, option_map.

Pass this through the List_map and Option_map metadata options to the
label of the subgraph in the Graphviz input.

Signed-off-by: Ewan Mellor <ewan@tarides.com>