### PR TITLE
Depend on conf-libev

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -37,6 +37,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "result" {>= "1.5"}
   "prometheus-app" {>= "0.7" & with-test}
+  "conf-libev" {os != "win32"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Several services have failed due to Lwt using `select` by default. Ideally this should be fixed in Lwt (see https://github.com/ocsigen/lwt/issues/871), but for now at least fix it for all OCurrent pipelines.