### PR TITLE
Add query entries for Github PR's: fork repository name and fork branch name

### DIFF
--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -33,6 +33,8 @@ module Commit : sig
   val uri : t -> Uri.t
   val pr_name : t -> string option
   val branch_name : t -> string option
+  val pr_fork_branch_name : t -> string option
+  val pr_fork_with_owner : t -> string option
 end
 
 
@@ -49,6 +51,8 @@ module Ref : sig
     title: string;
     labels: string list;
     bodyHTML: string;
+    branch_name: string;
+    fork: string;
   }
   type t = [ `Ref of string | `PR of pr_info ]
   type id = [ `Ref of string | `PR of int ]

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -123,6 +123,12 @@ module Api : sig
 
     val branch_name : t -> string option
     (** [branch_name t] is the name of the ref that the commit belongs to if it is a branch, and None if it is a PR *)
+
+    val pr_fork_branch_name : t -> string option
+    (** [pr_fork_branch_name t] is the name of the branch of the fork from which the PR originated from, and None if it is a branch *)
+
+    val pr_fork_with_owner : t -> string option
+    (** [pr_fork_with_owner t] is the name as "owner/name" of the fork from which the PR originated from, and None if it is a branch *)
   end
 
   module CheckRun : sig
@@ -155,6 +161,8 @@ module Api : sig
       title: string;
       labels: string list;
       bodyHTML: string;
+      branch_name: string;
+      fork: string;
     }
 
     type t = [ `Ref of string | `PR of pr_info ]


### PR DESCRIPTION
This PR adds two new fields to the pull request GraphQL request and their respective functions:
- `Commit.pr_fork_owner_name`: returns the name as `owner/name` of the fork from which the PR originated from, or `None` if it is a branch. Uses the field `headRepository.nameWithOwner` in the GraphQL request;
- `Commit.pr_fork_branch_name`: returns the branch name of that fork, or `None` if it is a regular (non-fork) branch. Uses the field `headRefName` in the GraphQL request;

This might be useful for pushing results (from the pipeline) to the fork where the PR originated.

---

A use case example can be found [here](https://github.com/zazedd/radiocarbon-pipeline/blob/1141cda9602d82962f65066752c3141f928b88ac/src/git_cache.ml#L243C5-L243C22), where I have vendored a version of OCurrent with these functions available.
The outputs are pushed to the fork repository of the person who submitted the pull request so that they can confirm whether they look correct or not.