### PR TITLE
Make default_ref a Ref.t and remove bug when filtering stale references

### DIFF
--- a/plugins/gitlab/api.mli
+++ b/plugins/gitlab/api.mli
@@ -32,7 +32,7 @@ type refs
 val of_oauth : token:string -> webhook_secret:string -> t
 val head_commit : t -> Repo_id.t -> Commit.t Current.t
 val refs : t -> Repo_id.t -> refs Current.Primitive.t
-val default_ref : refs -> string
+val default_ref : refs -> Ref.t
 val webhook_secret : t -> string
 val all_refs : refs -> Commit.t Ref_map.t
 val ci_refs : ?staleness:Duration.t -> t -> Repo_id.t -> Commit.t list Current.t

--- a/plugins/gitlab/current_gitlab.mli
+++ b/plugins/gitlab/current_gitlab.mli
@@ -129,7 +129,7 @@ module Api : sig
       [default_ref] and [all_refs] will expose useful information for you.
       The result is cached (so calling it twice will return the same primitive). *)
 
-  val default_ref : refs -> string
+  val default_ref : refs -> Ref.t
   (** [default_ref refs] will return the full name of the repository's default branch ref *)
 
   val all_refs : refs -> Commit.t Ref_map.t


### PR DESCRIPTION
Also removes an extra HTTP round-trip when getting the latest commit for a branch.