### PR TITLE
Add missing dependencies on Unix

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -16,5 +16,6 @@
    prometheus
    re
    result
+   unix
    sqlite3)
  (preprocess (pps ppx_deriving.std)))

--- a/lib_cache/dune
+++ b/lib_cache/dune
@@ -13,4 +13,5 @@
    prometheus
    re
    result
+   unix
    sqlite3))

--- a/lib_web/dune
+++ b/lib_web/dune
@@ -33,6 +33,7 @@
    tyxml
    tyxml.functor
    ppx_deriving_yojson.runtime
+   unix
    yojson
    uri)
  (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))

--- a/plugins/github/dune
+++ b/plugins/github/dune
@@ -27,6 +27,7 @@
    uri
    x509
    tyxml
+   unix
    tyxml.functor
    yojson)
  (preprocess (pps ppx_deriving_yojson)))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.