### PR TITLE
Expose filepath for git clone.

### DIFF
--- a/plugins/git/commit.ml
+++ b/plugins/git/commit.ml
@@ -35,3 +35,5 @@ let unmarshal s =
   match Yojson.Safe.from_string s |> of_yojson with
   | Ok x -> x
   | Error e -> failwith e
+
+let repo t = t.repo

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -32,6 +32,7 @@ module Commit : sig
   val equal : t -> t -> bool
   val pp : t Fmt.t
 
+  val repo : t -> Fpath.t
   val pp_short : t Fmt.t
   (** [pp_short] shows just the start of the hash. *)
 


### PR DESCRIPTION
Useful for running git operations on the watched git repo.

https://github.com/ocurrent/ocaml-docs-ci/pull/131