### PR TITLE
Add a new Active Waiting_for_confirmation state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ### unreleased
 
+API:
+
+- Add an Active Waiting_for_confirmation state, allows manual confirmation to run a task. (@kit-ty-kate @maiste, #269)
+
 Web UI:
 
 - Allow controlling and disabling the refresh timer for pipelines

--- a/doc/examples/confirmation.ml
+++ b/doc/examples/confirmation.ml
@@ -1,0 +1,83 @@
+(** Show how to use the [`Waiting-for-activation] state to
+    execute a task only when confirm. Roles should be set to
+    have a better control on who can execute these actions.
+
+    To run the program, you have to run this command in the terminal...
+    $ dune exec -- ./doc/examples/confirmation.exe
+
+    and check the state at [http://localhost:8080]. You can click on the show
+    node and click the button to run the step. *)
+
+open Lwt.Infix
+open Current.Syntax
+
+module Git = Current_git
+
+let program_name = "confirmation"
+
+(* This is a minimal cache example to show the confirmation lock with
+   OCurrent. *)
+module Show = struct
+    type t = No_context
+    let id = "show-cmd"
+    module Key = Current.String
+    module Value = Current.Unit
+
+    let build No_context job key =
+        (* We specify this job as [Dangerous] so the confirmation will be hold. *)
+        Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
+            Current.Job.log job "You are using this commit %s" key;
+            Lwt.return @@ Ok ()
+
+    let pp = Key.pp
+    let auto_cancel = true
+end
+
+(* We create the cache using the OCurrent function. *)
+module Show_cache = Current_cache.Make(Show)
+
+let show hash =
+    Current.component "show" |>
+    let> key = hash in
+    Show_cache.get Show.No_context key
+
+let () = Prometheus_unix.Logging.init ()
+
+(* The pipeline will execute these actions:
+    1. Fetch a commit
+    2. Wait for confirmation
+    3. Display the commit once the stage is confirmed. *)
+let pipeline ~repo () =
+    let commit = Git.Local.head_commit repo in
+    let hash = Current.map Git.Commit.hash commit in
+    show hash
+
+let main mode repo =
+    (* Here, we set the config to request a confirmation above job with [Average] value. *)
+    let config = Current.Config.v ~confirm:Current.Level.Average () in
+    Lwt_main.run begin
+        let repo = Git.Local.v (Fpath.v repo) in
+        let engine = Current.Engine.create ~config (pipeline ~repo) in
+        let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name (Current_web.routes engine) in
+        Lwt.choose [
+            Current.Engine.thread engine;
+            Current_web.run ~mode site
+        ]
+    end
+
+open Cmdliner
+
+let repo =
+  Arg.value @@
+  Arg.pos 0 Arg.dir (Sys.getcwd ()) @@
+  Arg.info
+    ~doc:"The directory containing the .git subdirectory."
+    ~docv:"DIR"
+    []
+
+let cmd =
+  let doc = "Build the head commit of a local Git repository using Docker." in
+  let info = Cmd.info program_name ~doc in
+  Cmd.v info Term.(term_result (const main $ Current_web.cmdliner $ repo))
+
+let () = exit @@ Cmd.eval cmd

--- a/doc/examples/dune
+++ b/doc/examples/dune
@@ -9,7 +9,8 @@
                github
                github_app
                rpc_server
-               rpc_client)
+               rpc_client
+               confirmation)
  (package current_examples)
  (libraries
    capnp-rpc

--- a/lib/current.ml
+++ b/lib/current.ml
@@ -176,8 +176,9 @@ module Engine = struct
 
   let update_metrics _t =
     (*  { Current_term.S.ok; ready; running; failed; blocked } = Analysis.stats (pipeline t) in *)
-    let { Current_term.S.ok; ready; running; failed; blocked } = Analysis.quick_stat () in
+    let { Current_term.S.ok; waiting_for_confirmation; ready; running; failed; blocked } = Analysis.quick_stat () in
     Prometheus.Gauge.set (Metrics.pipeline_stage_total "ok") (float_of_int ok);
+    Prometheus.Gauge.set (Metrics.pipeline_stage_total "waiting_for_confirmation") (float_of_int waiting_for_confirmation);
     Prometheus.Gauge.set (Metrics.pipeline_stage_total "ready") (float_of_int ready);
     Prometheus.Gauge.set (Metrics.pipeline_stage_total "running") (float_of_int running);
     Prometheus.Gauge.set (Metrics.pipeline_stage_total "failed") (float_of_int failed);

--- a/lib_cache/current_cache.ml
+++ b/lib_cache/current_cache.ml
@@ -469,7 +469,13 @@ module Generic(Op : S.GENERIC) = struct
         | `Active (op, latched) ->
           let a =
             let started = Job.start_time op.job in
-            if Lwt.state started = Lwt.Sleep then `Ready else `Running
+            if Lwt.state started = Lwt.Sleep then
+              if Job.is_waiting_for_confirmation op.job then
+                `Waiting_for_confirmation
+              else
+                `Ready
+            else
+              `Running
           in
           match latched with
           | None -> Error (`Active a), None

--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -114,6 +114,7 @@ module Make (Meta : sig type t end) = struct
   end
 
   let colour_of_activity = function
+    | `Waiting_for_confirmation -> "#4975ff"
     | `Ready -> "#ffff00"
     | `Running -> "#ffa500"
 
@@ -319,6 +320,7 @@ module Make (Meta : sig type t end) = struct
     let seen : Out_node.t Id.Map.t ref = ref Id.Map.empty in
     let next = ref 0 in
     let ok = ref 0 in
+    let waiting_for_confirmation = ref 0 in
     let ready = ref 0 in
     let running = ref 0 in
     let failed = ref 0 in
@@ -344,6 +346,7 @@ module Make (Meta : sig type t end) = struct
           match v with
           | Ok _ -> incr ok
           | _ when not error_from_self -> incr blocked
+          | Error (_, `Active `Waiting_for_confirmation) -> incr waiting_for_confirmation
           | Error (_, `Active `Ready) -> incr ready
           | Error (_, `Active `Running) -> incr running
           | Error (_, `Msg _) -> incr failed
@@ -425,5 +428,12 @@ module Make (Meta : sig type t end) = struct
         outputs
     in
     ignore (aux (Term x));
-    { S.ok = !ok; ready = !ready; running = !running; failed = !failed; blocked = !blocked  }
+    {
+      S.ok = !ok;
+      waiting_for_confirmation = !waiting_for_confirmation;
+      ready = !ready;
+      running = !running;
+      failed = !failed;
+      blocked = !blocked;
+    }
 end

--- a/lib_term/dyn.ml
+++ b/lib_term/dyn.ml
@@ -52,6 +52,7 @@ let run = strip_id
 
 let pp ok f = function
   | Ok x -> ok f x
+  | Error (_, `Active `Waiting_for_confirmation) -> Fmt.string f "(waiting for confirmation)"
   | Error (_, `Active `Ready) -> Fmt.string f "(ready)"
   | Error (_, `Active `Running) -> Fmt.string f "(running)"
   | Error (_, `Msg m) -> Fmt.pf f "FAILED: %s" m

--- a/lib_term/output.ml
+++ b/lib_term/output.ml
@@ -1,4 +1,4 @@
-type active = [`Ready | `Running]
+type active = [`Ready | `Running | `Waiting_for_confirmation]
   [@@deriving eq]
 
 type 'a t = ('a, [`Active of active | `Msg of string]) result
