### PR TITLE
Adopt the OCaml Code of Conduct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ API:
 Other:
 
 - Bump constraint to OCaml 4.12. (@MisterDA, #415)
+- Adopt the OCaml Code of Conduct (@tmcgilchrist)
 
 ### v0.6.4 (2023-02-27)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+ This project has adopted the [OCaml Code of Conduct](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md).
+
+ # Enforcement
+
+ This project follows the OCaml Code of Conduct
+ [enforcement policy](https://github.com/ocaml/code-of-conduct/blob/main/CODE_OF_CONDUCT.md#enforcement).


### PR DESCRIPTION
The OCaml Code of Conduct can be found in [ocaml/code-of-conduct](https://github.com/ocaml/code-of-conduct) and has been discussed [in this Discourse thread](https://discuss.ocaml.org/t/ocaml-community-code-of-conduct/10494).

It's been adopted in [ocaml/ocaml#11761](https://github.com/ocaml/ocaml/pull/11761), [ocaml/opam#5419](https://github.com/ocaml/opam/pull/5419), and [ocaml/dune#6875](https://github.com/ocaml/dune/pull/6875), and we propose adopting it for ocurrent/ocurrent as well.