### PR TITLE
Current_web: fix access to logfiles with spaces in the name

### DIFF
--- a/lib_web/current_web.ml
+++ b/lib_web/current_web.ml
@@ -59,7 +59,7 @@ let routes engine =
 let handle_request ~site _conn request body =
   let meth = Cohttp.Request.meth request in
   let uri = Cohttp.Request.uri request in
-  let path = Uri.path uri in
+  let path = Uri.path uri |> Uri.pct_decode in
   Log.info (fun f -> f "HTTP %s %S" (Cohttp.Code.string_of_method meth) path);
   match Routes.match' site.Site.router ~target:path with
   | Routes.NoMatch -> Utils.Server.respond_not_found ()


### PR DESCRIPTION
`Uri.path` is documented to return an encoded path, so we need to decode it before using it. Otherwise some job logs are inaccessible from the web UI:
```
Job log /home/edvint/git/personal_pipelines2/var/job/2023-10-27/110201-bump%20commit-272052.log does not exist
```