### PR TITLE
Support Github rebuild via webooks.

### DIFF
--- a/current_github.opam
+++ b/current_github.opam
@@ -24,6 +24,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "mirage-crypto"
   "mirage-crypto-pk"
+  "hex" {>= "1.4.0"}
   "x509" {>= "0.10.0"}
   "tls" {>= "0.11.0"}
   "dune" {>= "2.0"}

--- a/doc/examples/github.ml
+++ b/doc/examples/github.ml
@@ -44,12 +44,13 @@ let pipeline ~github ~repo () =
   |> Github.Api.Commit.set_status head "ocurrent"
 
 let main config mode github repo =
+  let has_role = Current_web.Site.allow_all in
   let engine = Current.Engine.create ~config (pipeline ~github ~repo) in
   let routes =
-    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook) ::
+    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~has_role) ::
     Current_web.routes engine
   in
-  let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name routes in
+  let site = Current_web.Site.(v ~has_role) ~name:program_name routes in
   Lwt_main.run begin
     Lwt.choose [
       Current.Engine.thread engine;

--- a/doc/examples/github.ml
+++ b/doc/examples/github.ml
@@ -35,7 +35,7 @@ let pipeline ~github ~repo () =
   let head = Github.Api.head_commit github repo in
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   let dockerfile =
-    let+ base = Docker.pull ~schedule:weekly "ocaml/opam:alpine-3.12-ocaml-4.08" in
+    let+ base = Docker.pull ~schedule:weekly "ocaml/opam:alpine-3.13-ocaml-4.08" in
     `Contents (dockerfile ~base)
   in
   Docker.build ~pull:false ~dockerfile (`Git src)
@@ -47,7 +47,7 @@ let main config mode github repo =
   let has_role = Current_web.Site.allow_all in
   let engine = Current.Engine.create ~config (pipeline ~github ~repo) in
   let routes =
-    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~has_role) ::
+    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~webhook_secret:(Github.Api.webhook_secret github) ~has_role) ::
     Current_web.routes engine
   in
   let site = Current_web.Site.(v ~has_role) ~name:program_name routes in

--- a/doc/examples/github_app.ml
+++ b/doc/examples/github_app.ml
@@ -31,10 +31,17 @@ let dockerfile ~base =
 let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
 
 (* Map from Current.state to CheckRunStatus *)
-let github_check_run_status_of_state = function
-  | Ok _              -> Github.Api.CheckRunStatus.v ~url (`Completed `Success) ~summary:"Passed"
-  | Error (`Active _) -> Github.Api.CheckRunStatus.v ~url `Queued
-  | Error (`Msg m)    -> Github.Api.CheckRunStatus.v ~url (`Completed (`Failure m)) ~summary:m
+let github_check_run_status_of_state ?job_id = function
+  | Ok _              -> Github.Api.CheckRunStatus.v ~url ?job_id (`Completed `Success) ~summary:"Passed"
+  | Error (`Active _) -> Github.Api.CheckRunStatus.v ~url ?job_id `Queued
+  | Error (`Msg m)    -> Github.Api.CheckRunStatus.v ~url ?job_id (`Completed (`Failure m)) ~summary:m
+
+let check_run_status x =
+  let+ md = Current.Analysis.metadata x
+  and+ state = Current.state x in
+  match md with
+  | Some { Current.Metadata.job_id; _ } -> github_check_run_status_of_state ?job_id state
+  | None -> github_check_run_status_of_state state
 
 let pipeline ~app () =
   let dockerfile =
@@ -48,18 +55,18 @@ let pipeline ~app () =
   |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   Docker.build ~pool ~pull:false ~dockerfile (`Git src)
-  |> Current.state
-  |> Current.map github_check_run_status_of_state 
+  |> check_run_status
   |> Github.Api.CheckRun.set_status head program_name
 
 let main config mode app =
   Lwt_main.run begin
+    let has_role = Current_web.Site.allow_all in
     let engine = Current.Engine.create ~config (pipeline ~app) in
     let routes =
-      Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook) ::
+      Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~has_role) ::
       Current_web.routes engine
     in
-    let site = Current_web.Site.(v ~has_role:allow_all) ~name:program_name routes in
+    let site = Current_web.Site.(v ~has_role) ~name:program_name routes in
     Lwt.choose [
       Current.Engine.thread engine;
       Current_web.run ~mode site;

--- a/lib_web/current_web.mli
+++ b/lib_web/current_web.mli
@@ -5,6 +5,9 @@ module User : sig
   val v : string -> (t, [> `Msg of string]) result
   (** [v id] is a user with ID [id]. *)
 
