### PR TITLE
Log the receipt of a webhook event.

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -500,6 +500,7 @@ module Monitor (Query : GRAPHQL_QUERY) = struct
     let watch refresh =
       let owner_name = Printf.sprintf "%s/%s" repo.owner repo.name in
       let rec aux x =
+        Log.info (fun f -> f "Received webhook for owner/name: %s" owner_name);
         x >>= fun () ->
         let x = await_event ~owner_name in
         refresh ();


### PR DESCRIPTION
Adding extra logging to help with determining when a pipeline is triggered on the receipt of a webhook.