### PR TITLE
Add Current_github.Api.cmdliner_opt

### DIFF
--- a/plugins/github/app.mli
+++ b/plugins/github/app.mli
@@ -6,5 +6,6 @@ val input_installation_webhook : unit -> unit
 type t
 
 val cmdliner : t Cmdliner.Term.t
+val cmdliner_opt : t option Cmdliner.Term.t
 val installation : t -> account:string -> int -> Installation.t
 val installations : t -> Installation.t list Current.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -195,6 +195,9 @@ module App : sig
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub app configuration. *)
 
+  val cmdliner_opt : t option Cmdliner.Term.t
+  (** Like [cmdliner], but the arguments are all optional. *)
+
   val installation : t -> account:string -> int -> Installation.t
   (** [installation t ~account id] gives access to the API for installation [id].
       Note: this generates a fresh value on each call and should not be used inside


### PR DESCRIPTION
Allows writing pipelines which can optionally be run as GitHub apps.