### PR TITLE
Remove explicit tls dependency

### DIFF
--- a/current_github.opam
+++ b/current_github.opam
@@ -27,7 +27,6 @@ depends: [
   "mirage-crypto-pk"
   "hex" {>= "1.4.0"}
   "x509" {>= "0.10.0"}
-  "tls" {>= "0.11.0"}
   "dune" {>= "3.3"}
   "github-unix" {>= "4.4.0"}
   "astring" {>= "0.8.5"}

--- a/current_slack.opam
+++ b/current_slack.opam
@@ -16,7 +16,6 @@ depends: [
   "fmt" {>= "0.8.9"}
   "yojson"
   "lwt" {>= "5.6.1"}
-  "tls" {>= "0.12.0"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dune" {>= "3.3"}
   "logs" {>= "0.7.0"}


### PR DESCRIPTION
`tls` is already an implicit dependency, and the `lower-bound` linter find 0.12.5 without the explicit dependency, so all seems fine.