### PR TITLE
Gitlab 0.1.7 bugfix for de-serialising webhooks and projects.

### DIFF
--- a/current_gitlab.opam
+++ b/current_gitlab.opam
@@ -22,7 +22,7 @@ depends: [
   "yojson"
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dune" {>= "3.3"}
-  "gitlab-unix" {>= "0.1.4"}
+  "gitlab-unix" {>= "0.1.7"}
   "cmdliner" {>= "1.1.0"}
   "logs" {>= "0.7.0"}
   "ppx_deriving_yojson" {>= "3.6.1"}


### PR DESCRIPTION
Update when https://github.com/ocaml/opam-repository/pull/23221 is released.