### PR TITLE
Added ci_refs_with_default (ocaml-ci)

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -700,13 +700,18 @@ let to_ci_refs ?staleness refs =
   |> List.map snd
   |> remove_stale ?staleness ~default_ref:refs.default_ref
 
+let collect_ci_refs t repo =
+  Current.component "%a CI refs" Repo_id.pp repo |>
+  let> () = Current.return () in
+  refs t repo
+
 let ci_refs ?staleness t repo =
-  let+ refs =
-    Current.component "%a CI refs" Repo_id.pp repo |>
-    let> () = Current.return () in
-    refs t repo
-  in
+  let+ refs = collect_ci_refs t repo in
   to_ci_refs ?staleness refs
+
+let ci_refs_with_default ?staleness t repo =
+  let+ refs = collect_ci_refs t repo in
+  (to_ci_refs ?staleness refs, default_ref refs)
 
 let head_of t repo (id: Ref.id) =
   Current.component "%a@,%a" Repo_id.pp repo Ref.pp_id id |>

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -69,6 +69,7 @@ val webhook_secret : t -> string
 val all_refs : refs -> Commit.t Ref_map.t
 val head_of : t -> Repo_id.t -> Ref.id -> Commit.t Current.t
 val ci_refs : ?staleness:Duration.t -> t -> Repo_id.t -> Commit.t list Current.t
+val ci_refs_with_default : ?staleness:Duration.t -> t -> Repo_id.t -> (Commit.t list * string) Current.t
 val cmdliner : t Cmdliner.Term.t
 val cmdliner_opt : t option Cmdliner.Term.t
 val webhook_secret_file : string Cmdliner.Term.t


### PR DESCRIPTION
If we get the default ref by calling `refs t repo |> default_ref` then we will unnecessarily duplicate calls to the GitHub API, this PR allows them to be aggregated.