### PR TITLE
Show line numbers and allow jumping to specific lines in job logs

### DIFF
--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -41,6 +41,7 @@ let routes engine =
     empty @--> Main.r ~engine;
     s "index.html" /? nil @--> Main.r ~engine;
     s "css" / s "style.css" /? nil @--> Style.r;
+    s "js" / s "line-numbers.js" /? nil @--> Script.line_numbers;
     s "pipeline.svg" /? nil @--> Pipeline.r ~engine;
     s "query" /? nil @--> Query.r ~engine;
     s "log-rules" /? nil @--> Log_rules.r;

--- a/lib_web/job.ml
+++ b/lib_web/job.ml
@@ -72,8 +72,11 @@ let render ctx ~actions ~job_id ~log:path =
           ol items]
       ]
   in
+  let line_numbers_js = [script ~a:[a_src (Xml.uri_of_string "/js/line-numbers.js")] (txt "");] 
+  in
   let tmpl =
     Context.template ctx (
+      line_numbers_js @
       history @
       rebuild_button @
       cancel_button @

--- a/lib_web/script.ml
+++ b/lib_web/script.ml
@@ -55,11 +55,16 @@ const showLineNumbers = () => {
 }
 
 const addMutationObserver = () => {
+
+  let debounceTimer
   const mutationCallback = function(mutationsList) {
     for(const mutation of mutationsList) {
       if (mutation.type === 'characterData') {
-        const lineCount = showLineNumbers()
-        highlightLines(lineCount, noScroll=true)
+        clearTimeout(debounceTimer)
+        debounceTimer = setTimeout(() => {
+          const lineCount = showLineNumbers()
+          highlightLines(lineCount, noScroll=true)
+        }, 200)
       }
     }
   }

--- a/lib_web/script.ml
+++ b/lib_web/script.ml
@@ -1,5 +1,39 @@
 let js = {|
 
+const highlightLines = (renderedLines, noScroll=false) => {
+  const mLines = location.hash.match(/L(\d+)(-L(\d+))*/)
+  // Ignore non line-range hashes
+  if (!mLines) {
+    return
+  }
+
+  let [_, start, __, end] = mLines
+  start = Number(start)
+  end = end ? Number(end) : start
+  // Return early if chosen lines are not rendered still
+  if (renderedLines && start > renderedLines) {
+    return
+  }
+
+  // Remove previous highlights if any
+  document.querySelectorAll('.highlight').forEach(
+    (node) => node.classList.remove('highlight')
+  )
+  // Highlight lines in selected range
+  for (let i = start; i <= end; i++) {
+    let lineSpan = document.getElementById('L' + String(i))
+    if (!lineSpan) {
+      break
+    }
+    lineSpan.classList.add('highlight')
+
+    // Scroll to the first selected line, if not triggered by mutations
+    if (i === start && !noScroll) {
+      lineSpan.scrollIntoView()
+    }
+  }
+}
+
 const showLineNumbers = () => {
   const node = document.querySelector('pre')
   const oldLineNumbers = document.getElementById('line-numbers')
@@ -17,13 +51,15 @@ const showLineNumbers = () => {
     number.setAttribute('id', 'L' + String(i))
     lineNumbers.appendChild(number)
   }
+  return lineCount
 }
 
 const addMutationObserver = () => {
   const mutationCallback = function(mutationsList) {
     for(const mutation of mutationsList) {
       if (mutation.type === 'characterData') {
-        showLineNumbers()
+        const lineCount = showLineNumbers()
+        highlightLines(lineCount, noScroll=true)
       }
     }
   }
@@ -41,7 +77,9 @@ const timer = setTimeout(addMutationObserver, 100)
 document.addEventListener('DOMContentLoaded', (event) => {
   clearTimeout(timer) // If the page has loaded completely, don't add mutation observer
   showLineNumbers()
+  highlightLines()
 })
+window.addEventListener('hashchange', () => {highlightLines()})
 
 |}
 

--- a/lib_web/script.ml
+++ b/lib_web/script.ml
@@ -1,0 +1,56 @@
+let js = {|
+
+const showLineNumbers = () => {
+  const node = document.querySelector('pre')
+  const oldLineNumbers = document.getElementById('line-numbers')
+  const lineNumbers = oldLineNumbers ? oldLineNumbers : document.createElement('span')
+  if (!oldLineNumbers) {
+    lineNumbers.setAttribute('id', 'line-numbers')
+    node.prepend(lineNumbers)
+  }
+
+  const lineCount = node.innerHTML.split(/\n/).length
+  const oldLineCount = lineNumbers.getElementsByTagName('span').length
+  for (let i = oldLineCount + 1; i <= lineCount; i++) {
+    let number = document.createElement('span')
+    number.innerHTML = i
+    number.setAttribute('id', 'L' + String(i))
+    lineNumbers.appendChild(number)
+  }
+}
+
+const addMutationObserver = () => {
+  const mutationCallback = function(mutationsList) {
+    for(const mutation of mutationsList) {
+      if (mutation.type === 'characterData') {
+        showLineNumbers()
+      }
+    }
+  }
+
+  // Create an observer instance and watch changes on the pre tag
+  const observer = new MutationObserver(mutationCallback)
+  const pre = document.querySelector('pre')
+  observer.observe(pre, { subtree: true, characterData: true })
+  console.debug('Added observer on pre tag')
+}
+
+// Wait for pre tag to load before attaching the mutation observer
+const timer = setTimeout(addMutationObserver, 100)
+
+document.addEventListener('DOMContentLoaded', (event) => {
+  clearTimeout(timer) // If the page has loaded completely, don't add mutation observer
+  showLineNumbers()
+})
+
+|}
+
+let line_numbers = object
+  inherit Resource.t
+
+  val! can_get = `Viewer
+
+  method! private get _ctx =
+    let headers = Cohttp.Header.init_with "Content-Type" "text/javascript" in
+    Utils.Server.respond_string ~status:`OK ~headers ~body:js ()
+end

--- a/lib_web/script.mli
+++ b/lib_web/script.mli
@@ -1,0 +1,1 @@
+val line_numbers : Resource.t

--- a/lib_web/style.ml
+++ b/lib_web/style.ml
@@ -1,4 +1,5 @@
-let css = {|
+let css =
+  {|
   body {
     margin: 0;
     padding: 0;
@@ -149,15 +150,35 @@ let css = {|
     margin-left: 0.5em;
     margin-right: 2em;
   }
-|} ^ Current_ansi.css
 
-let r = object
-  inherit Resource.t
+  #line-numbers {
+    color:black;
+    display:block;
+  }
 
-  val! can_get = `Viewer
+  #line-numbers {
+    float:left;
+    margin:0 1em 0 -1em;
+    border-right:1px solid;
+    text-align:right;
+  }
 
-  method! private get _ctx =
-    let headers = Cohttp.Header.init_with "Content-Type" "text/css" in
-    Utils.Server.respond_string ~status:`OK ~headers ~body:css ()
+  #line-numbers span {
+    display:block;
+    padding:0 .5em 0 1em;
+  }
+
+|}
+  ^ Current_ansi.css
+
+let r =
+  object
+    inherit Resource.t
+
+    val! can_get = `Viewer
+
+    method! private get _ctx =
+      let headers = Cohttp.Header.init_with "Content-Type" "text/css" in
+      Utils.Server.respond_string ~status:`OK ~headers ~body:css ()
     (*   Server.respond_file ~fname:"style.css" () *)
-end
+  end

--- a/lib_web/style.ml
+++ b/lib_web/style.ml
@@ -168,6 +168,10 @@ let css =
     padding:0 .5em 0 1em;
   }
 
+  #line-numbers .highlight {
+    background: lightgrey;
+  }
+
 |}
   ^ Current_ansi.css
 


### PR DESCRIPTION
This PR adds some simple JS and CSS to allow jumping to a specific line number in the logs, and also displays line numbers for all logs

A URL like `http://localhost:8080/job/2022-02-09/115753-docker-build-71c777#L11-L15` would highlight lines 11 to 15 and scroll the page to line 11. 
![image](https://user-images.githubusercontent.com/315678/153196953-8099a77f-2532-482e-af75-862991f0e2b5.png)
