### PR TITLE
Set confirmation level

### DIFF
--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -33,6 +33,7 @@ module Raw : sig
 
   val build :
     docker_context:string option ->
+    ?level:Current.Level.t ->
     ?schedule:Current_cache.Schedule.t ->
     ?timeout:Duration.t ->
     ?squash:bool ->

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -38,6 +38,7 @@ module type DOCKER = sig
                       has no [valid_for] limit then we will only ever check once. *)
 
   val build :
+    ?level:Current.Level.t ->
     ?schedule:Current_cache.Schedule.t ->
     ?timeout:Duration.t ->
     ?squash:bool ->


### PR DESCRIPTION
Explicitly set confirmation levels to allow for manually triggered jobs.

Pulling this across from @TheLortex fork for [tarides/tezos-ci](https://github.com/tarides/tezos-ci)