### PR TITLE
Fix type error in line-numbers

### DIFF
--- a/lib_web/static/js/line-numbers.js
+++ b/lib_web/static/js/line-numbers.js
@@ -62,16 +62,15 @@ const showLineNumbers = () => {
 
 const addMutationObserver = () => {
 
-  let debounceTimerFn = setTimeout(() => {
+  let debounceTimer = () => {
     const lineCount = showLineNumbers();
     highlightLines(lineCount, noScroll = true);
-  }, 200);
-  let debounceTimer;
+  };
   const mutationCallback = function (mutationsList) {
     for (const mutation of mutationsList) {
       if (mutation.type === 'characterData') {
         clearTimeout(debounceTimer);
-        debounceTimer = debounceTimerFn();
+        debounceTimer = setTimeout(debounceTimer, 200);
       }
     }
   };


### PR DESCRIPTION
Eager to silent a jshint warning,

> error: Functions declared within loops referencing an outer scope
> variable may lead to confusing semantics. (W083)

I introduced an incorrect little change in b50b9578ac986ff12b9649fe2ab940cc9c10028f, which led to errors
reported in browsers:

> Uncaught TypeError: debounceTimerFn is not a function
>   mutationCallback https://tezos.ci.dev/js/line-numbers.js:74