### PR TITLE
Fix compile error with new X509 version

### DIFF
--- a/plugins/github/app.ml
+++ b/plugins/github/app.ml
@@ -182,6 +182,7 @@ let make_config app_id private_key_file allowlist =
       let t = { app_id; key; allowlist; installations } in
       Lwt.async (monitor_installations t);
       t
+    | Ok _ -> Fmt.failwith "Unsupported private key type" [@@warning "-11"]
 
 open Cmdliner
 


### PR DESCRIPTION
Error was:

    Error (warning 8): this pattern-matching is not exhaustive.
    Here is an example of a case that is not matched:
    Ok (`P256 _|`P521 _|`P384 _|`P224 _|`ED25519 _)