### PR TITLE
doc(Current_web.Role.t): make comments visible in docs

### DIFF
--- a/lib_web/current_web.mli
+++ b/lib_web/current_web.mli
@@ -14,10 +14,10 @@ end
 
 module Role : sig
   type t = [
-    | `Viewer   (* Read-only access, suitable for the general public. *)
-    | `Builder  (* Can cancel and rebuild jobs. *)
-    | `Monitor  (* Can read the metrics. *)
-    | `Admin    (* Can manage log matcher rules. *)
+    | `Viewer   (** Read-only access, suitable for the general public. *)
+    | `Builder  (** Can cancel and rebuild jobs. *)
+    | `Monitor  (** Can read the metrics. *)
+    | `Admin    (** Can manage log matcher rules. *)
   ]
 
   val pp : t Fmt.t


### PR DESCRIPTION
Need to be doc-comments to be visible in the generated documentation.