### PR TITLE
Expose refresh pipeline timer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### unreleased
+
+Web UI:
+
+- Allow controlling and disabling the refresh timer for pipelines
+  graphs and job page (@MisterDA, #398, #400)
+
 ### v0.6.3
 
 Web UI:
@@ -41,7 +48,7 @@ Other:
 Web UI:
 
 - Update prometheus-app to support version 1.2.
- 
+
 Plugins:
 
 - GitLab plugin depend on ocaml-gitlab >= "0.1.4" to include bugfixes.

--- a/lib_web/current_web.mli
+++ b/lib_web/current_web.mli
@@ -46,12 +46,16 @@ module Site : sig
     ?name:string ->
     ?authn:(csrf:string -> Uri.t) ->
     ?secure_cookies:bool ->
+    ?refresh_pipeline:int ->
     has_role:(User.t option -> Role.t -> bool) ->
     raw_resource Routes.route list -> t
   (** [v ~name ~authn ~has_role routes] is a site named [name] (used for the HTML title, etc)
       that uses [authn] to authenticate users and [has_role] to control what they can do.
       @param authn A link to a login page.
-      @param secure_cookies Set secure cookie attribute (turn on if public site uses https). *)
+      @param secure_cookies Set secure cookie attribute (turn on if public site uses https).
+      @param refresh_pipeline Refresh the pipeline graphs and jobs page each
+        [refresh_pipeline] seconds. Defaults to never.
+   *)
 end
 
 module Context : sig

--- a/lib_web/jobs.ml
+++ b/lib_web/jobs.ml
@@ -22,7 +22,7 @@ let r = object
 
   method! private get ctx =
     let jobs = Current.Job.jobs () in
-    Context.respond_ok ctx ~refresh:60 (
+    Context.respond_ok ctx ?refresh:ctx.site.refresh_pipeline (
       if Current.Job.Map.is_empty jobs then [
         txt "There are no active jobs."
       ] else [

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -37,8 +37,7 @@ let r ~engine = object
     let { Current.Engine.value; jobs = _ } = Current.Engine.state engine in
     let verbatim_query = Uri.verbatim_query uri in
     let path = "/pipeline.svg?" ^ (Option.value verbatim_query ~default:"") in
-    let refresh = Option.(map (fun _ -> ctx.site.refresh_pipeline) verbatim_query |> join) in
-    Context.respond_ok ctx ?refresh [
+    Context.respond_ok ctx ?refresh:ctx.site.refresh_pipeline [
       div [
         object_ ~a:[a_data path] [txt "Pipeline diagram"];
       ];

--- a/lib_web/main.ml
+++ b/lib_web/main.ml
@@ -37,7 +37,7 @@ let r ~engine = object
     let { Current.Engine.value; jobs = _ } = Current.Engine.state engine in
     let verbatim_query = Uri.verbatim_query uri in
     let path = "/pipeline.svg?" ^ (Option.value verbatim_query ~default:"") in
-    let refresh = Option.map (fun _ -> 60) verbatim_query in
+    let refresh = Option.(map (fun _ -> ctx.site.refresh_pipeline) verbatim_query |> join) in
     Context.respond_ok ctx ?refresh [
       div [
         object_ ~a:[a_data path] [txt "Pipeline diagram"];

--- a/lib_web/site.ml
+++ b/lib_web/site.ml
@@ -17,13 +17,14 @@ type t = {
   session_backend : Sess.backend;
   router : t raw Routes.router;
   nav_links : (string * string) list;   (* Label, path *)
+  refresh_pipeline : int option;
 }
 
 class type raw_resource = [t] raw
 
 let allow_all _ _ = true
 
-let v ?(name="OCurrent") ?authn ?(secure_cookies=false) ~has_role routes =
+let v ?(name="OCurrent") ?authn ?(secure_cookies=false) ?refresh_pipeline ~has_role routes =
   let db = Lazy.force Current.Db.v in
   let router = Routes.one_of routes in
   let nav_links = routes |> List.filter_map (fun route ->
@@ -38,4 +39,5 @@ let v ?(name="OCurrent") ?authn ?(secure_cookies=false) ~has_role routes =
         Option.map (fun label -> (label, target)) resource#nav_link
       )
     ) in
-  { name; authn; has_role; secure_cookies; session_backend = Sqlite_session.create db; router; nav_links }
+  { name; authn; has_role; secure_cookies; session_backend = Sqlite_session.create db;
+    router; nav_links; refresh_pipeline }


### PR DESCRIPTION
Applications can now set or disable this timer. Fixes #398. The timer is disabled by default, so I'll re-enable it in applications (the deployer and ocaml-ci-local).