### PR TITLE
Extend docker capabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 API:
 
 - Add `Current_term.observe` to evaluate the current state of a term. (@TheLortex, #374)
+- Add `up_args` to `Current_docker.compose_cli` (@maiste, #418)
+- Add support for `buildx` in `Current_docker.build` (@maiste, #418)
 
 Other:
 

--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -72,7 +72,7 @@ let with_context ~job context fn =
   | `Git commit -> Current_git.with_checkout ~job commit fn
 
 let build { pull; pool; timeout; level } job key =
-    let { Key.commit; docker_context; dockerfile; squash; buildx; build_args; path } = key in
+  let { Key.commit; docker_context; dockerfile; squash; buildx; build_args; path } = key in
   begin match dockerfile with
     | `Contents contents ->
       Current.Job.log job "@[<v2>Using Dockerfile:@,%a@]" Fmt.lines contents
@@ -97,11 +97,13 @@ let build { pull; pool; timeout; level } job key =
   let squash = if squash then ["--squash"] else [] in
   let buildx = if buildx then ["buildx"] else [] in
   let iidfile = Fpath.add_seg dir "docker-iid" in
-  let cmd = Cmd.docker ~docker_context @@ buildx @ ["build"] @
-                                          pull @ squash @ build_args @ file @
-                                          ["--iidfile";
-                                           Fpath.to_string iidfile; "--";
-                                           Fpath.to_string dir] in
+  let cmd = Cmd.docker ~docker_context (
+    buildx @ ["build"] @
+    pull @ squash @ build_args @ file @
+    ["--iidfile";
+     Fpath.to_string iidfile; "--";
+     Fpath.to_string dir])
+  in
   let pp_error_command f = Fmt.string f "Docker build" in
   Current.Process.exec ~cancellable:true ~pp_error_command ~job cmd >|= function
   | Error _ as e -> e

--- a/plugins/docker/compose_cli.ml
+++ b/plugins/docker/compose_cli.ml
@@ -1,17 +1,17 @@
 open Lwt.Infix
 
 type t = {
-    pull : bool ;
+  pull: bool ;
 }
 
 let id = "docker-compose-cli"
 
 module Key = struct
   type t = {
-    name : string;
-    docker_context : string option;
-    detach : bool;
-    up_args : string list;
+    name: string;
+    docker_context: string option;
+    detach: bool;
+    up_args: string list;
   } [@@deriving to_yojson]
 
   let digest t = Yojson.Safe.to_string (to_yojson t)
@@ -36,8 +36,8 @@ let cmd args { Key.docker_context; name; detach=_; up_args=_ } =
 let cmd_pull = cmd ["pull"]
 
 let cmd_update ({ Key.detach; up_args; _ } as key) =
-    let args = if detach then ["-d"] else [] @ up_args in
-    cmd ("up" :: args) key
+  let args = (if detach then ["-d"] else []) @ up_args in
+  cmd ("up" :: args) key
 
 let publish { pull } job key {Value.contents} =
   Current.Job.start job ~level:Current.Level.Dangerous >>= fun () ->

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -61,8 +61,8 @@ module Raw = struct
 
   module CCC = Current_cache.Output(Compose_cli)
 
-  let compose_cli ?(pull=true) ~docker_context ~name ~detach ~contents () =
-    CCC.set Compose_cli.{ pull } { Compose_cli.Key.name; docker_context; detach } { Compose_cli.Value.contents }
+  let compose_cli ?(pull=true) ?(up_args = []) ~docker_context ~name ~detach ~contents () =
+      CCC.set Compose_cli.{ pull } { Compose_cli.Key.name; docker_context; detach ; up_args } { Compose_cli.Value.contents }
 
   module Cmd = struct
     open Lwt.Infix
@@ -181,10 +181,10 @@ module Make (Host : S.HOST) = struct
     let> contents = contents in
     Raw.compose ?pull ~docker_context ~name ~contents ()
 
-  let compose_cli ?pull ~name ~detach ~contents () =
+  let compose_cli ?pull ?up_args ~name ~detach ~contents () =
     Current.component "docker-compose-cli@,%s" name |>
     let> contents = contents in
-    Raw.compose_cli ?pull ~docker_context ~name ~detach ~contents ()
+    Raw.compose_cli ?pull ?up_args ~docker_context ~name ~detach ~contents ()
 end
 
 module Default = Make(struct

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -62,7 +62,7 @@ module Raw = struct
   module CCC = Current_cache.Output(Compose_cli)
 
   let compose_cli ?(pull=true) ?(up_args = []) ~docker_context ~name ~detach ~contents () =
-      CCC.set Compose_cli.{ pull } { Compose_cli.Key.name; docker_context; detach ; up_args } { Compose_cli.Value.contents }
+     CCC.set Compose_cli.{ pull } { Compose_cli.Key.name; docker_context; detach ; up_args } { Compose_cli.Value.contents }
 
   module Cmd = struct
     open Lwt.Infix

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -37,6 +37,7 @@ module Raw : sig
     ?schedule:Current_cache.Schedule.t ->
     ?timeout:Duration.t ->
     ?squash:bool ->
+    ?buildx:bool ->
     ?dockerfile:[`File of Fpath.t | `Contents of string] ->
     ?path:Fpath.t ->
     ?pool:unit Current.Pool.t ->

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -79,10 +79,12 @@ module Raw : sig
 
   val compose_cli :
     ?pull:bool ->
+    ?up_args: string list ->
     docker_context:string option ->
     name:string ->
     detach:bool ->
-    contents:string -> unit -> unit Current.Primitive.t
+    contents:string ->
+    unit -> unit Current.Primitive.t
 
   (** Building Docker commands. *)
   module Cmd : sig

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -43,6 +43,7 @@ module type DOCKER = sig
     ?schedule:Current_cache.Schedule.t ->
     ?timeout:Duration.t ->
     ?squash:bool ->
+    ?buildx:bool ->
     ?label:string ->
     ?dockerfile:[`File of Fpath.t | `Contents of string] Current.t ->
     ?path:Fpath.t ->
@@ -54,6 +55,7 @@ module type DOCKER = sig
   (** [build ~pull src] builds a Docker image from source.
       @param timeout If set, abort builds that take longer than this.
       @param squash If set to [true], pass "--squash" to "docker build".
+      @param build If set to [true], runs with "docker buildx build" instead of "docker build".
       @param dockerfile If present, this is used as the contents of the Dockerfile.
       @param pull If [true], always check for updates and pull the latest version.
       @param pool Rate limit builds by requiring a resource from the pool.

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -90,15 +90,21 @@ module type DOCKER = sig
   (** [service ~name ~image ()] keeps a Docker SwarmKit service up-to-date. *)
 
   val compose : ?pull:bool -> name:string -> contents:string Current.t -> unit -> unit Current.t
-  (** [service ?pull ~name ~image ~contents ()] keeps a Docker Compose deployment up-to-date.
+  (** [compose ?pull ~name ~image ~contents ()] keeps a Docker Compose deployment up-to-date.
       [contents] contains the full Compose Yaml file.
       @param pull Controls whether images are pulled by the compose command, the default is [true] 
       This calls `docker-compose` version 1 which as of April 2022 is deprecated in favour of version 2 *)
 
-  val compose_cli : ?pull:bool -> name:string -> detach:bool -> contents:string Current.t -> unit -> unit Current.t
-  (** [service ~name ~image ~contents ()] keeps a Docker Compose Cli deployment up-to-date.
+  val compose_cli :
+    ?pull:bool ->
+    ?up_args: string list ->
+    name:string ->
+    detach:bool ->
+    contents:string Current.t ->
+    unit -> unit Current.t
+  (** [compose_cli ~name ~image ~contents ()] keeps a Docker Compose Cli deployment up-to-date.
       [contents] contains the full Compose Yaml file.
-      This calls `docker compose` which is GA as of April 2022 and should be used in preference over version 1 *)
+      This calls `docker compose` which is GA as of April 2022 and should be used in preference over version 1. *)
 end
 
 module type HOST = sig

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -55,7 +55,7 @@ module type DOCKER = sig
   (** [build ~pull src] builds a Docker image from source.
       @param timeout If set, abort builds that take longer than this.
       @param squash If set to [true], pass "--squash" to "docker build".
-      @param build If set to [true], runs with "docker buildx build" instead of "docker build".
+      @param buildx If set to [true], runs with "docker buildx build" instead of "docker build".
       @param dockerfile If present, this is used as the contents of the Dockerfile.
       @param pull If [true], always check for updates and pull the latest version.
       @param pool Rate limit builds by requiring a resource from the pool.
@@ -106,7 +106,8 @@ module type DOCKER = sig
     unit -> unit Current.t
   (** [compose_cli ~name ~image ~contents ()] keeps a Docker Compose Cli deployment up-to-date.
       [contents] contains the full Compose Yaml file.
-      This calls `docker compose` which is GA as of April 2022 and should be used in preference over version 1. *)
+      [up_args] contains additional arguments to pass to the {e docker compose up} command.
+      This calls {e docker compose} which is GA as of April 2022 and should be used in preference over version 1. *)
 end
 
 module type HOST = sig


### PR DESCRIPTION
This PR introduces two new elements to `current_docker`:
- `docker compose` supports `up_args`. It allows extending the command with other args like `--build` or any other thing that could be useful.
- `docker buildx build` is now supported with the `Current_docker.build`. It extends the capabilities for the command like the `--secret` argument required for https://github.com/ocurrent/ocurrent-deployer/pull/180.