### PR TITLE
Automatically refresh  jobs pages at fixed interval (60s)

### DIFF
--- a/lib_web/context.ml
+++ b/lib_web/context.ml
@@ -67,15 +67,20 @@ let render_nav_link (link_label, path) =
   let open Tyxml.Html in
   li [a ~a:[a_href path] [txt link_label]]
 
-let template t contents =
+let template t ?refresh contents =
   let site = t.site in
   let open Tyxml.Html in
   html_to_string (
     html
-      (head (title (txt site.name)) [
-          link ~rel:[ `Stylesheet ] ~href:"/css/style.css" ();
-          meta ~a:[a_charset "UTF-8"] ();
-        ]
+      (head (title (txt site.name)) (
+          let tags = [
+            link ~rel:[ `Stylesheet ] ~href:"/css/style.css" ();
+            meta ~a:[a_charset "UTF-8"] ();
+          ] in
+          match refresh with
+          | Some refresh -> meta ~a:[a_http_equiv "refresh"; a_content (string_of_int refresh)] () :: tags
+          | None -> tags
+          )
       )
       (body [
           nav [
@@ -100,8 +105,8 @@ let template t contents =
       )
   )
 
-let respond_ok t body =
-  let body = template t body in
+let respond_ok t ?refresh body =
+  let body = template t ?refresh body in
   Utils.Server.respond_string ~headers:(headers t) ~status:`OK ~body ()
 
 let respond_redirect t uri =

--- a/lib_web/current_web.mli
+++ b/lib_web/current_web.mli
@@ -69,8 +69,9 @@ module Context : sig
   (** [set_user t user] records a successful login by [user] and redirects the
       user back to the page they came from. *)
 
-  val respond_ok : t -> [< Html_types.div_content_fun ] Tyxml.Html.elt list -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-  (** [respond_ok ctx content] returns a successful page with [content] inserted into the site template. *)
+  val respond_ok : t -> ?refresh:int -> [< Html_types.div_content_fun ] Tyxml.Html.elt list -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  (** [respond_ok ctx refresh content] returns a successful page with [content] inserted into the site template.
+    If [refresh] is [Some s], the page is refreshed every [s] seconds. *)
 
   val respond_redirect : t -> Uri.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
   (** [respond_redirect ctx uri] redirects the user to [uri]. *)

--- a/lib_web/jobs.ml
+++ b/lib_web/jobs.ml
@@ -22,7 +22,7 @@ let r = object
 
   method! private get ctx =
     let jobs = Current.Job.jobs () in
-    Context.respond_ok ctx (
+    Context.respond_ok ctx ~refresh:60 (
       if Current.Job.Map.is_empty jobs then [
         txt "There are no active jobs."
       ] else [

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -35,8 +35,10 @@ let r ~engine = object
     let uri = Context.uri ctx in
     let config = Current.Engine.config engine in
     let { Current.Engine.value; jobs = _ } = Current.Engine.state engine in
-    let path = "/pipeline.svg?" ^ (Option.value (Uri.verbatim_query uri) ~default:"") in
-    Context.respond_ok ctx [
+    let verbatim_query = Uri.verbatim_query uri in
+    let path = "/pipeline.svg?" ^ (Option.value verbatim_query ~default:"") in
+    let refresh = Option.map (fun _ -> 60) verbatim_query in
+    Context.respond_ok ctx ?refresh [
       div [
         object_ ~a:[a_data path] [txt "Pipeline diagram"];
       ];


### PR DESCRIPTION
I find myself hitting the reload button sometimes... I thought that automatically refreshing the home and jobs pages every 60 seconds would be a good compromise to keep tracking the changes and not disturb the user too much if the page reloads while being used.