### PR TITLE
ansi: 24-bit colour parsing

### DIFF
--- a/lib_ansi/escape_parser.ml
+++ b/lib_ansi/escape_parser.ml
@@ -76,6 +76,7 @@ let read_intermediates ~params start =
     | Some (x, s2) when is_final_byte x -> (
         let func = Stream.(start -- s2 |> string_of_span) in
         let params = Astring.String.cuts ~sep:";" params in
+        let params = List.concat_map (Astring.String.cuts ~sep:":") params in
         try `Escape (`Ctrl (parse_ctrl ~params func), s2)
         with Unknown_escape -> `Invalid s2 )
     | Some _ -> `Invalid s

--- a/lib_ansi/escape_parser.mli
+++ b/lib_ansi/escape_parser.mli
@@ -1,10 +1,10 @@
 type colour =
-  [ `Black | `Blue | `Cyan | `Green | `Magenta | `Red | `White | `Yellow ]
+  [ `Default | `Black | `Blue | `Cyan | `Green | `Magenta | `Red | `White | `Yellow | `Rgb of int ]
 
 type sgr =
-  [ `BgCol of [ `Default | colour ]
+  [ `BgCol of colour
   | `Bold
-  | `FgCol of [ `Default | colour ]
+  | `FgCol of colour
   | `Italic
   | `NoBold
   | `NoItalic


### PR DESCRIPTION
I'm using `ocurrent_ansi` to render terminal content live in the browser. For that I needed some extra ansi escape code handling, in particular 24-bit colours and the reverse attribute, which are implemented in this PR.