### PR TITLE
Added ref_title accessor for commits (ocaml-ci)

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -338,7 +338,7 @@ module Commit_id = struct
       match Astring.String.cuts ~sep:"/" gref with
       | "refs" :: "heads" :: branch ->
         Some (Astring.String.concat ~sep:"/" branch)
-      | _ -> Some gref)
+      | _ -> None)
     | `PR _ -> None
 end
 

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -327,14 +327,19 @@ module Commit_id = struct
 
   let digest t = Yojson.Safe.to_string (to_yojson t)
 
-  let ref_title t =
+  let pr_name t =
+    match t.id with
+    | `Ref _ -> None
+    | `PR { title; _ } -> Some title
+
+  let branch_name t =
     match t.id with
     | `Ref gref -> (
-        match Astring.String.cuts ~sep:"/" gref with
-        | "refs" :: "heads" :: branch ->
-          Astring.String.concat ~sep:"/" branch
-        | _ -> gref)
-    | `PR { title; _ } -> title
+      match Astring.String.cuts ~sep:"/" gref with
+      | "refs" :: "heads" :: branch ->
+        Some (Astring.String.concat ~sep:"/" branch)
+      | _ -> Some gref)
+    | `PR _ -> None
 end
 
 module Repo_key = struct
@@ -921,7 +926,9 @@ module Commit = struct
     and> status = status in
     Set_status_cache.set t {Set_status.Key.commit; context} status
 
-  let ref_title (_, id) = Commit_id.ref_title id
+  let pr_name (_, id) = Commit_id.pr_name id
+
+  let branch_name (_, id) = Commit_id.branch_name id
 end
 
 module Repo = struct

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -326,6 +326,15 @@ module Commit_id = struct
     Fmt.pf f "%s/%s@ %s" owner repo (Astring.String.with_range ~len:8 hash)
 
   let digest t = Yojson.Safe.to_string (to_yojson t)
+
+  let ref_title t =
+    match t.id with
+    | `Ref gref -> (
+        match Astring.String.cuts ~sep:"/" gref with
+        | "refs" :: "heads" :: branch ->
+          Astring.String.concat ~sep:"/" branch
+        | _ -> gref)
+    | `PR { title; _ } -> title
 end
 
 module Repo_key = struct
@@ -911,6 +920,8 @@ module Commit = struct
     let> (t, commit) = commit
     and> status = status in
     Set_status_cache.set t {Set_status.Key.commit; context} status
+
+  let ref_title (_, id) = Commit_id.ref_title id
 end
 
 module Repo = struct

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -31,7 +31,8 @@ module Commit : sig
   val compare : t -> t -> int
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
   val uri : t -> Uri.t
-  val ref_title : t -> string
+  val pr_name : t -> string option
+  val branch_name : t -> string option
 end
 
 

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -31,6 +31,7 @@ module Commit : sig
   val compare : t -> t -> int
   val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t
   val uri : t -> Uri.t
+  val ref_title : t -> string
 end
 
 

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -117,6 +117,9 @@ module Api : sig
 
     val uri : t -> Uri.t
     (** [uri t] is a URI for the GitHub web page showing [t]. *)
+
+    val ref_title : t -> string
+    (** [ref_title t] is the title of the ref that the commit belongs to, either branch or PR *)
   end
 
   module CheckRun : sig

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -118,8 +118,11 @@ module Api : sig
     val uri : t -> Uri.t
     (** [uri t] is a URI for the GitHub web page showing [t]. *)
 
-    val ref_title : t -> string
-    (** [ref_title t] is the title of the ref that the commit belongs to, either branch or PR *)
+    val pr_name : t -> string option
+    (** [pr_name t] is the name of the ref that the commit belongs to if it is a PR, and None if it is a branch *)
+
+    val branch_name : t -> string option
+    (** [branch_name t] is the name of the ref that the commit belongs to if it is a branch, and None if it is a PR *)
   end
 
   module CheckRun : sig


### PR DESCRIPTION
Currently the ref title of a commit is not exposed, which is necessary for displaying the list of refs retrieved for a repository via the `ci_refs` function for display in the ocaml-ci web UI. This adds an accessor for that field.

Note: while the gref is already provided which allows us to derive the title for a branch ('refs/heads/[title]'), this doesn't work for PRs which are identified by the ID number ('refs/pull/[id]/head'), thus necessitating the change.