### PR TITLE
Fix lower-bounds problems

### DIFF
--- a/current_web.opam
+++ b/current_web.opam
@@ -29,7 +29,7 @@ depends: [
   "cohttp" {>= "2.2.0" & < "3.0.0"}
   "cohttp-lwt" {>= "2.2.0" & < "3.0.0"}
   "cohttp-lwt-unix" {>= "2.2.0" & < "3.0.0"}
-  "tyxml"
+  "tyxml" {>= "4.4.0"}
   "routes" {>= "0.8.0"}
   "dune" {>= "2.0"}
   "conf-graphviz"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,3 @@
 (lang dune 2.0)
 (name current)
-(implicit_transitive_deps false)
 (formatting disabled)


### PR DESCRIPTION
- Set `implicit_transitive_deps` back to true. Otherwise, if we select an old version of `seq` then the type equality is hidden and the build fails with:

      Type Re.Group.t Stdlib.Seq.t = unit -> Re.Group.t Stdlib.Seq.node
      is not compatible with type Re__Core.Group.t Seq/1.t

- Lower-bound for tyxml.