### PR TITLE
Add cutoff operation

### DIFF
--- a/current.opam
+++ b/current.opam
@@ -19,7 +19,7 @@ doc: "https://ocurrent.github.io/ocurrent/"
 bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "current_incr" {>= "0.5"}
+  "current_incr" {>= "0.6.1"}
   "fmt" {>= "0.8.9"}
   "bos"
   "ppx_deriving"

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -83,12 +83,7 @@ module Make (Metadata : sig type t end) = struct
     let id = Id.mint () in
     node ~id (Constant None) @@ Current_incr.const (Dyn.fail ~id msg)
 
-  let incr_map ?eq fn v =
-    let open Current_incr in
-    of_cc begin
-      read v @@ fun x ->
-      write ~eq:(Dyn.equal ?eq) (fn x)
-    end
+  let incr_map ?eq fn v = Current_incr.map ~eq:(Dyn.equal ?eq) fn v
 
   let state ?(hidden=false) t =
     let eq = Output.equal (==) in

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -128,6 +128,11 @@ module Make (Metadata : sig type t end) = struct
     let id = Id.mint () in
     node ~id (Map (Term x)) @@ incr_map (Dyn.map_error ~id f) x.v
 
+  let cutoff ~eq x =
+    let id = Id.mint () in
+    let eq = Dyn.equal ~eq in
+    node ~id (Map (Term x)) Current_incr.(of_cc @@ read x.v @@ write ~eq)
+
   let ignore_value x = map ignore x
 
   let pair a b =

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -160,6 +160,13 @@ module type TERM = sig
       ]}
   *)
 
+  val cutoff : eq:('a -> 'a -> bool) -> 'a t -> 'a t
+  (** [cutoff ~eq x] is the same as [x], but changes to [x] that are equal
+      according to [eq] do not propagate further down. It should be used
+      when values of type ['a] have a precise definition of equality
+      to avoid triggering redundant work.
+  *)
+
   (** {2 Diagram control} *)
 
   val collapse : key:string -> value:string -> input:_ t -> 'a t -> 'a t

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -100,8 +100,14 @@ module type TERM = sig
 
   (** {2 Applicative operations} *)
 
-  val map : ('a -> 'b) -> 'a t -> 'b t
-  (** [map f x] is a term that runs [x] and then transforms the result using [f]. *)
+  val map : ?eq:('b -> 'b -> bool) -> ('a -> 'b) -> 'a t -> 'b t
+  (** [map f x] is a term that runs [x] and then transforms the result using [f].
+
+      The optional equality function [?eq] defaults to physical equality.  When
+      [f] produces an updated result following a change in [x], the equality
+      function will be called with the previous and the new value [eq b_old b_new]:
+      returning [true] indicates that the change can be ignored and should
+      not propagate further down the pipeline.  *)
 
   val map_error : (string -> string) -> 'a t -> 'a t
   (** [map_error f x] is a term that runs [x] and then transforms the error string (if any) using [f]. *)
@@ -194,7 +200,7 @@ module type TERM = sig
   (** {b N.B.} these operations create terms that cannot be statically
       analysed until after they are executed. *)
 
-  val bind : ?info:description -> ('a -> 'b t) -> 'a t -> 'b t
+  val bind : ?info:description -> ?eq:('b -> 'b -> bool) -> ('a -> 'b t) -> 'a t -> 'b t
   (** [bind f x] is a term that first runs [x] to get [y] and then behaves as
       the term [f y]. Static analysis cannot look inside the [f] function until
       [x] is ready, so using [bind] makes static analysis less useful. You can


### PR DESCRIPTION
This is a follow up on the ["abort propagation on equality" PR](https://github.com/ocurrent/ocurrent/pull/318) -- I now think that it can be very useful to customize the equality operator in some specific situations, as otherwise the code becomes terrible in order to conform to physical equality.

- I didn't want to add an `?eq` argument to `map`... its usage should be rare in practice, so the signature shouldn't encourage it :)
- The name `cutoff` and its documentation is rather low-level and might only speak to myself... your suggestions are welcome!