### PR TITLE
Current_git: ensure stale submodules are removed

### DIFF
--- a/current_git.opam
+++ b/current_git.opam
@@ -28,6 +28,7 @@ depends: [
   "result" {>= "1.5"}
   "cstruct" {>= "6.0.0"}
   "mirage-crypto" {>= "0.8.0"}
+  "mdx" {with-test}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -59,5 +59,13 @@ let cp_r ~cancellable ~job ~src ~dst =
 let git_submodule_sync ~cancellable ~job ~repo =
   git ~cancellable ~job ~cwd:repo ["submodule"; "sync"]
 
+let git_submodule_deinit ~cancellable ~job ~repo ~force ~all =
+  let flags = List.concat [
+      (if force then ["--force"] else []);
+      (if all then ["--all"] else []);
+    ]
+  in
+  git ~cancellable ~job ~cwd:repo ("submodule" :: "deinit" :: flags)
+
 let git_submodule_update ~cancellable ~job ~repo ~init =
   git ~cancellable ~job ~cwd:repo ("submodule" :: "update" :: "--recursive" :: (if init then ["--init"] else []))

--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -44,9 +44,6 @@ let git_fetch ?recurse_submodules ~cancellable ~job ~src ~dst gref =
   in
   git ~cancellable ~job ~cwd:dst ("fetch" :: flags @ ["-f"; src; gref])
 
-let git_checkout_force ~job ~repo treeish =
-  git ~cancellable:false ~job ~cwd:repo ["-c"; "advice.detachedHead=false"; "checkout"; "-f"; treeish]
-
 let git_reset_hard ~job ~repo hash =
   git ~cancellable:false ~job ~cwd:repo ["reset"; "--hard"; "-q"; hash]
 

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -78,11 +78,10 @@ let with_checkout ?pool ~job commit fn =
        end >>= fun () ->
        Current.Process.with_tmpdir ~prefix:"git-checkout" @@ fun tmpdir ->
        Cmd.cp_r ~cancellable:true ~job ~src:(Fpath.(repo / ".git")) ~dst:tmpdir >>!= fun () ->
-       Cmd.git_submodule_update ~init:false ~cancellable:true ~job ~repo:tmpdir >>!= fun () ->
+       Cmd.git_submodule_deinit ~force:true ~all:true ~cancellable:false ~job ~repo:tmpdir >>!= fun () ->
        Cmd.git_checkout_force ~job ~repo:tmpdir id.Commit_id.gref >>!= fun () ->
        Cmd.git_reset_hard ~job ~repo:tmpdir id.Commit_id.hash >>= function
        | Ok () ->
-         Cmd.git_submodule_sync ~cancellable:true ~job ~repo:tmpdir >>!= fun () ->
          Cmd.git_submodule_update ~init:true ~cancellable:true ~job ~repo:tmpdir >>!= fun () ->
          Current.Switch.turn_off switch >>= fun () ->
          fn tmpdir

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -94,7 +94,6 @@ let with_checkout ?pool ~job commit fn =
        Current.Process.with_tmpdir ~prefix:"git-checkout" @@ fun tmpdir ->
        Cmd.cp_r ~cancellable:true ~job ~src:(Fpath.(repo / ".git")) ~dst:tmpdir >>!= fun () ->
        Cmd.git_submodule_deinit ~force:true ~all:true ~cancellable:false ~job ~repo:tmpdir >>!= fun () ->
-       Cmd.git_checkout_force ~job ~repo:tmpdir id.Commit_id.gref >>!= fun () ->
        Cmd.git_reset_hard ~job ~repo:tmpdir id.Commit_id.hash >>= function
        | Ok () ->
          Cmd.git_submodule_update ~init:true ~cancellable:true ~fetch:false ~job ~repo:tmpdir >>!= fun () ->

--- a/plugins/git/test/dune
+++ b/plugins/git/test/dune
@@ -1,0 +1,3 @@
+(mdx
+ (packages current_git)
+ (package current_git))

--- a/plugins/git/test/test_submodules.md
+++ b/plugins/git/test/test_submodules.md
@@ -1,0 +1,131 @@
+It's very difficult to get Git to behave sensibly when using submodules.
+If you find a problem, please add a test-case to this file along with the fix.
+
+Set up the environment:
+
+```ocaml
+# #require "current_git";;
+# #require "lwt.unix";;
+# open Current.Syntax;;
+# open Lwt.Infix;;
+# Unix.putenv "EMAIL" "test@example.com";;
+- : unit = ()
+```
+
+Create an "upstream" repository for the submodule:
+
+```sh
+$ mkdir sub
+$ git init -q sub
+$ echo sub > sub/file
+$ git -C sub add file
+$ git -C sub commit -q -a -m 'Initial submodule commit'
+```
+
+Create the main repository and add the submodule to it:
+
+```sh
+$ mkdir main
+$ git init -q main
+$ echo main > main/file
+$ git -C main add file
+$ git -C main submodule add -q ../sub
+$ git -C main commit -q -a -m 'Initial main commit'
+```
+
+Make an OCurrent job that just lists the files in a commit
+(sending the sorted list to `results` on each build):
+
+```ocaml
+let results, push_result = Lwt_stream.create ()
+
+module Show_files = struct
+  type t = unit
+
+  let id = "show-files"
+
+  module Key = struct
+    include Current_git.Commit
+
+    let digest t = Current_git.Commit_id.digest (id t)
+  end
+
+  module Value = Current.Unit
+
+  let build () job commit =
+    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+    Current_git.with_checkout ~job commit (fun tmpdir ->
+      let files =
+        Sys.readdir (Fpath.to_string tmpdir)
+        |> Array.to_list
+        |> List.filter (fun x -> x.[0] <> '.')
+        |> List.sort String.compare
+      in
+      (* Fmt.pr "Building: %a@." Fmt.(Dump.list string) files; *)
+      push_result (Some files);
+      Lwt.return (Ok ())
+    )
+
+  let pp = Current_git.Commit.pp
+  let auto_cancel = false
+end
+
+module SF = Current_cache.Make(Show_files)
+
+let show_files commit =
+  Current.component "show_files" |>
+  let> commit = commit in
+  SF.get () commit
+```
+
+Start an OCurrent pipeline monitoring the main repository.
+We watch "main" directly just to get the commit ID, then clone it as if it were remote:
+
+```ocaml
+# let repo = Current_git.Local.v (Fpath.v "./main");;
+val repo : Current_git.Local.t = <abstr>
+# let pipeline () =
+    let remote_commit = Current_git.Local.head_commit repo in
+    let id = Current.map Current_git.Commit.id remote_commit in
+    let clone = Current_git.fetch id in
+    show_files clone;;
+val pipeline : unit -> unit Current.term = <fun>
+# let engine = Current.Engine.create pipeline;;
+val engine : Current.Engine.t = <abstr>
+```
+
+In the initial state we should see the submodule:
+
+```ocaml
+# Lwt_stream.get results;;
+- : string list option = Some ["file"; "sub"]
+```
+
+Remove the submodule:
+
+```sh
+$ rm main/.gitmodules
+$ rm -r main/sub
+$ git -C main commit -q -a -m 'Remove submodule'
+```
+
+Ensure that our new checkout doesn't have the deleted submodule:
+
+```ocaml
+# Lwt_stream.get results;;
+- : string list option = Some ["file"]
+```
+
+Add it back in again:
+
+```sh
+$ git -C main submodule add --force -q ../sub >/dev/null
+$ git -C main commit -q -a -m 'Restore submodule'
+```
+
+Ensure we re-create it in our checkout:
+
+```ocaml
+# Lwt_stream.get results;;
+- : string list option = Some ["file"; "sub"]
+```


### PR DESCRIPTION
- Do `git submodule deinit` first, otherwise git won't remove old files on reset.
- Add a test for this.

I also removed the extra submodule update and sync added recently. The sync only affects initialised submodules and there aren't any with this change. The extra update was to help the sync succeed.

Fixes #340.