### PR TITLE
Add Current.observe to inspect the state of a term

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### dev
+
+API:
+
+- Add `Current_term.observe` to evaluate the current state of a term. (@TheLortex, #374)
+
 ### v0.6.4 (2023-02-27)
 
 API:

--- a/lib_term/current_term.ml
+++ b/lib_term/current_term.ml
@@ -323,6 +323,15 @@ module Make (Metadata : sig type t end) = struct
     Quick_stats.update ~id x;
     node ~id (Constant None) @@ Current_incr.const x
 
+  let observe t =
+    let v = Current_incr.observe t.v in
+    match v with
+    | Error (id, `Msg e) when Id.equal id t.id ->
+      Error (`Msg e)
+    | Error (_, `Active e) -> Error (`Active e)
+    | Error (_, `Msg _) -> Error `Blocked
+    | Ok v -> Ok v
+
   module Executor = struct
     let run (t : 'a t) = Current_incr.map Dyn.run t.v
   end

--- a/lib_term/output.ml
+++ b/lib_term/output.ml
@@ -10,3 +10,16 @@ let pp ok f = function
   | Error (`Active `Running) -> Fmt.string f "Running"
   | Error (`Active `Waiting_for_confirmation) -> Fmt.string f "Waiting for confirmation"
   | Error (`Msg e) -> Fmt.pf f "Error: %s" e
+
+module Blockable = struct
+
+  type 'a t = ('a, [`Active of active | `Msg of string | `Blocked]) result
+  [@@deriving eq]
+
+  let pp ok f = function
+    | Ok x -> pp ok f (Ok x)
+    | Error (`Active v) -> pp ok f (Error (`Active v))
+    | Error (`Msg e) -> pp ok f (Error (`Msg e))
+    | Error `Blocked -> Fmt.string f "Blocked"
+
+end

--- a/lib_term/output.mli
+++ b/lib_term/output.mli
@@ -5,3 +5,13 @@ type 'a t = ('a, [`Active of active | `Msg of string]) result
   [@@deriving eq]
 
 val pp : 'a Fmt.t -> ('a, [< `Active of active | `Msg of string]) result Fmt.t
+
+module Blockable : sig
+
+  type 'a t = ('a, [`Active of active | `Msg of string | `Blocked]) result
+  [@@deriving eq]
+
+  val pp : 'a Fmt.t -> 
+    ('a, [< `Active of active | `Msg of string | `Blocked]) result Fmt.t
+
+end

--- a/lib_term/s.ml
+++ b/lib_term/s.ml
@@ -225,6 +225,10 @@ module type TERM = sig
       as the label for the bind in the generated dot diagrams.
       For convenience, [name] can also be a format string. *)
 
+  val observe : 'a t -> 'a Output.Blockable.t
+  (** [observe x] evaluates the current state of term [x]. A [`Blocked] value
+      occurs when the term failed because an upstream dependency errored. *)
+
   module Syntax : sig
     (** {1 Applicative syntax} *)
 


### PR DESCRIPTION
This PR adds a function to enable looking at an ocurrent node's state.

I have extended the `'a Current.Output.t` result type to provide an additional `` `Blocked`` error state, happening when the node has failed because an upstream dependency failed. 

There are some tests to demonstrate the 4 possible cases. 