### PR TITLE
Github PRs: pulling labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Web UI:
 - Allow controlling and disabling the refresh timer for pipelines
   graphs and job page (@MisterDA, #398, #400)
 
+Plugins:
+
+- GitHub: Added information about labels in Api.Ref.pr_info (@ElectreAAS, #402)
+
 ### v0.6.3
 
 Web UI:

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -47,6 +47,7 @@ module Ref : sig
     id: int;
     base: string;
     title: string;
+    labels: string list;
     bodyHTML: string;
   }
   type t = [ `Ref of string | `PR of pr_info ]

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -153,6 +153,7 @@ module Api : sig
       id: int;
       base: string;
       title: string;
+      labels: string list;
       bodyHTML: string;
     }
 


### PR DESCRIPTION
This PR allows `pr_info` to hold label information.