### PR TITLE
Shorten the PR labels

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -319,8 +319,8 @@ module Commit_id = struct
       end
     | x -> x
 
-  let pp f { owner; repo; id; hash; committed_date; message } =
-    Fmt.pf f "%s/%s@ %a@ %s@ %s (%s)" owner repo pp_id id (Astring.String.with_range ~len:8 hash) committed_date message
+  let pp f { owner; repo; id; hash; committed_date = _; message = _ } =
+    Fmt.pf f "%s/%s@ %a@ %s" owner repo pp_id id (Astring.String.with_range ~len:8 hash)
 
   let pp_short f { owner; repo; hash; _ } =
     Fmt.pf f "%s/%s@ %s" owner repo (Astring.String.with_range ~len:8 hash)


### PR DESCRIPTION
Having the body of the PR in the label makes it very hard to work with the admin interface of ocurrent. For example:

![scrn-2022-12-20-13-17-24](https://user-images.githubusercontent.com/2611789/208684311-407fc057-0e7b-4d76-8a4e-19c334f7c85c.png)