@@ -8,4 +8,5 @@ let pp ok f = function
   | Ok x -> Fmt.pf f "Ok: %a" ok x
   | Error (`Active `Ready) -> Fmt.string f "Ready"
   | Error (`Active `Running) -> Fmt.string f "Running"
+  | Error (`Active `Waiting_for_confirmation) -> Fmt.string f "Waiting for confirmation"
   | Error (`Msg e) -> Fmt.pf f "Error: %s" e

--- a/lib_term/output.mli
+++ b/lib_term/output.mli
@@ -1,4 +1,4 @@
-type active = [`Ready | `Running]
+type active = [`Ready | `Running | `Waiting_for_confirmation]
   [@@deriving eq]
 
 type 'a t = ('a, [`Active of active | `Msg of string]) result

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -2,6 +2,7 @@ type 'a or_error = ('a, [`Msg of string]) result
 
 type stats = {
   ok : int;
+  waiting_for_confirmation : int;
   ready : int;
   running : int;
   failed : int;

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -2,6 +2,7 @@ open Tyxml.Html
 
 let render_result = function
   | Ok () -> [txt "Success!"]
+  | Error (`Active `Waiting_for_confirmation) -> [txt "Waiting for confirmation..."]
   | Error (`Active `Ready) -> [txt "Ready..."]
   | Error (`Active `Running) -> [txt "Running..."]
   | Error (`Msg msg) -> [txt ("ERROR: " ^ msg)]

