### PR TITLE
Current_github: Allow `Current_git.Commit_id` to be created with an SSH URL

### DIFF
--- a/plugins/github/api.mli
+++ b/plugins/github/api.mli
@@ -20,7 +20,7 @@ end
 
 module Commit : sig
   type t
-  val id : t -> Current_git.Commit_id.t
+  val id : ?ssh:bool -> t -> Current_git.Commit_id.t
   val repo_id : t -> Repo_id.t
   val owner_name : t -> string
   val hash : t -> string

--- a/plugins/github/current_github.mli
+++ b/plugins/github/current_github.mli
@@ -86,7 +86,7 @@ module Api : sig
   module Commit : sig
     type t
 
-    val id : t -> Current_git.Commit_id.t
+    val id : ?ssh:bool -> t -> Current_git.Commit_id.t
     (** The commit ID, which can be used to fetch it. *)
 
     val set_status : t Current.t -> string -> Status.t Current.t -> unit Current.t


### PR DESCRIPTION
This PR changes the `Current_github.Commit_id.to_git` function to create a `Current_git.Commit_id.t` with either an HTTPS or SSH repo URL, and introduces an optional argument to the `Current_github.Commit.id` function to choose between the two.

---

This is useful if, for example, the remote repository is private and ssh is needed for authentication while fetching.

