### PR TITLE
Current_incr: abort propagation on constant/equal changes

### DIFF
--- a/lib_term/dyn.ml
+++ b/lib_term/dyn.ml
@@ -55,3 +55,13 @@ let pp ok f = function
   | Error (_, `Active `Ready) -> Fmt.string f "(ready)"
   | Error (_, `Active `Running) -> Fmt.string f "(running)"
   | Error (_, `Msg m) -> Fmt.pf f "FAILED: %s" m
+
+let equal_progress x y = match x, y with
+  | `Msg x, `Msg y -> String.equal x y
+  | `Active x, `Active y -> Output.equal_active x y
+  | _ -> false
+
+let equal ?(eq = (==)) x y = match x, y with
+  | Ok x, Ok y -> eq x y
+  | Error (id_x, x), Error (id_y, y) -> Id.equal id_x id_y && equal_progress x y
+  | _ -> false

--- a/lib_term/dyn.mli
+++ b/lib_term/dyn.mli
@@ -14,6 +14,8 @@ val map : id:Id.t -> ('a -> 'b) -> 'a t -> 'b t
 val map_error : id:Id.t -> (string -> string) -> 'a t -> 'a t
 val bind : 'a t -> ('a -> 'b t) -> 'b t
 val pair : 'a t -> 'b t -> ('a * 'b) t
+
+val equal : ?eq:('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 val pp : 'a Fmt.t -> 'a t Fmt.t
 
 val run : 'a t -> 'a Output.t


### PR DESCRIPTION
The mental model of OCurrent is confusing when one comes with the belief that current_incr is driving the show. In practice, code is executed a lot more often than the incremental library would suggest.

This has the merit of forcing users to handle their side effects properly to guard against duplicated execution (with `Current_cache` or custom database upsert logic). As a result, the pipeline works correctly when it's restarted from scratch :)

But this does put the pressure on the databases to detect spurious changes! It also makes it impossible to reason locally about the cost of algorithms, as the number of evaluations is dependent on the setup of the global pipeline. The confusion is visible in comments "this is executed twice??" and algorithms that looks "ok" but are actually freezing the pipeline by constantly attempting to update the db with no changes.

The mismatch is that `current_incr` uses physical equality to detect constant changes, but `Current_term` wraps everything inside a `Dyn.map`, so `==` is unable to ever be true.

This PR is potentially a breaking change as some code will execute less than before!.. But I can't think of existing logic that would break as a result? I've refrained from exposing the `?eq` in the signatures, but I would happy to add it if there's a need.