### PR TITLE
Set the state dir following XDG Base Directory Specification

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -26,6 +26,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "sqlite3"
   "duration"
+  "directories" {>= "0.5"}
   "prometheus"
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -5,10 +5,11 @@ module Level = Level
 module Config : sig
   type t
 
-  val v : ?auto_release:Duration.t -> ?confirm:Level.t -> unit -> t
+  val v : ?auto_release:Duration.t -> ?confirm:Level.t -> ?state_dir:Fpath.t -> unit -> t
   (** A new configuration.
       @param auto_release Remove confirmation requirement this period (unless changed manually first).
-      @param confirm Confirm before performing operations at or above this level. *)
+      @param confirm Confirm before performing operations at or above this level.
+      @param state_dir State directory for the current pipeline. *)
 
   val set_confirm : t -> Level.t option -> unit
   (** Change the [confirm] setting. Existing jobs waiting for confirmation

--- a/lib/disk_store.ml
+++ b/lib/disk_store.ml
@@ -1,9 +1,31 @@
-let state_dir_root = Fpath.v @@ Filename.concat (Sys.getcwd ()) "var"
+let state_dir_root = ref None
+
+let state_dir_root ?default () =
+  match !state_dir_root with
+  | None when default <> None ->
+    state_dir_root := default;
+    Option.get default
+  | None ->
+    let module M =
+      Directories.Project_dirs (struct
+          let qualifier = "org"
+          let organization = "ocurrent"
+          let application = "current"
+        end) in
+    let current_root =
+      match M.state_dir with
+      | None -> failwith "Couldn't determine suitable state directory."
+      | Some dir -> Fpath.v dir in
+    let name = Unix.realpath Sys.argv.(0) |> Hashtbl.hash |> string_of_int |> Fpath.v in
+    let pipeline_root = Fpath.append current_root name in
+    state_dir_root := Some pipeline_root;
+    pipeline_root
+  | Some path -> path
 
 let state_dir name =
   let name = Fpath.v name in
   assert (Fpath.is_rel name);
-  let path = Fpath.append state_dir_root name in
+  let path = Fpath.append (state_dir_root ()) name in
   match Bos.OS.Dir.create path with
   | Ok (_ : bool) -> path
   | Error (`Msg m) -> failwith m

--- a/lib/dune
+++ b/lib/dune
@@ -6,6 +6,7 @@
    cmdliner
    current_term
    current_incr
+   directories
    duration
    fmt
    fpath


### PR DESCRIPTION
Add a `--current-state-dir` option to set the state directory used
internally by OCurrent. The realpath of the executable is used to
derive a hash for the pipeline, to be able to re-use the same
directories across runs of the same pipeline.

Closes #106.