### PR TITLE
GitHub - Add support for rebuilding a commit.

### DIFF
--- a/doc/examples/github.ml
+++ b/doc/examples/github.ml
@@ -56,8 +56,10 @@ let pipeline ~github ~repo () =
 let main config mode github repo =
   let has_role = Current_web.Site.allow_all in
   let engine = Current.Engine.create ~config (pipeline ~github ~repo) in
+  (* this example does not have support for looking up job_ids for a commit *)
+  let get_job_ids = (fun ~owner:_owner ~name:_name ~hash:_hash -> []) in
   let routes =
-    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~webhook_secret:(Github.Api.webhook_secret github) ~has_role) ::
+    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~get_job_ids ~webhook_secret:(Github.Api.webhook_secret github) ~has_role) ::
     Current_web.routes engine
   in
   let site = Current_web.Site.(v ~has_role) ~name:program_name routes in

--- a/doc/examples/github_app.ml
+++ b/doc/examples/github_app.ml
@@ -76,8 +76,10 @@ let main config mode app =
     let has_role = Current_web.Site.allow_all in
     let engine = Current.Engine.create ~config (pipeline ~app) in
     let webhook_secret = Current_github.App.webhook_secret app in
+    (* this example does not have support for looking up job_ids for a commit *)
+    let get_job_ids = (fun ~owner:_owner ~name:_name ~hash:_hash -> []) in
     let routes =
-      Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~has_role ~webhook_secret) ::
+      Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~get_job_ids ~webhook_secret ~has_role) ::
       Current_web.routes engine
     in
     let site = Current_web.Site.(v ~has_role) ~name:program_name routes in

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -115,6 +115,7 @@ val get_token : t -> (string, [`Msg of string]) result Lwt.t
 (** [get_token t] returns the cached token for [t], or fetches a new one if it has expired. *)
 
 val rebuild_webhook : engine:Current.Engine.t
+                      -> get_job_ids:(owner:string -> name:string -> hash:string -> string list)
                       -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
                       -> Yojson.Safe.t -> unit
 (** Call this when we get a "check_run" webhook event. *)

--- a/plugins/github/current_github.ml
+++ b/plugins/github/current_github.ml
@@ -31,7 +31,7 @@ See https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-
         event signature request_signature in
     Error s
 
-let webhook ~engine ~webhook_secret ~has_role = object
+let webhook ~engine ~get_job_ids ~webhook_secret ~has_role = object
   inherit Current_web.Resource.t
 
   method! post_raw _site req body =
@@ -52,7 +52,7 @@ let webhook ~engine ~webhook_secret ~has_role = object
         | Some "installation_repositories" -> Installation.input_installation_repositories_webhook ()
         | Some "installation" -> App.input_installation_webhook ()
         | Some ("pull_request" | "push" | "create") -> Api.input_webhook json_body
-        | Some "check_run" -> Api.rebuild_webhook ~engine ~has_role json_body
+        | Some "check_run" -> Api.rebuild_webhook ~engine ~get_job_ids ~has_role json_body
         | Some x -> Log.warn (fun f -> f "Unknown GitHub event type %S" x)
         | None -> Log.warn (fun f -> f "Missing GitHub event type in webhook!")
       end;

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -1,6 +1,7 @@
 (** Integration with GitHub. *)
 
 val webhook : engine:Current.Engine.t
+              -> get_job_ids:(owner:string -> name:string -> hash:string -> string list)
               -> webhook_secret:string
               -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
               -> Current_web.Resource.t
@@ -15,6 +16,10 @@ val webhook : engine:Current.Engine.t
 Webhook payloads are validated against [webhook_secret].
 
 See {{:https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks}}
+
+Note that the endpoint is supplied with a callback `get_job_ids.` This is used to determine what job_ids correspond to a commit.
+The checks API specifies the repository and the commit (that the action is being requested against) - this callback is
+used to determine what jobs to apply the action to.
  *)
 
 (** Identifier for a repository hosted on GitHub. *)
@@ -141,7 +146,7 @@ module Api : sig
       title: string;
       bodyHTML: string;
     }
-    
+
     type t = [ `Ref of string | `PR of pr_info ]
 
     type id = [ `Ref of string | `PR of int ]


### PR DESCRIPTION
Threading a callback through the rebuild machinery so that ocurrent can get to the job_ids that pertain to a commit. These can then be rebuilt.

Ref https://github.com/ocurrent/ocaml-ci/issues/97