### PR TITLE
current_docker: support auth in pull

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ API:
 - Add `Current_term.observe` to evaluate the current state of a term. (@TheLortex, #374)
 - Add `up_args` to `Current_docker.compose_cli` (@maiste, #418)
 - Add support for `buildx` in `Current_docker.build` (@maiste, #418)
+- Add `auth` to `Current_docker.pull` (@maiste, #423)
 
 Plugins:
 

--- a/plugins/docker/current_docker.ml
+++ b/plugins/docker/current_docker.ml
@@ -9,8 +9,8 @@ module Raw = struct
 
   module PullC = Current_cache.Make(Pull)
 
-  let pull ~docker_context ~schedule ?arch tag =
-    PullC.get ~schedule Pull.No_context { Pull.Key.docker_context; tag; arch }
+  let pull ~docker_context ~schedule ?auth ?arch tag =
+    PullC.get ~schedule auth { Pull.Key.docker_context; tag; arch }
 
   module PeekC = Current_cache.Make(Peek)
 
@@ -126,11 +126,11 @@ module Make (Host : S.HOST) = struct
     | None -> ()
     | Some arch -> Fmt.pf f "@,%s" arch
 
-  let pull ?label ?arch ~schedule tag =
+  let pull ?auth ?label ?arch ~schedule tag =
     let label = Option.value label ~default:tag in
     Current.component "pull %s%a" label pp_opt_arch arch |>
     let> () = Current.return () in
-    Raw.pull ~docker_context ~schedule ?arch tag
+    Raw.pull ~docker_context ~schedule ?arch ?auth tag
 
   let peek ?label ~arch ~schedule tag =
     let label = Option.value label ~default:tag in

--- a/plugins/docker/current_docker.mli
+++ b/plugins/docker/current_docker.mli
@@ -24,6 +24,7 @@ module Raw : sig
   val pull :
     docker_context:string option ->
     schedule:Current_cache.Schedule.t ->
+    ?auth:(string * string) ->
     ?arch:string -> string -> Image.t Current.Primitive.t
 
   val peek :

--- a/plugins/docker/s.ml
+++ b/plugins/docker/s.ml
@@ -19,6 +19,7 @@ module type DOCKER = sig
   val docker_context : string option
 
   val pull :
+    ?auth:(string * string) ->
     ?label:string ->
     ?arch:string ->
     schedule:Current_cache.Schedule.t ->
@@ -26,7 +27,8 @@ module type DOCKER = sig
   (** [pull ~schedule tag] ensures that the latest version of [tag] is cached locally, downloading it if not.
       @param arch Select a specific architecture from a multi-arch manifest.
       @param schedule Controls how often we check for updates. If the schedule
-                      has no [valid_for] limit then we will only ever pull once. *)
+                      has no [valid_for] limit then we will only ever pull once.
+      @param auth If given do a "docker login" using this username/password pair before pulling. *)
 
   val peek :
     ?label:string ->


### PR DESCRIPTION
This PR adds support for `authentication` with `docker login` in the `pull` function. This is a mirror of the `push` and `push_manifest` implementations. This PR is a part of solving ocurrent/ocurrent-deployer#172