### PR TITLE
Log a message when cancelling a job finishes

### DIFF
--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -245,7 +245,9 @@ module Generic(Op : S.GENERIC) = struct
                   in
                   let outcome =
                     match Current.Job.cancelled_state op.job, outcome with
-                    | Error _cancelled, _ -> Error (`Msg "Cancelled")
+                    | Error (`Msg msg), _ ->
+                      Job.log job "%s" msg;
+                      Error (`Msg "Cancelled")
                     | Ok (), Ok _ -> Job.log job "Job succeeded"; outcome
                     | Ok (), Error (`Msg m) ->
                       Job.log job "Job failed: %s" m;


### PR DESCRIPTION
This avoids the confusing situation where the job finishes as you cancel, and you see the success message from the build as the last thing in the log, even though the job actually failed.

See e.g. https://github.com/ocaml/opam-repository/pull/18500#issuecomment-820447249

/cc @kit-ty-kate