### PR TITLE
Decrement Docker Prometheus gauges when operation finishes

### DIFF
--- a/plugins/docker/metrics.ml
+++ b/plugins/docker/metrics.ml
@@ -5,20 +5,20 @@ let subsystem = "docker"
 
 let docker_pull_events =
   let help = "Incoming docker pull events" in
-  Counter.v ~help ~namespace ~subsystem "pull_events"
+  Gauge.v ~help ~namespace ~subsystem "pull_events"
 
 let docker_push_events =
   let help = "Outgoing docker push events" in
-  Counter.v ~help ~namespace ~subsystem "push_events"
+  Gauge.v ~help ~namespace ~subsystem "push_events"
 
 let docker_push_manifest_events =
   let help = "Outgoing docker push manifest events" in
-  Counter.v ~help ~namespace ~subsystem "push_manifest_events"
+  Gauge.v ~help ~namespace ~subsystem "push_manifest_events"
 
 let docker_peek_events =
   let help = "Incoming docker peek events" in
-  Counter.v ~help ~namespace ~subsystem "peek_events"
+  Gauge.v ~help ~namespace ~subsystem "peek_events"
 
 let docker_build_events =
   let help = "Docker build events" in
-  Counter.v ~help ~namespace ~subsystem "build_events"
+  Gauge.v ~help ~namespace ~subsystem "build_events"


### PR DESCRIPTION
Currently we add to a counter when an operation starts, but don't decrement when it finishes. This PR fixes that.