### PR TITLE
Lwt_unix.yield was deprecated in favor of Lwt.pause

### DIFF
--- a/lib_web/log_rules.ml
+++ b/lib_web/log_rules.ml
@@ -36,7 +36,7 @@ let test_pattern pattern =
         begin
           if !i = 0 then (
             i := 100;
-            Lwt_main.yield ()
+            Lwt.pause ()
           ) else (
             decr i;
             Lwt.return_unit


### PR DESCRIPTION
Deprecated in the lwt dev, but it's a safe change to make now.