+  val create : string -> t
+  (** [create id] is a user with ID [id]. *)
+
   val id : t -> string
   (** [id t] is the user ID (e.g. "github:alice") *)
 end

--- a/lib_web/current_web.mli
+++ b/lib_web/current_web.mli
@@ -5,8 +5,8 @@ module User : sig
   val v : string -> (t, [> `Msg of string]) result
   (** [v id] is a user with ID [id]. *)
 
-  val create : string -> t
-  (** [create id] is a user with ID [id]. *)
+  val v_exn : string -> t
+  (** [v_exn id] is a user with ID [id]. *)
 
   val id : t -> string
   (** [id t] is the user ID (e.g. "github:alice") *)

--- a/lib_web/job.ml
+++ b/lib_web/job.ml
@@ -139,7 +139,7 @@ let job ~engine ~job_id = object
       Utils.Server.respond ~status:`OK ~headers ~body ()
 end
 
-let rebuild ~engine ~job_id= object
+let rebuild ~engine ~job_id = object
   inherit Resource.t
 
   val! can_post = `Builder

--- a/lib_web/user.ml
+++ b/lib_web/user.ml
@@ -4,7 +4,7 @@ type t = {
 
 let v id = Ok { id }
 
-let create id = { id }
+let v_exn id = { id }
 
 let id t = t.id
 

--- a/lib_web/user.ml
+++ b/lib_web/user.ml
@@ -4,6 +4,8 @@ type t = {
 
 let v id = Ok { id }
 
+let create id = { id }
+
 let id t = t.id
 
 let marshal t =

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -9,12 +9,12 @@ end
 
 module CheckRunStatus : sig
   type t
-  type action 
+  type action
   type conclusion = [`Failure of string | `Success | `Skipped of string]
   type state = [`Queued | `InProgress | `Completed of conclusion]
 
   val action: label:string -> description:string -> identifier:string -> action
-  val v : ?text:string -> ?summary:string -> ?url:Uri.t -> ?actions:action list -> state -> t
+  val v : ?text:string -> ?summary:string -> ?url:Uri.t -> ?actions:action list -> ?identifier:string -> state -> t
 end
 
 
@@ -29,7 +29,7 @@ module Commit : sig
   val compare : t -> t -> int
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
   val uri : t -> Uri.t
-end 
+end
 
 
 module CheckRun : sig
@@ -91,11 +91,16 @@ type token = {
 val get_token : t -> (string, [`Msg of string]) result Lwt.t
 (** [get_token t] returns the cached token for [t], or fetches a new one if it has expired. *)
 
+val rebuild_webhook : engine:Current.Engine.t
+                      -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
+                      -> Yojson.Safe.t -> unit
+(** Call this when we get a "check_run" webhook event. *)
+
 val input_webhook : Yojson.Safe.t -> unit
 (** Call this when we get a "pull_request", "push" or "create" webhook event. *)
 
 val v : get_token:(unit -> token Lwt.t) -> ?app_id:string -> string -> t
