### PR TITLE
Stop using `Dockerfile.t` and use strings instead

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### unreleased
+
+- Stop using `Dockerfile.t` completely and use strings instead.
+  (@MisterDA, #301, #316)
+
 ### v0.5
 
 Web UI:

--- a/current_docker.opam
+++ b/current_docker.opam
@@ -18,7 +18,6 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ppx_deriving"
   "lwt"
-  "dockerfile"
   "ppx_deriving_yojson" {>= "3.5.1"}
   "yojson"
   "dune" {>= "2.0"}

--- a/doc/examples/build_matrix.ml
+++ b/doc/examples/build_matrix.ml
@@ -27,6 +27,7 @@ let dockerfile ~base ~ocaml_version =
   run "opam install . --show-actions --deps-only -t" @@
   copy ~src:["."] ~dst:"/src/" () @@
   run "opam install -tv ."
+  |> string_of_t
 
 (* included in doc/example_pipelines.md as code snippet *)
 [@@@part "pipeline"]

--- a/doc/examples/docker_custom.ml
+++ b/doc/examples/docker_custom.ml
@@ -81,6 +81,7 @@ let pipeline () =
     `Contents Dockerfile.(
         from (Docker.Image.hash base) @@
         run "apt-get update && apt-get install -y curl --no-install-recommends"
+        |> string_of_t
       )
   in
   test (Docker.build ~pull:false ~dockerfile `No_context)

--- a/doc/examples/github.ml
+++ b/doc/examples/github.ml
@@ -32,6 +32,7 @@ let dockerfile ~base =
   run "opam install . --show-actions --deps-only -t" @@
   copy ~src:["."] ~dst:"/src/" () @@
   run "opam install -tv ."
+  |> string_of_t
 
 let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
 

--- a/doc/examples/github_app.ml
+++ b/doc/examples/github_app.ml
@@ -39,6 +39,7 @@ let dockerfile ~base =
   run "opam install . --show-actions --deps-only -t" @@
   copy ~src:["."] ~dst:"/src/" () @@
   run "opam install -tv ."
+  |> string_of_t
 
 let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
 

--- a/doc/examples/gitlab.ml
+++ b/doc/examples/gitlab.ml
@@ -34,6 +34,7 @@ let dockerfile ~base =
   run "opam install . --show-actions --deps-only -t" @@
   copy ~src:["."] ~dst:"/src/" () @@
   run "opam install -tv ."
+  |> string_of_t
 
 let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
 

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -24,7 +24,7 @@ module Raw = struct
       match dockerfile with
       | None -> `File (Fpath.v "Dockerfile")
       | Some (`File _ as f) -> f
-      | Some (`Contents c) -> `Contents (Dockerfile.string_of_t c)
+      | Some (`Contents c) -> `Contents c
     in
     BC.get ?schedule { Build.pull; pool; timeout; level }
       { Build.Key.commit; dockerfile; docker_context; squash; build_args }

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -37,7 +37,7 @@ module Raw : sig
     ?schedule:Current_cache.Schedule.t ->
     ?timeout:Duration.t ->
     ?squash:bool ->
-    ?dockerfile:[`File of Fpath.t | `Contents of Dockerfile.t] ->
+    ?dockerfile:[`File of Fpath.t | `Contents of string] ->
     ?pool:unit Current.Pool.t ->
     ?build_args:string list ->
     pull:bool ->

--- a/plugins/docker/dune
+++ b/plugins/docker/dune
@@ -7,7 +7,6 @@
    current.cache
    current.term
    current_git
-   dockerfile
    duration
    fmt
    fpath

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -43,7 +43,7 @@ module type DOCKER = sig
     ?timeout:Duration.t ->
     ?squash:bool ->
     ?label:string ->
-    ?dockerfile:[`File of Fpath.t | `Contents of Dockerfile.t] Current.t ->
+    ?dockerfile:[`File of Fpath.t | `Contents of string] Current.t ->
     ?pool:unit Current.Pool.t ->
     ?build_args:string list ->
     pull:bool ->


### PR DESCRIPTION
> Ah, yes! OCurrent should probably just stop using the `Dockerfile.t` type completely. The only function OCurrent ever calls from that module is `Dockerfile.string_of_t`!

Close #301.