### PR TITLE
Add build context parameter to docker build

### DIFF
--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -19,7 +19,7 @@ module Raw = struct
 
   module BC = Current_cache.Make(Build)
 
-  let build ~docker_context ?level ?schedule ?timeout ?(squash=false) ?dockerfile ?pool ?(build_args=[]) ~pull commit =
+  let build ~docker_context ?level ?schedule ?timeout ?(squash=false) ?dockerfile ?path ?pool ?(build_args=[]) ~pull commit =
     let dockerfile =
       match dockerfile with
       | None -> `File (Fpath.v "Dockerfile")
@@ -27,7 +27,7 @@ module Raw = struct
       | Some (`Contents c) -> `Contents c
     in
     BC.get ?schedule { Build.pull; pool; timeout; level }
-      { Build.Key.commit; dockerfile; docker_context; squash; build_args }
+    { Build.Key.commit; dockerfile; docker_context; squash; build_args; path }
 
   module RC = Current_cache.Make(Run)
 
@@ -144,11 +144,11 @@ module Make (Host : S.HOST) = struct
     | `No_context -> Current.return `No_context
     | `Git commit -> Current.map (fun x -> `Git x) commit
 
-  let build ?level ?schedule ?timeout ?squash ?label ?dockerfile ?pool ?build_args ~pull src =
+  let build ?level ?schedule ?timeout ?squash ?label ?dockerfile ?path ?pool ?build_args ~pull src =
     Current.component "build%a" pp_sp_label label |>
     let> commit = get_build_context src
     and> dockerfile = Current.option_seq dockerfile in
-    Raw.build ~docker_context ?level ?schedule ?timeout ?squash ?dockerfile ?pool ?build_args ~pull commit
+    Raw.build ~docker_context ?level ?schedule ?timeout ?squash ?dockerfile ?path ?pool ?build_args ~pull commit
 
   let run ?label ?pool ?run_args image ~args  =
     Current.component "run%a" pp_sp_label label |>

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -38,6 +38,7 @@ module Raw : sig
     ?timeout:Duration.t ->
     ?squash:bool ->
     ?dockerfile:[`File of Fpath.t | `Contents of string] ->
+    ?path:Fpath.t ->
     ?pool:unit Current.Pool.t ->
     ?build_args:string list ->
     pull:bool ->

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -56,7 +56,8 @@ module type DOCKER = sig
       @param dockerfile If present, this is used as the contents of the Dockerfile.
       @param pull If [true], always check for updates and pull the latest version.
       @param pool Rate limit builds by requiring a resource from the pool.
-      @param path The relative file path passed to the docker build command as the build context. *)
+      @param path The relative file path passed to the docker build command as the build context.
+                  No checks are done over the path: it can point anywhere outside the build directory. *)
 
   val run :
     ?label:string ->

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -44,6 +44,7 @@ module type DOCKER = sig
     ?squash:bool ->
     ?label:string ->
     ?dockerfile:[`File of Fpath.t | `Contents of string] Current.t ->
+    ?path:Fpath.t ->
     ?pool:unit Current.Pool.t ->
     ?build_args:string list ->
     pull:bool ->
@@ -54,7 +55,8 @@ module type DOCKER = sig
       @param squash If set to [true], pass "--squash" to "docker build".
       @param dockerfile If present, this is used as the contents of the Dockerfile.
       @param pull If [true], always check for updates and pull the latest version.
-      @param pool Rate limit builds by requiring a resource from the pool. *)
+      @param pool Rate limit builds by requiring a resource from the pool.
+      @param path The relative file path passed to the docker build command as the build context. *)
 
   val run :
     ?label:string ->


### PR DESCRIPTION
Currently the `Current_docker.Default.build` function allows a user to specify the relative path to a Dockerfile from the Git src, but there's no way as far as I can tell to specify the build context path. So if I have a Dockerfile in `src` that assumes the build context is `src` I can't run a build in that context.

The current implementation does potentially allow a user to escape the build directory though. I don't know if this is too much of a problem if the user is always specifying this path and maybe it is up to the user to check the `~path` variable is not trying to do something bad?