-(** [v ~get_token ?app_id] is a configuration that uses [get_token] when it needs to get or 
+(** [v ~get_token ?app_id] is a configuration that uses [get_token] when it needs to get or
     refresh the API token.
     Note: [get_token] can return a failed token, in which case the expiry time says when to try again.
           If [get_token] instead raises an exception, this is turned into an error token with a 1 minute expiry.

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -49,15 +49,17 @@ module Ref_map : Map.S with type key = Ref.t
 
 type t
 type refs
-val of_oauth : string -> t
+val of_oauth : token:string -> webhook_secret:string -> t
 val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
 val refs : t -> Repo_id.t -> refs Current.Primitive.t
 val default_ref : refs -> string
+val webhook_secret : t -> string
 val all_refs : refs -> Commit.t Ref_map.t
 val head_of : t -> Repo_id.t -> [ `Ref of string | `PR of int ] -> Commit.t Current.t
 val ci_refs : ?staleness:Duration.t -> t -> Repo_id.t -> Commit.t list Current.t
 val cmdliner : t Cmdliner.Term.t
+val webhook_secret_file : string Cmdliner.Term.t
 
 module Repo : sig
   type nonrec t = t * Repo_id.t
@@ -99,7 +101,7 @@ val rebuild_webhook : engine:Current.Engine.t
 val input_webhook : Yojson.Safe.t -> unit
 (** Call this when we get a "pull_request", "push" or "create" webhook event. *)
 
-val v : get_token:(unit -> token Lwt.t) -> ?app_id:string -> string -> t
+val v : get_token:(unit -> token Lwt.t) -> ?app_id:string -> account:string -> webhook_secret:string -> unit -> t
 (** [v ~get_token ?app_id] is a configuration that uses [get_token] when it needs to get or
     refresh the API token.
     Note: [get_token] can return a failed token, in which case the expiry time says when to try again.

--- a/plugins/github/app.ml
+++ b/plugins/github/app.ml
@@ -52,7 +52,10 @@ type t = {
   key : Mirage_crypto_pk.Rsa.priv;
   allowlist : Allowlist.t;      (* Accounts which can use this app. *)
   installations : Installs.t;
+  webhook_secret : string; (* Shared secret for validating webhooks from GitHub *)
 }
+
+let webhook_secret t = t.webhook_secret
 
 let http { app_id; key; _ } op uri =
   let iat = truncate @@ Unix.gettimeofday () in
@@ -133,7 +136,7 @@ let get_installations app =
     )
 
 let installation t ~account iid =
-  let api = Api.v ~get_token:(fun () -> get_token t iid) ("i-" ^ account) ~app_id:t.app_id in
+  let api = Api.v ~get_token:(fun () -> get_token t iid) ~account:("i-" ^ account) ~app_id:t.app_id ~webhook_secret:t.webhook_secret () in
   Installation.v ~api ~account ~iid
 
 module Int_set = Set.Make(Int)
@@ -173,24 +176,25 @@ let installations t =
 
 (* Command-line options *)
 
-let make_config app_id private_key_file allowlist =
+let make_config app_id private_key_file allowlist webhook_secret_file =
   let allowlist = Allowlist.of_list allowlist in
   let data = Api.read_file private_key_file in
+  let webhook_secret = Api.read_file webhook_secret_file in
   match X509.Private_key.decode_pem (Cstruct.of_string data) with
     | Error (`Msg msg) -> Fmt.failwith "Failed to parse secret key!@ %s" msg
     | Ok (`RSA key) ->
       let installations = Installs.create ~name:"installations" (Error (`Active `Running)) in
-      let t = { app_id; key; allowlist; installations } in
+      let t = { app_id; key; allowlist; installations; webhook_secret } in
       Lwt.async (monitor_installations t);
       t
     | Ok _ -> Fmt.failwith "Unsupported private key type" [@@warning "-11"]
 
 open Cmdliner
 
-let make_config_opt app_id private_key_file allowlist : t option Term.ret =
+let make_config_opt app_id private_key_file allowlist webhook_secret : t option Term.ret =
   match app_id, private_key_file, allowlist with
   | None, None, _ -> `Ok None
-  | Some app_id, Some private_key_file, Some allowlist -> `Ok (Some (make_config app_id private_key_file allowlist))
+  | Some app_id, Some private_key_file, Some allowlist -> `Ok (Some (make_config app_id private_key_file allowlist webhook_secret))
   | Some _, Some _, None -> `Error (true, "--github-account-allowlist is required with --github-app-id")
   | Some _, None, _ -> `Error (true, "--github-private-key-file is required with --github-app-id")
   | None, Some _, _ -> `Error (true, "--github-app-id is required with --github-private-key-file")
@@ -217,7 +221,7 @@ let allowlist =
     ["github-account-allowlist"]
 
 let cmdliner =
-  Term.(const make_config $ Arg.required app_id $ Arg.required private_key_file $ Arg.required allowlist)
+  Term.(const make_config $ Arg.required app_id $ Arg.required private_key_file $ Arg.required allowlist $ Api.webhook_secret_file)
 
 let cmdliner_opt =
-  Term.(ret (const make_config_opt $ Arg.value app_id $ Arg.value private_key_file $ Arg.value allowlist))
+  Term.(ret (const make_config_opt $ Arg.value app_id $ Arg.value private_key_file $ Arg.value allowlist $ Api.webhook_secret_file))

--- a/plugins/github/app.mli
+++ b/plugins/github/app.mli
@@ -5,6 +5,7 @@ val input_installation_webhook : unit -> unit
 
 type t
 
+val webhook_secret : t -> string
 val cmdliner : t Cmdliner.Term.t
 val cmdliner_opt : t option Cmdliner.Term.t
 val installation : t -> account:string -> int -> Installation.t

--- a/plugins/github/current_github.ml
+++ b/plugins/github/current_github.ml
@@ -17,7 +17,13 @@ module Metrics = struct
     Counter.v_label ~label_name:"event" ~help ~namespace ~subsystem "webhook_events_total"
 end
 
-let webhook ~engine ~has_role = object
+let validate_webhook_payload webhook_secret body headers =
+  let request_signature = Option.value ~default:"<empty>" (Cohttp.Header.get headers "X-Hub-Signature-256") in
+  let signature = "sha256=" ^ Hex.show @@ Hex.of_cstruct @@
+    Mirage_crypto.Hash.SHA256.(hmac ~key:(Cstruct.of_string webhook_secret) (Cstruct.of_string body)) in
+  Eqaf.equal signature request_signature
+
+let webhook ~engine ~webhook_secret ~has_role = object
   inherit Current_web.Resource.t
 
   method! post_raw _site req body =
@@ -26,14 +32,20 @@ let webhook ~engine ~has_role = object
     let event = Cohttp.Header.get headers "X-GitHub-Event" in
     Log.info (fun f -> f "Got GitHub event %a" Fmt.(option ~none:(any "NONE") (quote string)) event);
     Prometheus.Counter.inc_one (Metrics.webhook_events_total (Option.value event ~default:"NONE"));
-    Cohttp_lwt.Body.to_string body >|= Yojson.Safe.from_string >>= fun body ->
-    begin match event with
-      | Some "installation_repositories" -> Installation.input_installation_repositories_webhook ()
-      | Some "installation" -> App.input_installation_webhook ()
-      | Some ("pull_request" | "push" | "create") -> Api.input_webhook body
-      | Some "check_run" -> Api.rebuild_webhook ~engine ~has_role body 
-      | Some x -> Log.warn (fun f -> f "Unknown GitHub event type %S" x)
-      | None -> Log.warn (fun f -> f "Missing GitHub event type in webhook!")
-    end;
-    Cohttp_lwt_unix.Server.respond_string ~status:`OK ~body:"OK" ()
+    Cohttp_lwt.Body.to_string body >>= fun body ->
+    match validate_webhook_payload webhook_secret body headers with
+    | false ->
+      Log.warn (fun f -> f "Invalid X-Hub-Signature-256 received!");
+      Cohttp_lwt_unix.Server.respond_string ~status:`Unauthorized ~body:"Invalid X-Hub-Signature-256" ()
+    | true ->
+      let json_body = Yojson.Safe.from_string body in
+      begin match event with
+        | Some "installation_repositories" -> Installation.input_installation_repositories_webhook ()
+        | Some "installation" -> App.input_installation_webhook ()
+        | Some ("pull_request" | "push" | "create") -> Api.input_webhook json_body
+        | Some "check_run" -> Api.rebuild_webhook ~engine ~has_role json_body
+        | Some x -> Log.warn (fun f -> f "Unknown GitHub event type %S" x)
+        | None -> Log.warn (fun f -> f "Missing GitHub event type in webhook!")
+      end;
+      Cohttp_lwt_unix.Server.respond_string ~status:`OK ~body:"OK" ()
 end

--- a/plugins/github/current_github.ml
+++ b/plugins/github/current_github.ml
@@ -17,7 +17,7 @@ module Metrics = struct
     Counter.v_label ~label_name:"event" ~help ~namespace ~subsystem "webhook_events_total"
 end
 
-let webhook = object
+let webhook ~engine ~has_role = object
   inherit Current_web.Resource.t
 
   method! post_raw _site req body =
@@ -31,6 +31,7 @@ let webhook = object
       | Some "installation_repositories" -> Installation.input_installation_repositories_webhook ()
       | Some "installation" -> App.input_installation_webhook ()
       | Some ("pull_request" | "push" | "create") -> Api.input_webhook body
+      | Some "check_run" -> Api.rebuild_webhook ~engine ~has_role body 
       | Some x -> Log.warn (fun f -> f "Unknown GitHub event type %S" x)
       | None -> Log.warn (fun f -> f "Missing GitHub event type in webhook!")
     end;

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -1,17 +1,20 @@
 (** Integration with GitHub. *)
 
 val webhook : engine:Current.Engine.t
+              -> webhook_secret:string
               -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
               -> Current_web.Resource.t
-(** Our web-hook endpoint. This must be added to {!Current_web.routes} so that we get notified of events.
-
-This webhook handles the events:
+(** GitHub webhook endpoint. This MUST be added to {!Current_web.routes} so that we get notified of events. This webhook handles the events:
  - installation_repositories
  - installation
  - pull_request
  - push
  - create
  - check_run
+
+Webhook payloads are validated against [webhook_secret].
+
+See {{:https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks}}
  *)
 
 (** Identifier for a repository hosted on GitHub. *)
@@ -32,6 +35,9 @@ end
 module Api : sig
   type t
   (** Configuration for accessing GitHub. *)
+
+  val webhook_secret : t -> string
+  (** Webhook secret to validate payloads from GitHub *)
 
   type refs
   (** Reference information for the repository *)
@@ -54,14 +60,14 @@ module Api : sig
 
     type conclusion = [`Failure of string | `Success | `Skipped of string]
     (** Sub-set of conclusions from GitHub.
-        Not supported are action_required, cancelled, neutral, skipped, stale, or timed_out. *)
+        Not supported are action_required, cancelled, neutral, stale, or timed_out. *)
 
     type state = [`Queued | `InProgress | `Completed of conclusion]
 
     val action: label:string -> description:string -> identifier:string -> action
 
     val v : ?text:string -> ?summary:string -> ?url:Uri.t -> ?actions:action list -> ?identifier:string -> state -> t
-    (** [v ?text ?summary ?url ?actions ?identifier] creates a CheckRunStatus with [?text] description, a link to
+    (** [v ?text ?summary ?url ?actions ?identifier state] creates a CheckRunStatus with [?text] description, a link to
         the build details at [?url] and an [?identifier] for triggering a rebuild of a job.
      *)
   end
@@ -130,8 +136,8 @@ module Api : sig
 
   module Ref_map : Map.S with type key = Ref.t
 
-  val of_oauth : string -> t
-  (** [of_oauth token] is a configuration that authenticates to GitHub using [token]. *)
+  val of_oauth : token:string -> webhook_secret:string -> t
+  (** [of_oauth ~token ~webhook_secret] is a configuration that authenticates to GitHub using [token]. *)
 
   val exec_graphql : ?variables:(string * Yojson.Safe.t) list -> t -> string -> Yojson.Safe.t Lwt.t
   (** [exec_graphql t query] executes [query] on GitHub. *)
@@ -200,6 +206,9 @@ end
 module App : sig
   type t
   (** Configuration for a GitHub application. *)
+
+  val webhook_secret : t -> string
+  (** Webhook secret to validate payloads from GitHub. *)
 
   val cmdliner : t Cmdliner.Term.t
   (** Command-line options to generate a GitHub app configuration. *)

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -1,7 +1,9 @@
 (** Integration with GitHub. *)
 
-val webhook : Current_web.Resource.t
-(** Our web-hook endpoint. This must be added to {!Current_web.routes} so that we get notified of events. 
+val webhook : engine:Current.Engine.t
+              -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
+              -> Current_web.Resource.t
+(** Our web-hook endpoint. This must be added to {!Current_web.routes} so that we get notified of events.
 
 This webhook handles the events:
  - installation_repositories
@@ -9,6 +11,7 @@ This webhook handles the events:
  - pull_request
  - push
  - create
+ - check_run
  *)
 
 (** Identifier for a repository hosted on GitHub. *)
@@ -47,19 +50,19 @@ module Api : sig
     type t
     (** CheckRun status type. *)
 
-    type action 
+    type action
 
     type conclusion = [`Failure of string | `Success | `Skipped of string]
