### PR TITLE
Add prometheus metrics for Docker plugin

### DIFF
--- a/plugins/docker/build.ml
+++ b/plugins/docker/build.ml
@@ -110,6 +110,7 @@ let build { pull; pool; timeout; level } job key =
   | Ok () ->
     Bos.OS.File.read iidfile |> Stdlib.Result.map @@ fun hash ->
     Log.info (fun f -> f "Built docker image %s" hash);
+    Prometheus.Counter.inc_one Metrics.docker_build_events;
     Image.of_hash hash
 
 let pp f key = Fmt.pf f "@[<v2>docker build %a@]" Key.pp key

--- a/plugins/docker/metrics.ml
+++ b/plugins/docker/metrics.ml
@@ -5,20 +5,20 @@ let subsystem = "docker"
 
 let docker_pull_events =
   let help = "Incoming docker pull events" in
-  Counter.v ~help ~namespace ~subsystem "docker_pull_events"
+  Counter.v ~help ~namespace ~subsystem "pull_events"
 
 let docker_push_events =
   let help = "Outgoing docker push events" in
-  Counter.v ~help ~namespace ~subsystem "docker_push_events"
+  Counter.v ~help ~namespace ~subsystem "push_events"
 
 let docker_push_manifest_events =
   let help = "Outgoing docker push manifest events" in
-  Counter.v ~help ~namespace ~subsystem "docker_push_manifest_events"
+  Counter.v ~help ~namespace ~subsystem "push_manifest_events"
 
 let docker_peek_events =
   let help = "Incoming docker peek events" in
-  Counter.v ~help ~namespace ~subsystem "docker_peek_events"
+  Counter.v ~help ~namespace ~subsystem "peek_events"
 
 let docker_build_events =
   let help = "Docker build events" in
-  Counter.v ~help ~namespace ~subsystem "docker_build_events"
+  Counter.v ~help ~namespace ~subsystem "build_events"

--- a/plugins/docker/metrics.ml
+++ b/plugins/docker/metrics.ml
@@ -1,0 +1,24 @@
+open Prometheus
+
+let namespace = "ocurrent"
+let subsystem = "docker"
+
+let docker_pull_events =
+  let help = "Incoming docker pull events" in
+  Counter.v ~help ~namespace ~subsystem "docker_pull_events"
+
+let docker_push_events =
+  let help = "Outgoing docker push events" in
+  Counter.v ~help ~namespace ~subsystem "docker_push_events"
+
+let docker_push_manifest_events =
+  let help = "Outgoing docker push manifest events" in
+  Counter.v ~help ~namespace ~subsystem "docker_push_manifest_events"
+
+let docker_peek_events =
+  let help = "Incoming docker peek events" in
+  Counter.v ~help ~namespace ~subsystem "docker_peek_events"
+
+let docker_build_events =
+  let help = "Docker build events" in
+  Counter.v ~help ~namespace ~subsystem "docker_build_events"

--- a/plugins/docker/peek.ml
+++ b/plugins/docker/peek.ml
@@ -28,6 +28,7 @@ let build No_context job key =
   | Error _ as e -> Lwt.return e
   | Ok hash ->
     Current.Job.log job "Got %S" hash;
+    Prometheus.Counter.inc_one Metrics.docker_peek_events;
     Lwt_result.return (tag ^ "@" ^ hash)
 
 let pp f key = Cmd.pp f (Key.cmd key)

--- a/plugins/docker/pull.ml
+++ b/plugins/docker/pull.ml
@@ -1,16 +1,5 @@
 open Lwt.Infix
 
-module Metrics = struct
-  open Prometheus
-
-  let namespace = "ocurrent"
-  let subsystem = "docker"
-
-  let docker_pull_events =
-    let help = "Incoming docker pull events" in
-    Counter.v ~help ~namespace ~subsystem "docker_pull_events"
-end
-
 type auth = Push.auth
 
 type t = auth option

--- a/plugins/docker/push.ml
+++ b/plugins/docker/push.ml
@@ -51,6 +51,7 @@ let publish auth job key value =
     Current.Process.check_output ~cancellable:false ~job cmd >|= Stdlib.Result.map @@ fun id ->
     let repo_id = String.trim id in
     Current.Job.log job "Pushed %S -> %S" tag repo_id;
+    Prometheus.Counter.inc_one Metrics.docker_push_events;
     repo_id
 
 let pp f (key, value) =

--- a/plugins/docker/push_manifest.ml
+++ b/plugins/docker/push_manifest.ml
@@ -68,6 +68,7 @@ let publish auth job tag value =
     in
     let repo_id = Printf.sprintf "%s@%s" tag hash in
     Current.Job.log job "--> %S" repo_id;
+    Prometheus.Counter.inc_one Metrics.docker_push_manifest_events;
     Lwt_result.return repo_id
 
 let pp f (tag, value) =


### PR DESCRIPTION
Add counters for Docker functionality:
- Number of builds
- Number of pushes
- Number of push manifests
- Number of peeks

A counter for the number of pulls was already included.