### PR TITLE
Added option to directly construct Current_git.Commit.t values

### DIFF
--- a/plugins/git/commit.ml
+++ b/plugins/git/commit.ml
@@ -16,6 +16,8 @@ type t = {
 
 [@@@ocaml.warning "+3"]
 
+let v ~repo ~id = {repo; id}
+
 let id t = t.id
 let hash t = t.id.Commit_id.hash
 let compare a b = String.compare (hash a) (hash b)

--- a/plugins/git/current_git.mli
+++ b/plugins/git/current_git.mli
@@ -27,6 +27,7 @@ end
 module Commit : sig
   include Set.OrderedType
 
+  val v : repo:Fpath.t -> id:Commit_id.t -> t
   val id : t -> Commit_id.t
   val hash : t -> string
   val equal : t -> t -> bool


### PR DESCRIPTION
I added the `Current_git.v` function, and I am wondering why it didn't exist in the first place.
Anyway I think there's no way around doing it that way for my use case (see https://github.com/ocurrent/current-bench/pull/482).