### PR TITLE
Backport changes from Ewan's fork

### DIFF
--- a/lib_term/analysis.ml
+++ b/lib_term/analysis.ml
@@ -167,8 +167,22 @@ module Make (Meta : sig type t end) = struct
           | Error (_, `Msg msg) when error_from_self -> Some msg
           | _ -> None
         in
-        let node ?(bg=bg) ?url =
-          Dot.node ~style:"filled" ~bg ?tooltip ?url f in
+        let node ?(bg=bg) ?url ?shape idx label =
+          (* Add a marker to the node if it is for a job (i.e. can be clicked
+             through to reach a build log. *)
+          let suffix =
+            match url with
+            | None -> ""
+            | Some _ -> begin
+              match v with
+              | Ok _ -> " &#x2714;" (* Checkmark *)
+              | Error _ when not error_from_self -> "" (* Blocked *)
+              | Error (_, `Active _) -> " &#x2026;" (* Ellipsis *)
+              | Error (_, `Msg _) when error_from_self -> " &#x2717;" (* Cross *)
+              | _ -> ""
+              end
+          in
+          Dot.node ~style:"filled" ?shape ~bg ?tooltip ?url f idx (label ^ suffix) in
         let outputs =
           match t.ty with
           | Constant (Some l) -> node i l; Out_node.singleton ~deps:ctx i

--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -39,6 +39,9 @@ let git_clone ~cancellable ~job ~src dst =
 let git_fetch ~cancellable ~job ~src ~dst gref =
   git ~cancellable ~job ~cwd:dst ["fetch"; "-f"; src; gref]
 
+let git_checkout_force ~job ~repo treeish =
+  git ~cancellable:false ~job ~cwd:repo ["-c"; "advice.detachedHead=false"; "checkout"; "-f"; treeish]
+
 let git_reset_hard ~job ~repo hash =
   git ~cancellable:false ~job ~cwd:repo ["reset"; "--hard"; "-q"; hash]
 

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -79,6 +79,7 @@ let with_checkout ?pool ~job commit fn =
        Current.Process.with_tmpdir ~prefix:"git-checkout" @@ fun tmpdir ->
        Cmd.cp_r ~cancellable:true ~job ~src:(Fpath.(repo / ".git")) ~dst:tmpdir >>!= fun () ->
        Cmd.git_submodule_update ~init:false ~cancellable:true ~job ~repo:tmpdir >>!= fun () ->
+       Cmd.git_checkout_force ~job ~repo:tmpdir id.Commit_id.gref >>!= fun () ->
        Cmd.git_reset_hard ~job ~repo:tmpdir id.Commit_id.hash >>= function
        | Ok () ->
          Cmd.git_submodule_sync ~cancellable:true ~job ~repo:tmpdir >>!= fun () ->


### PR DESCRIPTION
The issue was addressed from https://github.com/ocurrent/ocaml-multicore-ci/issues/19.

There are some commits from Ewan's fork https://github.com/ewanmellor/ocurrent which could be merge in OCurrent, it's all about cherry-ping them.