### PR TITLE
Added compose_cli.ml

### DIFF
--- a/plugins/docker/compose_cli.ml
+++ b/plugins/docker/compose_cli.ml
@@ -8,6 +8,7 @@ module Key = struct
   type t = {
     name : string;
     docker_context : string option;
+    detach : bool;
   } [@@deriving to_yojson]
 
   let digest t = Yojson.Safe.to_string (to_yojson t)
@@ -26,10 +27,10 @@ end
 
 module Outcome = Current.Unit
 
-let cmd args { Key.docker_context; name } =
+let cmd args { Key.docker_context; name; _ } =
   Cmd.docker ~docker_context (["compose"; "-f"; "/dev/stdin"; "-p"; name ] @ args)
 
-let cmd_update = cmd ["up"]
+let cmd_update ({ Key.detach; _ } as key) = cmd ("up" :: if detach then ["-d"] else []) key
 
 let publish No_context job key {Value.contents} =
   Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->

--- a/plugins/docker/compose_cli.ml
+++ b/plugins/docker/compose_cli.ml
@@ -1,0 +1,41 @@
+open Lwt.Infix
+
+type t = No_context
+
+let id = "docker-compose-cli"
+
+module Key = struct
+  type t = {
+    name : string;
+    docker_context : string option;
+  } [@@deriving to_yojson]
+
+  let digest t = Yojson.Safe.to_string (to_yojson t)
+end
+
+module Value = struct
+  type t = {
+    contents: string;
+  }
+
+  let digest { contents } =
+    Yojson.Safe.to_string @@ `Assoc [
+      "contents", `String contents
+    ]
+end
+
+module Outcome = Current.Unit
+
+let cmd args { Key.docker_context; name } =
+  Cmd.docker ~docker_context (["compose"; "-f"; "/dev/stdin"; "-p"; name ] @ args)
+
+let cmd_update = cmd ["up"]
+
+let publish No_context job key {Value.contents} =
+  Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->
+  Current.Process.exec ~stdin:contents ~cancellable:true ~job (cmd_update key)
+
+let pp f (key, { Value.contents }) =
+  Fmt.pf f "%a@.@[%a@]" Cmd.pp (cmd_update key) Fmt.string contents
+
+let auto_cancel = false

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -61,8 +61,8 @@ module Raw = struct
 
   module CCC = Current_cache.Output(Compose_cli)
 
-  let compose_cli ~docker_context ~name ~contents () =
-    CCC.set Compose_cli.No_context { Compose_cli.Key.name; docker_context } { Compose_cli.Value.contents }
+  let compose_cli ~docker_context ~name ~detach ~contents () =
+    CCC.set Compose_cli.No_context { Compose_cli.Key.name; docker_context; detach } { Compose_cli.Value.contents }
 
   module Cmd = struct
     open Lwt.Infix
@@ -180,10 +180,10 @@ module Make (Host : S.HOST) = struct
     let> contents = contents in
     Raw.compose ~docker_context ~name ~contents ()
 
-  let compose_cli ~name ~contents () =
+  let compose_cli ~name ~detach ~contents () =
     Current.component "docker-compose-cli@,%s" name |>
     let> contents = contents in
-    Raw.compose_cli ~docker_context ~name ~contents ()
+    Raw.compose_cli ~docker_context ~name ~detach ~contents ()
 end
 
 module Default = Make(struct

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -59,6 +59,11 @@ module Raw = struct
   let compose ~docker_context ~name ~contents () =
     CC.set Compose.No_context { Compose.Key.name; docker_context } { Compose.Value.contents }
 
+  module CCC = Current_cache.Output(Compose_cli)
+
+  let compose_cli ~docker_context ~name ~contents () =
+    CCC.set Compose_cli.No_context { Compose_cli.Key.name; docker_context } { Compose_cli.Value.contents }
+
   module Cmd = struct
     open Lwt.Infix
 
@@ -174,6 +179,11 @@ module Make (Host : S.HOST) = struct
     Current.component "docker-compose@,%s" name |>
     let> contents = contents in
     Raw.compose ~docker_context ~name ~contents ()
+
+  let compose_cli ~name ~contents () =
+    Current.component "docker-compose-cli@,%s" name |>
+    let> contents = contents in
+    Raw.compose_cli ~docker_context ~name ~contents ()
 end
 
 module Default = Make(struct

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -78,6 +78,7 @@ module Raw : sig
   val compose_cli :
     docker_context:string option ->
     name:string ->
+    detach:bool ->
     contents:string -> unit -> unit Current.Primitive.t
 
   (** Building Docker commands. *)

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -75,6 +75,11 @@ module Raw : sig
     name:string ->
     contents:string -> unit -> unit Current.Primitive.t
 
+  val compose_cli :
+    docker_context:string option ->
+    name:string ->
+    contents:string -> unit -> unit Current.Primitive.t
+
   (** Building Docker commands. *)
   module Cmd : sig
     type t = Lwt_process.command

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -88,6 +88,10 @@ module type DOCKER = sig
   val compose : name:string -> contents:string Current.t -> unit -> unit Current.t
   (** [service ~name ~image ~contents ()] keeps a Docker Compose deployment up-to-date.
       [contents] contains the full Compose Yaml file. *)
+
+  val compose_cli : name:string -> contents:string Current.t -> unit -> unit Current.t
+  (** [service ~name ~image ~contents ()] keeps a Docker Compose Cli deployment up-to-date.
+      [contents] contains the full Compose Yaml file. *)
 end
 
 module type HOST = sig

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -87,11 +87,13 @@ module type DOCKER = sig
 
   val compose : name:string -> contents:string Current.t -> unit -> unit Current.t
   (** [service ~name ~image ~contents ()] keeps a Docker Compose deployment up-to-date.
-      [contents] contains the full Compose Yaml file. *)
+      [contents] contains the full Compose Yaml file.
+      This calls `docker-compose` version 1 which as of April 2022 is deprecated in favour of version 2 *)
 
-  val compose_cli : name:string -> contents:string Current.t -> unit -> unit Current.t
-  (** [service ~name ~image ~contents ()] keeps a Docker Compose Cli deployment up-to-date.
-      [contents] contains the full Compose Yaml file. *)
+  val compose_cli : name:string -> detach:bool -> contents:string Current.t -> unit -> unit Current.t
+  (** [service ~name ~image ~detach ~contents ()] keeps a Docker Compose Cli deployment up-to-date.
+      [contents] contains the full Compose Yaml file.
+      This calls `docker compose` which is GA as of April 2022 and should be used in preferance over version 1 *)
 end
 
 module type HOST = sig


### PR DESCRIPTION
This PR adds support for [Docker Compose V2](https://docs.docker.com/compose/reference/).

> Compose V2 supports the `compose` command as part of the Docker CLI.
> Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous `docker-compose` features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using `docker compose`, instead of `docker-compose`.

Compose CLI V2 is needed to support Amazon Elastic Container Service (ECS) as a target for `docker compose up`

For further information see the Docker documentation [here](https://docs.docker.com/cloud/ecs-integration/)
