### PR TITLE
Add a helper to expose Current_git.Local.repo.

### DIFF
--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -155,6 +155,9 @@ module Local = struct
       t.heads <- Ref_map.add gref i t.heads;
       i
 
+  let repo t =
+    t.repo
+
   let head t =
     Current.component "head" |>
     let> () = Current.return () in

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -70,4 +70,6 @@ module Local : sig
   val commit_of_ref : t -> string -> Commit.t Current.t
   (** [commit_of_ref t gref] evaluates to the commit at the head of [gref].
       e.g. [commit_of_ref t "/refs/heads/master"] *)
+
+  val repo : t -> Fpath.t
 end


### PR DESCRIPTION
This means that callers can use this for debugging or labelling.

Signed-off-by: Ewan Mellor <ewan@tarides.com>