### PR TITLE
Fetch commit messages for commits on GitHub

### DIFF
--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -25,6 +25,7 @@ module Commit : sig
   val owner_name : t -> string
   val hash : t -> string
   val committed_date : t -> string
+  val message : t -> string
   val pp : t Fmt.t
   val compare : t -> t -> int
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -96,6 +96,9 @@ module Api : sig
     val committed_date : t -> string
     (** [committed_date t] is the datetime when [t] was committed *)
 
+    val message : t -> string
+    (** [message t] is the Git commit message of [t]. *)
+
     val pp : t Fmt.t
     val compare : t -> t -> int
 


### PR DESCRIPTION
It is useful to fetch the commit message when fetching commits from GitHub. Current bench, for instance, could make the UI friendlier by displaying the commit message in the UI. https://github.com/ocurrent/current-bench/pull/356