### PR TITLE
Fetch most relevant PRs and branches by update dates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ API:
 - Add `up_args` to `Current_docker.compose_cli` (@maiste, #418)
 - Add support for `buildx` in `Current_docker.build` (@maiste, #418)
 
+Plugins:
+
+- GitHub: Fetch most relevant PRs and branches by update dates (@punchagan, #421)
+
 Other:
 
 - Bump constraint to OCaml 4.12. (@MisterDA, #415)

--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -587,7 +587,7 @@ module Refs = Monitor(struct
       defaultBranchRef {
         name
       }
-      refs(first: 100, refPrefix:"refs/heads/") {
+      refs(first: 100, refPrefix:"refs/heads/", orderBy: {field: TAG_COMMIT_DATE, direction: DESC}) {
         totalCount
         edges {
           node {
@@ -602,7 +602,7 @@ module Refs = Monitor(struct
           }
         }
       }
-      pullRequests(first: 100, states:[OPEN]) {
+      pullRequests(first: 100, states:[OPEN], orderBy: {field: UPDATED_AT, direction: DESC}) {
         totalCount
         edges {
           node {


### PR DESCRIPTION
Currently, we fetch only the first 100 PRs and branches of a GitHub repository, and there's a TODO [here](https://github.com/ocurrent/ocurrent/blob/acaa4181fdb9fbcb4db9052bd5e8f57f60de3ec7/plugins/github/api.ml#L665-L666) about using cursors to fix this.  It would be nice to have this fixed, but meanwhile returning the most relevant PRs and branches sorted by last update timestamp may be useful.  