### PR TITLE
Add CNAME for ocurrent.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+ocurrent.org


### PR DESCRIPTION
Before merging this:
1. Need to remove https://github.com/ocurrent/ocurrent.org as that has the same CNAME
2. Merge this change here.
3. Enforce https as documented here https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain

