### PR TITLE
Implement serving of static images.

### DIFF
--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -36,7 +36,7 @@ let set_confirm ~engine = object
     | _ -> Context.respond_error ctx `Bad_request "Missing level"
 end
 
-let routes engine =
+let routes ?(docroot="static") engine =
   Routes.[
     empty @--> Main.r ~engine;
     s "index.html" /? nil @--> Main.r ~engine;
@@ -50,6 +50,7 @@ let routes engine =
     s "set" / s "confirm" /? nil @--> set_confirm ~engine;
     s "jobs" /? nil @--> Jobs.r;
     s "logout" /? nil @--> Resource.logout;
+    s "images" / str /? nil @--> Static.r ~docroot;
   ] @ Job.routes ~engine
 
 let handle_request ~site _conn request body =

--- a/lib_web/current_web.mli
+++ b/lib_web/current_web.mli
@@ -103,8 +103,10 @@ module Resource : sig
   end
 end
 
-val routes : Current.Engine.t -> Resource.t Routes.route list
-(** [routes engine] is the default routes for a web interface to [engine]. *)
+val routes : ?docroot:string -> Current.Engine.t -> Resource.t Routes.route list
+(** [routes ~docroot engine] is the default routes for a web interface to [engine].
+    @param docroot The root directory for static resources. Files from /images
+    are served from here. Defaults to "static". *)
 
 val run : ?mode:Conduit_lwt_unix.server -> Site.t -> ('a, [`Msg of string]) result Lwt.t
 (** [run ~mode site] runs a web-server (with configuration [mode]) that handles incoming requests for [site]. *)

--- a/lib_web/static.ml
+++ b/lib_web/static.ml
@@ -1,0 +1,21 @@
+let serve_file ~docroot uri =
+  let fname = Utils.Server.resolve_local_file ~docroot ~uri in
+  Utils.Server.respond_file ~fname ()
+
+(*
+  Serve files directly out of the given docroot.
+
+  Note that we ignore the given path, and we use the Context.uri instead.
+  The routes package has added a wildcard option
+  (https://github.com/anuragsoni/routes/pull/118) but this has not been
+  released yet.  We're just using a string for matching for now, which
+  we discard.
+ *)
+let r ~docroot _path =
+  object
+    inherit Resource.t
+
+    method! private get ctx =
+      let uri = Context.uri ctx in
+      serve_file ~docroot uri
+  end


### PR DESCRIPTION
This adds a static module, which serves the file from a specified
docroot.  Hook this in to the routes under /images/*.

Signed-off-by: Ewan Mellor <ewan@tarides.com>