### PR TITLE
Be able to clone Git bare repository

### DIFF
--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -43,7 +43,7 @@ let build No_context job { Key.repo; gref } =
   end >>!= fun () ->
   Cmd.git_rev_parse ~cancellable:true ~job ~repo:local_repo ("origin/" ^ gref) >>!= fun hash ->
   let id = { Commit_id.repo; gref; hash } in
-  Lwt.return @@ Ok { Commit.repo = local_repo; id }
+  Lwt.return @@ Ok { Commit.repo = local_repo; id; bare = false }
 
 let pp f key = Fmt.pf f "git clone %a" Key.pp key
 

--- a/plugins/git/commit.ml
+++ b/plugins/git/commit.ml
@@ -11,6 +11,7 @@ end
 
 type t = {
   repo : Fpath.t;
+  bare : bool;
   id : Commit_id.t;
 } [@@deriving yojson]
 

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -33,7 +33,7 @@ module Fetch = struct
       if Cmd.dir_exists local_repo then Lwt.return (Ok ())
       else Cmd.git_clone ~cancellable:true ~job ~src:remote_repo local_repo
     end >>!= fun () ->
-    let commit = { Commit.repo = local_repo; id = key } in
+            let commit = { Commit.repo = local_repo; id = key; bare = false } in
     (* Fetch the commit (if missing). *)
     begin
       Commit.check_cached ~cancellable:false ~job commit >>= function
@@ -63,12 +63,16 @@ let clone ~schedule ?(gref="master") repo =
   let> () = Current.return () in
   Clone_cache.get ~schedule Clone.No_context { Clone.Key.repo; gref }
 
+let git_folder bare repo =
+  if bare then repo else Fpath.(repo / ".git")
+
 let with_checkout ?pool ~job commit fn =
-  let { Commit.repo; id } = commit in
+  let { Commit.repo; id; bare; } = commit in
   let short_hash = Astring.String.with_range ~len:8 id.Commit_id.hash in
   Current.Job.log job "@[<v2>Checking out commit %s. To reproduce:@,%a@]"
     short_hash Commit_id.pp_user_clone id;
   let switch = Current.Switch.create ~label:"clone" () in
+  let dotgit = git_folder bare repo in
   Lwt.finalize
     (fun () ->
        begin
@@ -77,7 +81,11 @@ let with_checkout ?pool ~job commit fn =
          | None -> Lwt.return_unit
        end >>= fun () ->
        Current.Process.with_tmpdir ~prefix:"git-checkout" @@ fun tmpdir ->
-       Cmd.cp_r ~cancellable:true ~job ~src:(Fpath.(repo / ".git")) ~dst:tmpdir >>!= fun () ->
+       begin
+         if bare
+         then Cmd.git_clone ~cancellable:true ~job ~src:(Fpath.to_string dotgit) tmpdir
+         else Cmd.cp_r ~cancellable:true ~job ~src:dotgit ~dst:tmpdir
+       end >>!= fun () ->
        Cmd.git_reset_hard ~job ~repo:tmpdir id.Commit_id.hash >>= function
        | Ok () ->
          Cmd.git_submodule_update ~cancellable:true ~job ~repo:tmpdir >>!= fun () ->
@@ -104,11 +112,12 @@ module Local = struct
 
   type t = {
     repo : Fpath.t;
+    bare : bool;
     head : [`Ref of string | `Commit of Commit_id.t] Current.Monitor.t;
     mutable heads : Commit.t Current.Monitor.t Ref_map.t;
   }
 
-  let pp_repo f t = Fpath.pp f t.repo
+  let pp_repo f t = Fpath.pp f t.repo ; if t.bare then Fmt.pf f " (bare)"
 
   let read_reference t gref =
     let cmd = [| "git"; "-C"; Fpath.to_string t.repo; "rev-parse"; "--revs-only"; gref |] in
@@ -117,10 +126,10 @@ module Local = struct
     | "" -> Error (`Msg (Fmt.str "Unknown ref %S" gref))
     | hash ->
       let id = { Commit_id.repo = Fpath.to_string t.repo; gref; hash } in
-      Ok { Commit.repo = t.repo; id }
+      Ok { Commit.repo = t.repo; id; bare = t.bare }
 
   let make_monitor t gref =
-    let dot_git = Fpath.(t.repo / ".git") in
+    let dot_git = git_folder t.bare t.repo in
     if not (Astring.String.is_prefix ~affix:"refs/" gref) then
       Fmt.failwith "Reference %S should start \"refs/\"" gref;
     let read () = read_reference t gref in
@@ -167,7 +176,7 @@ module Local = struct
     Current.component "head commit" |>
     let> h = head t in
     match h with
-    | `Commit id -> Current.Primitive.const { Commit.repo = t.repo; id }
+    | `Commit id -> Current.Primitive.const { Commit.repo = t.repo; id; bare = t.bare }
     | `Ref gref -> Current.Monitor.get @@ commit_of_ref t gref
 
   let commit_of_ref t gref =
@@ -175,8 +184,8 @@ module Local = struct
     let> () = Current.return () in
     Current.Monitor.get @@ commit_of_ref t gref
 
-  let read_head repo =
-    let path = Fpath.(repo / ".git" / "HEAD") in
+  let read_head ~bare repo =
+    let path = Fpath.(git_folder bare repo / "HEAD") in
     match Bos.OS.File.read path with
     | Error _ as e -> e
     | Ok contents ->
@@ -186,9 +195,9 @@ module Local = struct
       | [_;r]  -> Ok (`Ref r)
       | _      -> Error (`Msg (Fmt.str "Can't parse HEAD %S" contents))
 
-  let make_head repo =
-    let dot_git = Fpath.(repo / ".git") in
-    let read () = Lwt.return (read_head repo) in
+  let make_head ~bare repo =
+    let dot_git = git_folder bare repo in
+    let read () = Lwt.return (read_head ~bare repo) in
     let watch refresh =
       let watch_dir = dot_git in
       Log.debug (fun f -> f "Installing watch for %a" Fpath.pp watch_dir);
@@ -212,9 +221,9 @@ module Local = struct
     in
     Current.Monitor.create ~read ~watch ~pp
 
-  let v repo =
+  let v ?(bare= false) repo =
     let repo = Fpath.normalize @@ Fpath.append (Fpath.v (Sys.getcwd ())) repo in
-    let head = make_head repo in
+    let head = make_head ~bare repo in
     let heads = Ref_map.empty in
-    { repo; head; heads }
+    { repo; head; heads; bare }
 end

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -58,7 +58,7 @@ module Local : sig
   type t
   (** A local Git repository. *)
 
-  val v : Fpath.t -> t
+  val v : ?bare:bool -> Fpath.t -> t
   (** [v path] is the local Git repository at [path]. *)
 
   val head : t -> [`Commit of Commit_id.t | `Ref of string ] Current.t


### PR DESCRIPTION
It's a simple patch which is currently used by our SMTP stack to be able to synchronize some stuffs with local Git repository made by `git init --bare`. /cc @TheLortex