### PR TITLE
Set the current-state-dir via the cli

### DIFF
--- a/lib/current.ml
+++ b/lib/current.ml
@@ -325,8 +325,6 @@ module Unit = struct
     | x -> Fmt.failwith "Unit.unmarshal(%S)" x
 end
 
-let state_dir = Disk_store.state_dir
-
 module Db = Db
 module Process = Process
 module Switch = Switch

--- a/lib/current.mli
+++ b/lib/current.mli
@@ -5,10 +5,11 @@ module Level = Level
 module Config : sig
   type t
 
-  val v : ?auto_release:Duration.t -> ?confirm:Level.t -> unit -> t
+  val v : ?auto_release:Duration.t -> ?confirm:Level.t -> ?state_dir:Fpath.t -> unit -> t
   (** A new configuration.
       @param auto_release Remove confirmation requirement this period (unless changed manually first).
-      @param confirm Confirm before performing operations at or above this level. *)
+      @param confirm Confirm before performing operations at or above this level.
+      @param state_dir State directory for the current pipeline. *)
 
   val set_confirm : t -> Level.t option -> unit
   (** Change the [confirm] setting. Existing jobs waiting for confirmation
@@ -20,6 +21,11 @@ module Config : sig
 
   val now : t option Current_incr.t
   (** The configuration of the engine, if any. *)
+
+  val state_dir : string -> Fpath.t
+  (** [state_dir name] is a directory under which state (build results, logs) can be stored.
+      [name] identifies the sub-component of OCurrent, each of which gets its own subdirectory.
+      Can only be called after the configuration has happened. *)
 end
 
 type job_id = string
@@ -118,10 +124,6 @@ module Var (T : Current_term.S.T) : sig
   val set : t -> T.t Current_term.Output.t -> unit
   val update : t -> (T.t Current_term.Output.t -> T.t Current_term.Output.t) -> unit
 end
-
-val state_dir : string -> Fpath.t
-(** [state_dir name] is a directory under which state (build results, logs) can be stored.
-    [name] identifies the sub-component of OCurrent, each of which gets its own subdirectory. *)
 
 module String : sig
   type t = string

--- a/lib/db.ml
+++ b/lib/db.ml
@@ -53,7 +53,7 @@ let query_some stmt values =
 
 let v =
   lazy (
-    let db_dir = Disk_store.state_dir "db" in
+    let db_dir = Config.state_dir "db" in
     let db = Sqlite3.db_open Fpath.(to_string (db_dir / "sqlite.db")) in
     Sqlite3.busy_timeout db 1000;
     exec_literal db "PRAGMA journal_mode=WAL";

--- a/lib/disk_store.ml
+++ b/lib/disk_store.ml
@@ -1,9 +1,0 @@
-let state_dir_root = Fpath.v @@ Filename.concat (Sys.getcwd ()) "var"
-
-let state_dir name =
-  let name = Fpath.v name in
-  assert (Fpath.is_rel name);
-  let path = Fpath.append state_dir_root name in
-  match Bos.OS.Dir.create path with
-  | Ok (_ : bool) -> path
-  | Error (`Msg m) -> failwith m

--- a/lib/job.ml
+++ b/lib/job.ml
@@ -56,7 +56,7 @@ let log t fmt =
 
 let id t = t.id
 
-let jobs_dir = lazy (Disk_store.state_dir "job")
+let jobs_dir = lazy (Config.state_dir "job")
 
 let log_path job_id =
   let open Astring in

--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -21,7 +21,7 @@ let id_of_repo repo =
 
 (* .../var/git/myrepo-hhh *)
 let local_copy repo =
-  let repos_dir = Current.state_dir "git" in
+  let repos_dir = Current.Config.state_dir "git" in
   Fpath.append repos_dir (Fpath.v (id_of_repo repo))
 
 let git ~cancellable ~job ?cwd args =


### PR DESCRIPTION
Dropping XDG doesn't mean we cannot override the default state directory.
Does switching to a `ref` introduce an annoying side effect (if the caller changes the root state directory)? Should the variable be "read-only" once the cli switch overrides the default?