### PR TITLE
Fix GitHub CheckRun InProgress status identifier

### DIFF
--- a/plugins/github/api.ml
+++ b/plugins/github/api.ml
@@ -206,7 +206,7 @@ module CheckRunStatus = struct
       state_json ()
         ~title:"InProgress"
         ~summary:(Option.value summary ~default:"InProgress")
-        ~status:"inprogress"
+        ~status:"in_progress"
         ~text
         ?identifier
         ?url


### PR DESCRIPTION
`inprogress` is not valid. `in_progress` is the correct identifier as per [the docs](https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28)