-    (** Sub-set of conclusions from GitHub. 
+    (** Sub-set of conclusions from GitHub.
         Not supported are action_required, cancelled, neutral, skipped, stale, or timed_out. *)
 
     type state = [`Queued | `InProgress | `Completed of conclusion]
 
     val action: label:string -> description:string -> identifier:string -> action
 
-    val v : ?text:string -> ?summary:string -> ?url:Uri.t -> ?actions:action list -> state -> t
-    (** Construct a CheckRunStatus.t 
-        A maximum of three actions are accepted by GitHub.
+    val v : ?text:string -> ?summary:string -> ?url:Uri.t -> ?actions:action list -> ?identifier:string -> state -> t
+    (** [v ?text ?summary ?url ?actions ?identifier] creates a CheckRunStatus with [?text] description, a link to
+        the build details at [?url] and an [?identifier] for triggering a rebuild of a job.
      *)
   end
 

--- a/plugins/github/dune
+++ b/plugins/github/dune
@@ -20,6 +20,7 @@
    lwt.unix
    mirage-crypto
    mirage-crypto-pk
+   hex
    prometheus
    result
    rresult


### PR DESCRIPTION
Passing job_id through to set_status, which then gets sent back via webhooks and can be looked up as a job to rebuild.  The core piece is `CheckRunStatus` now includes the job_id
```ocaml
  type t = {
      state: state;
      description: string option;
      url: Uri.t option;
      job_id: string option;
    }
```