### PR TITLE
Make git reset less verbose (Checking out files:  48% (10742/22378) ...)

### DIFF
--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -40,7 +40,7 @@ let git_fetch ~cancellable ~job ~src ~dst gref =
   git ~cancellable ~job ~cwd:dst ["fetch"; "-f"; src; gref]
 
 let git_reset_hard ~job ~repo hash =
-  git ~cancellable:false ~job ~cwd:repo ["reset"; "--hard"; hash]
+  git ~cancellable:false ~job ~cwd:repo ["reset"; "--hard"; "-q"; hash]
 
 let git_remote_set_url ~job ~repo ~remote url =
   git ~cancellable:false ~job ~cwd:repo ["remote"; "set-url"; remote; url]


### PR DESCRIPTION
Example: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/7d98ca091034a1e6b89e6e52b2615a5947a2eb6f/variant/(lint)

```
2021-09-09 13:52.27: Exec: "git" "-C" "/tmp/git-checkoutb643802" "reset" 
                           "--hard" "7d98ca091034a1e6b89e6e52b2615a5947a2eb6f"
Checking out files:  39% (8856/22378)   
Checking out files:  40% (8952/22378)   
Checking out files:  41% (9175/22378)   
Checking out files:  42% (9399/22378)   
Checking out files:  43% (9623/22378)   
Checking out files:  44% (9847/22378)   
Checking out files:  45% (10071/22378)   
Checking out files:  46% (10294/22378)   
Checking out files:  47% (10518/22378)   
Checking out files:  48% (10742/22378)   
Checking out files:  49% (10966/22378)   
Checking out files:  50% (11189/22378)   
....
```