### PR TITLE
Import and export rules from the web UI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+Web UI:
+
+- Allow to import and export using CSV the log rules. (@MisterDA, #327)
+
 ### v0.6
 
 Core:

--- a/current_web.opam
+++ b/current_web.opam
@@ -28,6 +28,7 @@ depends: [
   "prometheus-app"
   "cohttp-lwt-unix" {>= "4.0.0"}
   "tyxml" {>= "4.4.0"}
+  "csv" {>= "2.4"}
   "routes" {>= "0.8.0"}
   "dune" {>= "2.0"}
   "conf-graphviz"

--- a/current_web.opam
+++ b/current_web.opam
@@ -23,6 +23,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "bos"
   "lwt"
+  "multipart_form-lwt" {>= "0.4.0"}
   "cmdliner" {>= "1.1.0"}
   "prometheus" {>= "0.7"}
   "prometheus-app"

--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -45,6 +45,7 @@ let routes engine =
     s "pipeline.svg" /? nil @--> Pipeline.r ~engine;
     s "query" /? nil @--> Query.r ~engine;
     s "log-rules" /? nil @--> Log_rules.r;
+    s "log-rules" / s "rules.csv" /? nil @--> Log_rules.rules_csv;
     s "metrics" /? nil @--> metrics ~engine;
     s "set" / s "confirm" /? nil @--> set_confirm ~engine;
     s "jobs" /? nil @--> Jobs.r;

--- a/lib_web/dune
+++ b/lib_web/dune
@@ -11,6 +11,7 @@
    current
    current.cache
    current.term
+   csv
    ansi
    fmt
    fpath

--- a/lib_web/dune
+++ b/lib_web/dune
@@ -21,6 +21,7 @@
    mirage-crypto
    mirage-crypto-rng
    mirage-crypto-rng.unix
+   multipart_form-lwt
    ppx_sexp_conv.runtime-lib
    prometheus
    prometheus-app

--- a/lib_web/log_rules.mli
+++ b/lib_web/log_rules.mli
@@ -1,1 +1,2 @@
 val r : Resource.t
+val rules_csv : Resource.t


### PR DESCRIPTION
Allows to import (by a CSV file upload) and export rules (to a CSV
file) from the web UI. For now, uploading doesn't work as I'm not sure
how to correctly retreive the file data, and more importantly I can't
figure out why file file upload always errors with "Bad CSRF" (help
would be appreciated).

Sub-question: do we want to "atomically" import all rules, i.e. should
we validate the whole file before adding rules, or install rules but
retract installed rules if there's an error down the line, or just gather
errors as I've done?
