### PR TITLE
Support private repositories with GitHub.

### DIFF
--- a/plugins/git/clone.ml
+++ b/plugins/git/clone.ml
@@ -1,8 +1,15 @@
 open Lwt.Infix
 
-type t = No_context
+type t = {
+    token: string option;
+}
 
 let ( >>!= ) = Lwt_result.bind
+
+let insert_token ~token url =
+    match Astring.String.cut ~sep:"https://" url with
+    | Some ("", rest) -> Printf.sprintf "https://x-access-token:%s@%s" token rest
+    | Some (_,_) | None -> url
 
 module Key = struct
   type t = {
@@ -31,15 +38,19 @@ let repo_lock repo =
 
 let id = "git-clone"
 
-let build No_context job { Key.repo; gref } =
+let build { token } job { Key.repo; gref } =
   Lwt_mutex.with_lock (repo_lock repo) @@ fun () ->
   Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
+  let src = match token with
+  | Some token -> insert_token ~token repo
+  | None -> repo
+  in
   let local_repo = Cmd.local_copy repo in
   (* Ensure we have a local clone of the repository. *)
   begin
     if Cmd.dir_exists local_repo
-    then Cmd.git_fetch ~cancellable:true ~job ~src:repo ~dst:local_repo (Fmt.str "%s:refs/remotes/origin/%s" gref gref)
-    else Cmd.git_clone ~cancellable:true ~job ~src:repo local_repo
+    then Cmd.git_fetch ~cancellable:true ~job ~src ~dst:local_repo (Fmt.str "%s:refs/remotes/origin/%s" gref gref)
+    else Cmd.git_clone ~cancellable:true ~job ~src local_repo
   end >>!= fun () ->
   Cmd.git_rev_parse ~cancellable:true ~job ~repo:local_repo ("origin/" ^ gref) >>!= fun hash ->
   let id = { Commit_id.repo; gref; hash } in

--- a/plugins/git/current_git.ml
+++ b/plugins/git/current_git.ml
@@ -13,14 +13,20 @@ let ( >>!= ) x f =
   | Error _ as e -> Lwt.return e
 
 module Fetch = struct
-  type t = No_context
+  type t = {
+    token: string option;
+  }
   module Key = Commit_id
   module Value = Commit
 
   let id = "git-fetch"
 
-  let build No_context job key =
+  let build { token } job key =
     let { Commit_id.repo = remote_repo; gref; hash = _ } = key in
+    let src = match token with
+    | Some token -> Clone.insert_token ~token remote_repo
+    | None -> remote_repo
+    in
     let level =
       if Commit_id.is_local key then Current.Level.Harmless
       else Current.Level.Mostly_harmless
@@ -31,14 +37,14 @@ module Fetch = struct
     (* Ensure we have a local clone of the repository. *)
     begin
       if Cmd.dir_exists local_repo then Lwt.return (Ok ())
-      else Cmd.git_clone ~cancellable:true ~job ~src:remote_repo local_repo
+      else Cmd.git_clone ~cancellable:true ~job ~src local_repo
     end >>!= fun () ->
     let commit = { Commit.repo = local_repo; id = key } in
     (* Fetch the commit (if missing). *)
     begin
       Commit.check_cached ~cancellable:false ~job commit >>= function
       | Ok () -> Lwt.return (Ok ())
-      | Error _ -> Cmd.git_fetch ~cancellable:true ~job ~recurse_submodules:false ~src:remote_repo ~dst:local_repo gref
+      | Error _ -> Cmd.git_fetch ~cancellable:true ~job ~recurse_submodules:false ~src ~dst:local_repo gref
     end >>!= fun () ->
     (* Check we got the commit we wanted. *)
     Commit.check_cached ~cancellable:false ~job commit >>!= fun () ->
@@ -66,17 +72,17 @@ end
 
 module Fetch_cache = Current_cache.Make(Fetch)
 
-let fetch cid =
+let fetch ?token cid =
   Current.component "fetch" |>
   let> cid = cid in
-  Fetch_cache.get Fetch.No_context cid
+  Fetch_cache.get { token } cid
 
 module Clone_cache = Current_cache.Make(Clone)
 
-let clone ~schedule ?(gref="master") repo =
+let clone ~schedule ?token ?(gref="master") repo =
   Current.component "clone@ %s@ %s" repo gref |>
   let> () = Current.return () in
-  Clone_cache.get ~schedule Clone.No_context { Clone.Key.repo; gref }
+  Clone_cache.get ~schedule { token } { Clone.Key.repo; gref }
 
 let with_checkout ?pool ~job commit fn =
   let { Commit.repo; id } = commit in

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -41,14 +41,17 @@ end
 
 val clone :
   schedule:Current_cache.Schedule.t ->
-  ?token: string ->
+  ?token:(string, [ `Msg of string ]) result Lwt.t  ->
   ?gref:string ->
   string ->
   Commit.t Current.t
 (** [clone ~schedule ?token ~gref uri] evaluates to the head commit of [uri]'s [gref] branch (default: "master").
     [token] is an authentification token you can provide if the forge supports API tokens and private repositories. *)
 
-val fetch : ?token:string -> Commit_id.t Current.t -> Commit.t Current.t
+val fetch :
+  ?token:(string, [ `Msg of string ]) result Lwt.t  ->
+  Commit_id.t Current.t ->
+  Commit.t Current.t
 
 val with_checkout :
   ?pool:unit Current.Pool.t ->

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -39,10 +39,16 @@ module Commit : sig
   val unmarshal : string -> t
 end
 
-val clone : schedule:Current_cache.Schedule.t -> ?gref:string -> string -> Commit.t Current.t
-(** [clone ~schedule ~gref uri] evaluates to the head commit of [uri]'s [gref] branch (default: "master"). *)
+val clone :
+  schedule:Current_cache.Schedule.t ->
+  ?token: string ->
+  ?gref:string ->
+  string ->
+  Commit.t Current.t
+(** [clone ~schedule ?token ~gref uri] evaluates to the head commit of [uri]'s [gref] branch (default: "master").
+    [token] is an authentification token you can provide if the forge supports API tokens and private repositories. *)
 
-val fetch : Commit_id.t Current.t -> Commit.t Current.t
+val fetch : ?token:string -> Commit_id.t Current.t -> Commit.t Current.t
 
 val with_checkout :
   ?pool:unit Current.Pool.t ->

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -940,21 +940,30 @@ module Commit = struct
 end
 
 module Repo = struct
-  type nonrec t = t * Repo_id.t
 
-  let id = snd
+  type metadata = {
+      private_: bool;
+    }
+
+  type nonrec t = {
+    api: t;
+    repo_id: Repo_id.t;
+    metadata: metadata;
+  }
+
+  let id { repo_id ; _ } = repo_id
   let pp = Fmt.using id Repo_id.pp
   let compare a b = Repo_id.compare (id a) (id b)
 
   let head_commit t =
     Current.component "head" |>
-    let> (api, repo) = t in
+  let> {api ; repo_id = repo ; _ } = t in
     Head_ref.get api repo
 
   let ci_refs ?staleness t =
     let+ refs =
       Current.component "CI refs" |>
-      let> (api, repo) = t in
+  let> {api ; repo_id = repo ; _ } = t in
       refs api repo
     in
     to_ci_refs ?staleness refs

--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -75,7 +75,16 @@ val cmdliner_opt : t option Cmdliner.Term.t
 val webhook_secret_file : string Cmdliner.Term.t
 
 module Repo : sig
-  type nonrec t = t * Repo_id.t
+
+  type metadata = {
+      private_: bool;
+  }
+
+  type nonrec t = {
+    api: t;
+    repo_id: Repo_id.t;
+    metadata: metadata;
+  }
 
   val id : t -> Repo_id.t
   val ci_refs : ?staleness:Duration.t -> t Current.t -> Commit.t list Current.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -136,7 +136,16 @@ module Api : sig
   end
 
   module Repo : sig
-    type nonrec t = t * Repo_id.t
+
+    type metadata = {
+      private_: bool;
+    }
+
+    type nonrec t = {
+      api: t;
+      repo_id: Repo_id.t;
+      metadata: metadata;
+    }
 
     val id : t -> Repo_id.t
     val pp : t Fmt.t

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -47,6 +47,9 @@ module Api : sig
   val webhook_secret : t -> string
   (** Webhook secret to validate payloads from GitHub *)
 
+  val get_token : t -> (string, [`Msg of string]) result Lwt.t
+  (** [get_token t] fetches the token associated with the API. *)
+
   type refs
   (** Reference information for the repository *)
 

--- a/plugins/github/installation.ml
+++ b/plugins/github/installation.ml
@@ -62,8 +62,9 @@ let list_repositories ~api ~token ~account =
         |> List.map (fun r ->
             let name = r |> member "name" |> to_string in
             let archived = r |> member "archived" |> to_bool in
+            let private_ = r |> member "private"|> to_bool in
             let metadata = { archived } in
-            (api, Repo_id.{ owner = account; name }), metadata
+            ({ Api.Repo.api ; repo_id = Repo_id.{ owner = account; name } ; metadata = { private_} }), metadata
           )
       in
       begin match next (Cohttp.Response.headers resp) with
@@ -117,8 +118,8 @@ let repositories ?(include_archived=false) t =
     if include_archived then List.map fst
     else
       List.filter_map (function
-          | _, { archived = true } -> None
-          | repo, { archived = false } -> Some repo
+          | _, { archived = true ; _ } -> None
+          | repo, { archived = false ; _ } -> Some repo
         )
   in
   Current.Monitor.get t.repos


### PR DESCRIPTION
This PR is a weaker version of @patricoferris [branch](https://github.com/ocurrent/ocurrent/compare/master...patricoferris:ocurrent:private-repo) to support GitHub private repositories. The idea is to make it possible to clone repositories and fetch the data from private repositories. It is required to make ocurrent/ocurrent-deployer#180 work for the `tarides.com` website.

This is not a perfect solution. The only goal is to have a workable version of  `tarides.com` deployer. I'm open to any suggestion to make the code simpler and better.