--- a/test/driver.ml
+++ b/test/driver.ml
@@ -62,8 +62,10 @@ let rebuild msg =
   | Some rebuild -> rebuild () |> ignore
 
 let stats =
-  let pp f { Current_term.S.ok; ready; running; failed; blocked } =
-    Fmt.pf f "ok=%d,ready=%d,running=%d,failed=%d,blocked=%d" ok ready running failed blocked
+  let pp f { Current_term.S.ok; waiting_for_confirmation; ready; running; failed; blocked } =
+    Fmt.pf f
+      "ok=%d,waiting_for_confirmation=%d,ready=%d,running=%d,failed=%d,blocked=%d"
+      ok waiting_for_confirmation ready running failed blocked
   in
   Alcotest.testable pp (=)
 

--- a/test/expected/v2.3.dot
+++ b/test/expected/v2.3.dot
@@ -10,7 +10,7 @@ digraph pipeline {
   n6 [label="build",color="#90ee90",fillcolor="#90ee90",style="filled",tooltip=" "]
   n5 [label="docker run make test",color="#90ee90",fillcolor="#90ee90",style="filled",tooltip=" "]
   n4 [label="",color="#90ee90",fillcolor="#90ee90",style="filled",shape="circle",tooltip=" "]
-  n1 [label="docker push foo/bar",color="#ffff00",fillcolor="#ffff00",style="filled",tooltip=" "]
+  n1 [label="docker push foo/bar",color="#4975ff",fillcolor="#4975ff",style="filled",tooltip=" "]
   n4 -> n1
   n6 -> n4
   n5 -> n4 [style="dashed"]

--- a/test/test.ml
+++ b/test/test.ml
@@ -87,6 +87,7 @@ let test_v3 _switch () =
     { Current_term.S.
       ok = 8;
       failed = 1;
+      waiting_for_confirmation = 0;
       ready = 0;
       running = 1;
       blocked = 3;
@@ -135,6 +136,7 @@ let test_v5 _switch () =
     { Current_term.S.
       ok = 7;
       failed = 0;
+      waiting_for_confirmation = 0;
       ready = 0;
       running = 2;
       blocked = 4;
@@ -150,6 +152,7 @@ let test_v5_nil _switch () =
     { Current_term.S.
       ok = 7;
       failed = 0;
+      waiting_for_confirmation = 0;
       ready = 0;
       running = 0;
       blocked = 3;
@@ -172,6 +175,7 @@ let test_option_some _switch () =
     { Current_term.S.
       ok = 6;
       failed = 0;
+      waiting_for_confirmation = 0;
       ready = 0;
       running = 0;
       blocked = 0;
@@ -188,6 +192,7 @@ let test_option_none _switch () =
     { Current_term.S.
       ok = 5;
       failed = 0;
+      waiting_for_confirmation = 0;
       ready = 0;
       running = 0;
       blocked = 1;
@@ -235,6 +240,7 @@ let test_pair _switch () =
     { Current_term.S.
       ok = 2;
       failed = 0;
+      waiting_for_confirmation = 0;
       ready = 0;
       running = 0;
       blocked = 3;

--- a/test/test_monitor.ml
+++ b/test/test_monitor.ml
@@ -62,6 +62,7 @@ let get_watch () =
 
 let result =
   let pp f = function
+    | `Active `Waiting_for_confirmation -> Fmt.string f "Waiting for confirmation"
     | `Active `Ready -> Fmt.string f "Ready"
     | `Active `Running -> Fmt.string f "Running"
     | (`Msg m) -> Fmt.pf f "ERR: %s" m


### PR DESCRIPTION
The need for this came up while working on https://github.com/ocurrent/opam-repo-ci/pull/108, where I need some kind of way to tell the users and maintainers that after everything that can be done checking, there is still a button for the maintainers to click if they need the extra check. This also simplifies things in case we want to write something up to describe why this is there on the web-ui too.