### PR TITLE
Add pull argument to docker compose

### DIFF
--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -56,8 +56,8 @@ module Raw = struct
 
   module CC = Current_cache.Output(Compose)
 
-  let compose ~docker_context ~name ~contents () =
-    CC.set Compose.No_context { Compose.Key.name; docker_context } { Compose.Value.contents }
+  let compose ?(pull=true) ~docker_context ~name ~contents () =
+    CC.set Compose.{ pull } { Compose.Key.name; docker_context } { Compose.Value.contents }
 
   module Cmd = struct
     open Lwt.Infix
@@ -170,10 +170,10 @@ module Make (Host : S.HOST) = struct
     let> image = image in
     Raw.service ~docker_context ~name ~image ()
 
-  let compose ~name ~contents () =
+  let compose ?pull ~name ~contents () =
     Current.component "docker-compose@,%s" name |>
     let> contents = contents in
-    Raw.compose ~docker_context ~name ~contents ()
+    Raw.compose ?pull ~docker_context ~name ~contents ()
 end
 
 module Default = Make(struct

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -71,6 +71,7 @@ module Raw : sig
     name:string -> image:Image.t -> unit -> unit Current.Primitive.t
 
   val compose :
+    ?pull:bool ->
     docker_context:string option ->
     name:string ->
     contents:string -> unit -> unit Current.Primitive.t

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -85,9 +85,10 @@ module type DOCKER = sig
   val service : name:string -> image:Image.t Current.t -> unit -> unit Current.t
   (** [service ~name ~image ()] keeps a Docker SwarmKit service up-to-date. *)
 
-  val compose : name:string -> contents:string Current.t -> unit -> unit Current.t
-  (** [service ~name ~image ~contents ()] keeps a Docker Compose deployment up-to-date.
-      [contents] contains the full Compose Yaml file. *)
+  val compose : ?pull:bool -> name:string -> contents:string Current.t -> unit -> unit Current.t
+  (** [service ?pull ~name ~image ~contents ()] keeps a Docker Compose deployment up-to-date.
+      [contents] contains the full Compose Yaml file.
+      @param pull Controls whether images are pulled by the compose command, the default is [true] *)
 end
 
 module type HOST = sig


### PR DESCRIPTION
This PR adds an optional `pull` argument to the Docker compose command and retains the previous behaviour by setting it by default to `true`.

I found this necessary if the compose file didn't actually use published images but instead used local image hashes. I don't know if that is a bit of a docker-compose anti-pattern, but in a pipeline scenario it might be somewhat common when people don't want to publish images?