### PR TITLE
Fix `current_git` broken test

### DIFF
--- a/plugins/git/cmd.ml
+++ b/plugins/git/cmd.ml
@@ -39,6 +39,10 @@ let git ~cancellable ~job ?cwd ?config args =
   let cmd = Array.of_list ("git" :: config @ args) in
   Current.Process.exec ~cancellable ~job ("", cmd)
 
+(*  This command manipulates paths. It requires [protocol.file.allow=always] to
+    be set to make sure we can update the submodules.
+
+    Cf: https://git-scm.com/docs/git-config#Documentation/git-config.txt-protocolallow *)
 let git_clone ~cancellable ~job ~src dst =
     let config = [ "protocol.file.allow=always" ] in
     git ~config ~cancellable ~job ["clone"; "--recursive"; "-q"; src; Fpath.to_string dst]
@@ -76,6 +80,10 @@ let git_submodule_deinit ~cancellable ~job ~repo ~force ~all =
   in
   git ~cancellable ~job ~cwd:repo ("submodule" :: "deinit" :: flags)
 
+(*  This command manipulates paths. It requires [protocol.file.allow=always] to
+    be set to make sure we can update the submodules.
+
+    cf: https://git-scm.com/docs/git-config#Documentation/git-config.txt-protocolallow *)
 let git_submodule_update ~cancellable ~job ~repo ~init ~fetch =
   let config = [ "protocol.file.allow=always" ] in
   let flags = List.concat [

--- a/plugins/git/test/git_test.ml
+++ b/plugins/git/test/git_test.ml
@@ -33,7 +33,7 @@ module Cmd = struct
       with_file ~mode:Output file (fun cout -> Lwt_io.write_line cout content))
 
   let git ?cwd cmd =
-    let cmd = "git" :: cmd in
+    let cmd = "git" :: "-c" :: "protocol.file.allow=always" :: cmd in
     exec_or_fail ?cwd ~name:"git" cmd
 
   let git_with ?cwd ~path cmd =
@@ -82,8 +82,6 @@ let show_files commit =
 let init root =
   let cwd = Fpath.to_string root in
   let dir = "sub" in
-  Cmd.git ~cwd [ "config"; "--global"; "protocol.file.allow"; "always" ]
-  >>= fun () ->
   Cmd.mkdir ~cwd dir >>= fun () ->
   Cmd.git ~cwd [ "init"; "-q"; dir ] >>= fun () ->
   let file = "sub/file" in


### PR DESCRIPTION
This PR completes the fix for `current_git`. It moves the `protocol.file.always` inside the command instead of being in the global variable. It allows the users to run `current_git` even when the variable is not set.