### PR TITLE
add read and write functions to current_fs plugin

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -31,6 +31,7 @@ depends: [
   "re" {>= "1.9.0"}
   "lwt-dllist"
   "alcotest" {>= "1.2.0" & with-test}
+  "irmin-watcher"
   "alcotest-lwt" {>= "1.2.0" & with-test}
   "astring" {>= "0.8.5"}
   "fpath" {>= "0.7.3"}

--- a/examples/dune
+++ b/examples/dune
@@ -7,7 +7,8 @@
                github
                github_app
                rpc_server
-               rpc_client)
+               rpc_client
+               filesync)
  (package current_examples)
  (libraries
    capnp-rpc

--- a/examples/filesync.ml
+++ b/examples/filesync.ml
@@ -1,0 +1,44 @@
+let program_name = "filesync"
+
+let () = Prometheus_unix.Logging.init ()
+
+(* Watch a file and copy when there are changes to it *)
+let sync ~src ~dst () =
+  let read = Current_fs.File.read src in
+  Current_fs.File.write dst read
+
+let main config mode src dst =
+  let src = Fpath.v src in
+  let dst = Fpath.v dst in
+  let engine = Current.Engine.create ~config (sync ~src ~dst) in
+  let site =
+    Current_web.Site.(v ~has_role:allow_all)
+      ~name:program_name
+      (Current_web.routes engine)
+  in
+  Lwt_main.run
+    (Lwt.choose [ Current.Engine.thread engine; Current_web.run ~mode site ])
+
+(* Command-line parsing *)
+
+open Cmdliner
+
+let src =
+  Arg.(
+    required
+    @@ pos 0 (some file) None
+    @@ info ~doc:"Source file." ~docv:"SRC" [])
+
+let dst =
+  Arg.(
+    required
+    @@ pos 1 (some string) None
+    @@ info ~doc:"Destination file." ~docv:"DST" [])
+
+let cmd =
+  let doc = "Keep two files in sync." in
+  ( Term.(
+      const main $ Current.Config.cmdliner $ Current_web.cmdliner $ src $ dst),
+    Term.info program_name ~doc )
+
+let () = Term.(exit @@ eval cmd)

--- a/plugins/fs/current_fs.ml
+++ b/plugins/fs/current_fs.ml
@@ -1,25 +1,107 @@
 open Current.Syntax
+open Lwt.Infix
 
 let src = Logs.Src.create "current.fs" ~doc:"OCurrent filesystem plugin"
+
 module Log = (val Logs.src_log src : Logs.LOG)
 
 let save path value =
-  Current.component "save" |>
-  let> path = path
-  and> value = value in
-  Current_incr.const (
-    match Bos.OS.File.read path with
-    | Ok old when old = value ->
-      Log.info (fun f -> f "No change for %a" Fpath.pp path);
-      Ok (), None
-    | Error _ as e when Bos.OS.File.exists path = Ok true ->
-      e, None
-    | _ ->
-      (* Old contents differ, or file doesn't exist. *)
-      match Bos.OS.File.write path value with
-      | Ok () ->
-        Log.info (fun f -> f "Updated %a" Fpath.pp path);
-          Ok (), None
-        | Error _ as e ->
-          e, None
-  )
+  Current.component "save"
+  |> let> path = path and> value = value in
+     Current_incr.const
+       (match Bos.OS.File.read path with
+       | Ok old when old = value ->
+           Log.info (fun f -> f "No change for %a" Fpath.pp path);
+           (Ok (), None)
+       | Error _ as e when Bos.OS.File.exists path = Ok true -> (e, None)
+       | _ -> (
+           (* Old contents differ, or file doesn't exist. *)
+           match Bos.OS.File.write path value with
+           | Ok () ->
+               Log.info (fun f -> f "Updated %a" Fpath.pp path);
+               (Ok (), None)
+           | Error _ as e -> (e, None)))
+
+let next_id =
+  let i = ref 0 in
+  fun () ->
+    let id = !i in
+    incr i;
+    id
+
+let make_monitor f path =
+  let read () = f path in
+  Logs.info (fun f -> f "Installing monitor");
+  let watch refresh =
+    Log.debug (fun f -> f "Installing watch for %a" Fpath.pp path);
+    Irmin_watcher.hook (next_id ()) (Fpath.to_string path) (fun cpath ->
+        Log.info (fun f -> f "Detected change in %S" cpath);
+        refresh ();
+        Lwt.return_unit)
+    >|= fun unwatch ->
+    Log.debug (fun f -> f "Watch installed for %a" Fpath.pp path);
+    fun () ->
+      Log.debug (fun f -> f "Unwatching %a" Fpath.pp path);
+      unwatch ()
+  in
+  let pp f = Fpath.pp f path in
+  Current.Monitor.create ~read ~watch ~pp
+
+module Write = struct
+  type t = Fpath.t
+
+  module Key = struct 
+    type t = string
+
+    let digest  = Digest.string
+  end
+
+  module Value = Current.Unit
+  module File_map = Map.Make (Fpath)
+
+  let file_locks = ref File_map.empty
+
+  let file_lock file =
+    match File_map.find_opt file !file_locks with
+    | Some l -> l
+    | None ->
+        let l = Lwt_mutex.create () in
+        file_locks := File_map.add file l !file_locks;
+        l
+
+  let id = "fs-write"
+
+  let pp ppf s = Fmt.pf ppf "fs write: %s" s
+
+  let build file job write =
+    Lwt_mutex.with_lock (file_lock file) @@ fun () ->
+    Current.Job.start job ~level:Mostly_harmless >|= fun () ->
+    Bos.OS.File.write file write
+
+  let auto_cancel = true
+end
+
+module WC = Current_cache.Make (Write)
+
+module File = struct
+  let read path =
+    Current.component "read %a" Fpath.pp path
+  |> let> () = Current.return () in
+      Current.Monitor.get @@ make_monitor (fun t -> Lwt.return (Bos.OS.File.read t)) path
+
+  let write path write =
+    Current.component "write"
+    |> let> write = write in 
+       WC.get path write
+end
+
+module Dir = struct
+  let contents ?(recursive = false) path = 
+    let f t = 
+      if recursive then Lwt.return @@ Bos.OS.Dir.fold_contents (fun p acc -> p :: acc) [] t 
+      else Lwt.return @@ Bos.OS.Dir.contents t 
+    in 
+    Current.component "read %a" Fpath.pp path
+  |> let> () = Current.return () in
+      Current.Monitor.get @@ make_monitor f path
+end

--- a/plugins/fs/current_fs.mli
+++ b/plugins/fs/current_fs.mli
@@ -1,3 +1,17 @@
 val save : Fpath.t Current.t -> string Current.t -> unit Current.t
 (** [save path value] ensures that the path [path] contains [value], updating it
     atomically if not. *)
+
+module File : sig
+  val read : Fpath.t -> string Current.t
+  (** [read path] reads the contents of [path] returning the result of the read *)
+
+  val write : Fpath.t -> string Current.t -> unit Current.t
+  (** [write path content] will write [content] to [path] *)
+end
+
+module Dir : sig
+  val contents : ?recursive:bool -> Fpath.t -> Fpath.t list Current.t
+  (** [contents ?recursive dir] will give you the contents of [dir], if [recursive]
+      is [true] any directories will be recursively searched for contents too. *)
+end

--- a/plugins/fs/dune
+++ b/plugins/fs/dune
@@ -5,8 +5,12 @@
    bos
    current
    current.term
+   current.cache
    current_incr
    fmt
    fpath
    logs
+   irmin-watcher
+   lwt
+   lwt.unix
    result))


### PR DESCRIPTION
Opening a draft PR to gather some feedback on extending the functionality of the FS plugin for OCurrent, in particular to add `File.read` and `File.write` functions where the former monitors the changes similarly to how `Current_git` monitors local repositories. 

One question I had was why `Current_fs` isn't a standalone plugin? As is, it is an optional library under `Current`, I couldn't see any use of `Current_fs.save` so maybe it makes sense to spin this into it's own thing so it doesn't add more dependencies to the core `Current` library?

There's a little example too that syncs a file to another one, you can do `dune exec -- examples/filesync.exe README.md README2.md` and then it should update `README2.md` if you make changes to `README.md`.