### PR TITLE
Allow users to provide a command printer

### DIFF
--- a/lib/current.mli
+++ b/lib/current.mli
@@ -361,8 +361,13 @@ end
 
 (** Helper functions for spawning sub-processes. *)
 module Process : sig
+  val pp_cmd : Format.formatter -> Lwt_process.command -> unit
+  (** The default command printer used in {! exec} and {! check_output}
+      to write the command to the job's log. *)
+
   val exec :
     ?cwd:Fpath.t -> ?stdin:string ->
+    ?pp_cmd:(Format.formatter -> Lwt_process.command -> unit) ->
     ?pp_error_command:(Format.formatter -> unit) ->
     cancellable:bool ->
     job:Job.t -> Lwt_process.command ->
@@ -371,11 +376,13 @@ module Process : sig
       @param cwd Sets the current working directory for this command.
       @param cancellable Should the process be terminated if the job is cancelled?
       @param stdin Data to write to stdin before closing it.
+      @param pp_cmd Format the command for the job's log and error message.
       @param pp_error_command Format the command for an error message.
         The default is to print "Command $cmd". *)
 
   val check_output :
     ?cwd:Fpath.t -> ?stdin:string ->
+    ?pp_cmd:(Format.formatter -> Lwt_process.command -> unit) ->
     ?pp_error_command:(Format.formatter -> unit) ->
     cancellable:bool ->
     job:Job.t -> Lwt_process.command ->

--- a/lib/process.ml
+++ b/lib/process.ml
@@ -114,7 +114,7 @@ let send_to ch contents =
     (fun () -> Lwt.return (Ok ()))
     (fun ex -> Lwt.return (Error (`Msg (Printexc.to_string ex))))
 
-let pp_command cmd f = Fmt.pf f "Command %a" pp_cmd cmd
+let pp_command pp_cmd cmd f = Fmt.pf f "Command %a" pp_cmd cmd
 
 let copy_to_log ~job src =
   let rec aux () =
@@ -141,9 +141,9 @@ let add_shutdown_hooks ~cancellable ~job ~cmd proc =
       )
   )
 
-let exec ?cwd ?(stdin="") ?pp_error_command ~cancellable ~job cmd =
+let exec ?cwd ?(stdin="") ?(pp_cmd = pp_cmd) ?pp_error_command ~cancellable ~job cmd =
   let cwd = Option.map Fpath.to_string cwd in
-  let pp_error_command = Option.value pp_error_command ~default:(pp_command cmd) in
+  let pp_error_command = Option.value pp_error_command ~default:(pp_command pp_cmd cmd) in
   Log.info (fun f -> f "Exec: @[%a@]" pp_cmd cmd);
   Job.log job "Exec: @[%a@]" pp_cmd cmd;
   let proc = Lwt_process.open_process ?cwd ~stderr:(`FD_copy Unix.stdout) cmd in
@@ -156,9 +156,9 @@ let exec ?cwd ?(stdin="") ?pp_error_command ~cancellable ~job cmd =
   | Ok () -> stdin_result
   | Error _ as e -> e
 
-let check_output ?cwd ?(stdin="") ?pp_error_command ~cancellable ~job cmd =
+let check_output ?cwd ?(stdin="") ?(pp_cmd = pp_cmd) ?pp_error_command ~cancellable ~job cmd =
   let cwd = Option.map Fpath.to_string cwd in
-  let pp_error_command = Option.value pp_error_command ~default:(pp_command cmd) in
+  let pp_error_command = Option.value pp_error_command ~default:(pp_command pp_cmd cmd) in
   Log.info (fun f -> f "Exec: @[%a@]" pp_cmd cmd);
   Job.log job "Exec: @[%a@]" pp_cmd cmd;
   let proc = Lwt_process.open_process_full ?cwd cmd in

--- a/lib/process.mli
+++ b/lib/process.mli
@@ -1,11 +1,15 @@
+val pp_cmd : Format.formatter -> Lwt_process.command -> unit
+
 val exec :
   ?cwd:Fpath.t -> ?stdin:string ->
+  ?pp_cmd:(Format.formatter -> Lwt_process.command -> unit) ->
   ?pp_error_command:(Format.formatter -> unit) ->
   cancellable:bool -> job:Job.t -> Lwt_process.command ->
   unit Current_term.S.or_error Lwt.t
 
 val check_output :
   ?cwd:Fpath.t -> ?stdin:string ->
+  ?pp_cmd:(Format.formatter -> Lwt_process.command -> unit) ->
   ?pp_error_command:(Format.formatter -> unit) ->
   cancellable:bool -> job:Job.t -> Lwt_process.command ->
   string Current_term.S.or_error Lwt.t


### PR DESCRIPTION
This PR exposes the command printer for `Current.Process.exec` and `Current.Process.check_output`. This allows users to have greater control over what gets written to the job's log. In particular, if there are private tokens or secrets that need to be passed on the command line (for instance, cloning private repositories from Github, see https://github.com/ocurrent/ocluster/issues/179) a user may wish to remove them. The new test in `test_job.ml` mimics a very simple version of this.