### PR TITLE
Refactor and add support for check-suite events.

### DIFF
--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -115,10 +115,11 @@ val get_token : t -> (string, [`Msg of string]) result Lwt.t
 (** [get_token t] returns the cached token for [t], or fetches a new one if it has expired. *)
 
 val rebuild_webhook : engine:Current.Engine.t
+                      -> event:(Webhook_event.checks_api_event)
                       -> get_job_ids:(owner:string -> name:string -> hash:string -> string list)
                       -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
                       -> Yojson.Safe.t -> unit
-(** Call this when we get a "check_run" webhook event. *)
+(** Call this when we get a "check_run" or "check_suite" webhook event. *)
 
 val input_webhook : Yojson.Safe.t -> unit
 (** Call this when we get a "pull_request", "push" or "create" webhook event. *)

--- a/plugins/github/webhook_event.ml
+++ b/plugins/github/webhook_event.ml
@@ -1,0 +1,28 @@
+type t = [
+    `CheckRun
+  | `CheckSuite
+  | `PullRequest
+  | `Push
+  | `Create
+  | `Installation
+  | `InstallationRepositories
+  ]
+
+type checks_api_event = [ `Run | `Suite ]
+
+let checks_api_event_to_string = function
+  | `Run -> "check_run"
+  | `Suite -> "check_suite"
+
+let validate event =
+  begin match event with
+    | Some "installation_repositories" -> Ok `InstallationRepositories
+    | Some "installation" -> Ok `Installation
+    | Some "pull_request" -> Ok `PullRequest
+    | Some "push" -> Ok `Push
+    | Some "create" -> Ok `Create
+    | Some "check_run" -> Ok `CheckRun
+    | Some "check_suite" -> Ok `CheckSuite
+    | Some x -> Error (Fmt.str "Unknown GitHub event type %S" x)
+    | None -> Error "Missing GitHub event type in webhook!"
+  end

--- a/plugins/github/webhook_event.mli
+++ b/plugins/github/webhook_event.mli
@@ -1,0 +1,18 @@
+(** The Github webhook-events that are supported *)
+type t =
+    [ `CheckRun
+    | `CheckSuite
+    | `Create
+    | `Installation
+    | `InstallationRepositories
+    | `PullRequest
+    | `Push ]
+
+type checks_api_event = [ `Run | `Suite ]
+(** events specific to the checks-api *)
+
+val checks_api_event_to_string : checks_api_event -> string
+(** convert checks_api_event variant into string representation *)
+
+val validate : string option -> (t, string) result
+(** convert string into supported webhook-event variant *)


### PR DESCRIPTION
The refactoring was motivated by wanting to express (in types and not strings) that `rebuild_webhook` only supports events `check_run` and `check_suite.` I ended up constructing sum types to encode various things ... hopefully I have not gone way off the OCaml idioms :)