### PR TITLE
Remove the role check for webhooks.

### DIFF
--- a/doc/examples/github.ml
+++ b/doc/examples/github.ml
@@ -59,7 +59,7 @@ let main config mode github repo =
   (* this example does not have support for looking up job_ids for a commit *)
   let get_job_ids = (fun ~owner:_owner ~name:_name ~hash:_hash -> []) in
   let routes =
-    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~get_job_ids ~webhook_secret:(Github.Api.webhook_secret github) ~has_role) ::
+    Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~get_job_ids ~webhook_secret:(Github.Api.webhook_secret github)) ::
     Current_web.routes engine
   in
   let site = Current_web.Site.(v ~has_role) ~name:program_name routes in

--- a/doc/examples/github_app.ml
+++ b/doc/examples/github_app.ml
@@ -79,7 +79,7 @@ let main config mode app =
     (* this example does not have support for looking up job_ids for a commit *)
     let get_job_ids = (fun ~owner:_owner ~name:_name ~hash:_hash -> []) in
     let routes =
-      Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~get_job_ids ~webhook_secret ~has_role) ::
+      Routes.(s "webhooks" / s "github" /? nil @--> Github.webhook ~engine ~get_job_ids ~webhook_secret) ::
       Current_web.routes engine
     in
     let site = Current_web.Site.(v ~has_role) ~name:program_name routes in

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -30,7 +30,7 @@ let lookup_actions ~engine job_id =
        method rebuild = None
      end
 
-let rebuild_webhook ~engine ~event ~get_job_ids ~has_role json =
+let rebuild_webhook ~engine ~event ~get_job_ids json =
   (* Check that the event that has been passed in is supported *)
   let event_str = match event with
   | `Suite -> "check_suite"
@@ -47,8 +47,8 @@ let rebuild_webhook ~engine ~event ~get_job_ids ~has_role json =
   Log.info (fun f -> f "rebuild webhook -- event: %s action: %s" event_str action);
   Log.info (fun f -> f "rebuild_webhook %s external_id: %s, commit: %s, owner/name: %s -- triggered by %s"
               action job_id commit full_name (Current_web.User.id requester));
-  match (action, has_role (Some requester) `Builder) with
-  | ("rerequested", true) -> begin
+  match (action) with
+  | "rerequested" -> begin
       let actions = lookup_actions ~engine job_id in
       match actions#rebuild with
       | Some rebuild ->

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -117,7 +117,6 @@ val get_token : t -> (string, [`Msg of string]) result Lwt.t
 val rebuild_webhook : engine:Current.Engine.t
                       -> event:(Webhook_event.checks_api_event)
                       -> get_job_ids:(owner:string -> name:string -> hash:string -> string list)
-                      -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
                       -> Yojson.Safe.t -> unit
 (** Call this when we get a "check_run" or "check_suite" webhook event. *)
 

--- a/plugins/github/current_github.ml
+++ b/plugins/github/current_github.ml
@@ -33,7 +33,7 @@ See https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-
     Error s
 
 
-let webhook ~engine ~get_job_ids ~webhook_secret ~has_role = object
+let webhook ~engine ~get_job_ids ~webhook_secret = object
   inherit Current_web.Resource.t
 
   method! post_raw _site req body =
@@ -60,7 +60,7 @@ let webhook ~engine ~get_job_ids ~webhook_secret ~has_role = object
             let c : Webhook_event.checks_api_event =
               if event_v = Ok `CheckRun then `Run else `Suite
             in
-            Api.rebuild_webhook ~engine ~event:c ~get_job_ids ~has_role json_body
+            Api.rebuild_webhook ~engine ~event:c ~get_job_ids json_body
       end;
       Cohttp_lwt_unix.Server.respond_string ~status:`OK ~body:"OK" ()
 end

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -3,7 +3,6 @@
 val webhook : engine:Current.Engine.t
               -> get_job_ids:(owner:string -> name:string -> hash:string -> string list)
               -> webhook_secret:string
-              -> has_role:(Current_web.User.t option -> Current_web.Role.t -> bool)
               -> Current_web.Resource.t
 (** GitHub webhook endpoint. This MUST be added to {!Current_web.routes} so that we get notified of events. This webhook handles the events:
  - installation_repositories
@@ -12,6 +11,7 @@ val webhook : engine:Current.Engine.t
  - push
  - create
  - check_run
+ - check_suite
 
 Webhook payloads are validated against [webhook_secret].
 
@@ -20,6 +20,9 @@ See {{:https://docs.github.com/en/developers/webhooks-and-events/webhooks/securi
 Note that the endpoint is supplied with a callback `get_job_ids.` This is used to determine what job_ids correspond to a commit.
 The checks API specifies the repository and the commit (that the action is being requested against) - this callback is
 used to determine what jobs to apply the action to.
+
+Permissions are managed by the checks API so that re-runs can only be requested by anyone with write
+permission to a repository.
  *)
 
 (** Identifier for a repository hosted on GitHub. *)


### PR DESCRIPTION
Rationale: After deploying the check_run/suite work, we found that even though GitHub will only show a re-run button if you have write permissions to a repository, there is an additional check in the code on our end that ignores webhook requests unless they are from a member of a hard-coded list. This PR removes that restriction. 